### PR TITLE
Add initial RevCam WebRTC server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+.env
+.venv

--- a/README.md
+++ b/README.md
@@ -1,1 +1,69 @@
+# RevCam
+
+RevCam is a low-latency reversing camera stack targeted at the Raspberry Pi Zero 2 W (Bookworm).
+It streams a live camera feed to iOS devices through WebRTC and exposes a settings panel for
+configuring image orientation. The processing pipeline is modular so that future driver-assistance
+overlays can be injected on the server without major changes.
+
+## Features
+
+- Fast WebRTC video delivery optimised for mobile Safari (iPhone/iPad).
+- Camera orientation controls (rotation and horizontal/vertical flips).
+- Modular frame processing pipeline ready for future overlays (e.g. guidelines).
+- REST API for orientation control and WebRTC signalling.
+
+## Project layout
+
+```
+src/
+  rev_cam/
+    __init__.py
+    app.py                # FastAPI application and routes
+    camera.py             # Camera source abstractions
+    config.py             # Orientation persistence and validation
+    pipeline.py           # Frame processing pipeline (orientation + overlays)
+    webrtc.py             # WebRTC track implementation
+  rev_cam/static/
+    index.html            # Viewer client
+    settings.html         # Settings UI
+```
+
+## Getting started
+
+The project targets Python 3.11+. On development machines install the dependencies with
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .[camera]
+```
+
+The optional `camera` extra pulls in `picamera2`, which is only available on ARM
+hardware. On non-ARM hosts you can run the stack with a mock camera by setting the
+`REVCAM_CAMERA=synthetic` environment variable (see `camera.py`).
+
+Run the server with
+
+```bash
+uvicorn rev_cam.app:create_app --factory --host 0.0.0.0 --port 8000
+```
+
+Then open `http://<pi-address>:8000` on the iOS device to view the stream. Access the
+settings panel at `/settings` to adjust the camera orientation. Changes are persisted
+and applied immediately to the outgoing WebRTC stream.
+
+## Testing
+
+```
+pytest
+```
+
+Unit tests cover the frame pipeline and configuration management so that critical
+behaviour remains reliable.
+
+## Future work
+
+- Integrate computer-vision overlays (parking guidelines, obstacle detection).
+- Replace the default software encoder with hardware acceleration.
+- Add authentication for configuration endpoints.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+requires = ["setuptools>=67", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "rev-cam"
+version = "0.1.0"
+description = "Low-latency Raspberry Pi reversing camera WebRTC server"
+readme = "README.md"
+authors = [{name = "RevCam Team"}]
+requires-python = ">=3.11"
+dependencies = [
+    "aiortc>=1.5.0",
+    "fastapi>=0.109",
+    "uvicorn[standard]>=0.27",
+    "numpy>=1.24",
+    "pydantic>=2.5",
+    "python-multipart>=0.0.6"
+]
+
+[project.optional-dependencies]
+camera = [
+    "picamera2>=0.3; platform_machine=='armv7l' or platform_machine=='aarch64'"
+]
+dev = [
+    "pytest>=7.4"
+]
+
+dynamic = ["classifiers"]
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = src

--- a/src/rev_cam/__init__.py
+++ b/src/rev_cam/__init__.py
@@ -1,0 +1,12 @@
+"""RevCam package exposing factory helpers for the reversing camera server."""
+
+from typing import Any
+
+
+def create_app(*args: Any, **kwargs: Any):
+    from .app import create_app as _create_app
+
+    return _create_app(*args, **kwargs)
+
+
+__all__ = ["create_app"]

--- a/src/rev_cam/app.py
+++ b/src/rev_cam/app.py
@@ -1,0 +1,99 @@
+"""FastAPI application wiring together the RevCam services."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import HTMLResponse
+from pydantic import BaseModel
+
+from .camera import BaseCamera, create_camera
+from .config import ConfigManager
+from .pipeline import FramePipeline
+from .webrtc import WebRTCManager
+from aiortc import RTCSessionDescription
+
+STATIC_DIR = Path(__file__).resolve().parent / "static"
+
+
+def _load_static(name: str) -> str:
+    path = STATIC_DIR / name
+    if not path.exists():  # pragma: no cover - sanity check
+        raise FileNotFoundError(f"Static asset {name!r} missing")
+    return path.read_text(encoding="utf-8")
+
+
+class OfferPayload(BaseModel):
+    sdp: str
+    type: Literal["offer"]
+
+
+class OrientationPayload(BaseModel):
+    rotation: int = 0
+    flip_horizontal: bool = False
+    flip_vertical: bool = False
+
+
+def create_app(config_path: Path | str = Path("data/config.json")) -> FastAPI:
+    app = FastAPI(title="RevCam", version="0.1.0")
+
+    config_manager = ConfigManager(Path(config_path))
+    pipeline = FramePipeline(lambda: config_manager.get_orientation())
+    camera: BaseCamera | None = None
+    webrtc_manager: WebRTCManager | None = None
+
+    @app.on_event("startup")
+    async def startup() -> None:  # pragma: no cover - framework hook
+        nonlocal camera, webrtc_manager
+        camera = create_camera()
+        webrtc_manager = WebRTCManager(camera=camera, pipeline=pipeline)
+
+    @app.on_event("shutdown")
+    async def shutdown() -> None:  # pragma: no cover - framework hook
+        if webrtc_manager:
+            await webrtc_manager.shutdown()
+        if camera:
+            await camera.close()
+
+    @app.get("/", response_class=HTMLResponse)
+    async def index() -> str:
+        return _load_static("index.html")
+
+    @app.get("/settings", response_class=HTMLResponse)
+    async def settings() -> str:
+        return _load_static("settings.html")
+
+    @app.get("/api/orientation")
+    async def get_orientation() -> dict[str, int | bool]:
+        orientation = config_manager.get_orientation()
+        return {
+            "rotation": orientation.rotation,
+            "flip_horizontal": orientation.flip_horizontal,
+            "flip_vertical": orientation.flip_vertical,
+        }
+
+    @app.post("/api/orientation")
+    async def update_orientation(payload: OrientationPayload) -> dict[str, int | bool]:
+        try:
+            orientation = config_manager.set_orientation(payload.model_dump())
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return {
+            "rotation": orientation.rotation,
+            "flip_horizontal": orientation.flip_horizontal,
+            "flip_vertical": orientation.flip_vertical,
+        }
+
+    @app.post("/api/offer")
+    async def webrtc_offer(payload: OfferPayload) -> dict[str, str]:
+        if webrtc_manager is None:
+            raise HTTPException(status_code=503, detail="WebRTC service unavailable")
+        offer = RTCSessionDescription(sdp=payload.sdp, type=payload.type)
+        answer = await webrtc_manager.handle_offer(offer)
+        return {"sdp": answer.sdp, "type": answer.type}
+
+    return app
+
+
+__all__ = ["create_app"]

--- a/src/rev_cam/camera.py
+++ b/src/rev_cam/camera.py
@@ -1,0 +1,114 @@
+"""Camera source abstractions."""
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from abc import ABC, abstractmethod
+
+import numpy as np
+
+
+class CameraError(RuntimeError):
+    """Raised when the camera cannot be initialised."""
+
+
+class BaseCamera(ABC):
+    """Abstract camera capable of producing RGB frames."""
+
+    @abstractmethod
+    async def get_frame(self) -> np.ndarray:  # pragma: no cover - interface only
+        raise NotImplementedError
+
+    async def close(self) -> None:  # pragma: no cover - optional override
+        return None
+
+
+class Picamera2Camera(BaseCamera):
+    """Camera implementation using the Picamera2 stack."""
+
+    def __init__(self) -> None:
+        try:
+            from picamera2 import Picamera2
+        except ImportError as exc:  # pragma: no cover - hardware dependent
+            raise CameraError("picamera2 is not available") from exc
+
+        self._camera = Picamera2()
+        config = self._camera.create_video_configuration(main={"format": "RGB888"})
+        self._camera.configure(config)
+        self._camera.start()
+
+    async def get_frame(self) -> np.ndarray:  # pragma: no cover - hardware dependent
+        return await asyncio.to_thread(self._camera.capture_array)
+
+    async def close(self) -> None:  # pragma: no cover - hardware dependent
+        await asyncio.to_thread(self._camera.stop)
+        await asyncio.to_thread(self._camera.close)
+
+
+class OpenCVCamera(BaseCamera):
+    """Fallback implementation using OpenCV VideoCapture."""
+
+    def __init__(self, index: int = 0) -> None:
+        try:
+            import cv2
+        except ImportError as exc:  # pragma: no cover - optional dependency
+            raise CameraError("OpenCV is not installed") from exc
+
+        self._cv2 = cv2
+        self._capture = cv2.VideoCapture(index)
+        if not self._capture.isOpened():
+            raise CameraError(f"Failed to open camera index {index}")
+
+    async def get_frame(self) -> np.ndarray:
+        ret, frame = await asyncio.to_thread(self._capture.read)
+        if not ret:
+            raise CameraError("Failed to read frame from OpenCV camera")
+        return self._cv2.cvtColor(frame, self._cv2.COLOR_BGR2RGB)
+
+    async def close(self) -> None:
+        await asyncio.to_thread(self._capture.release)
+
+
+class SyntheticCamera(BaseCamera):
+    """Generates synthetic frames for development and testing."""
+
+    def __init__(self, width: int = 640, height: int = 480) -> None:
+        self._width = width
+        self._height = height
+        self._start = time.perf_counter()
+
+    async def get_frame(self) -> np.ndarray:
+        elapsed = time.perf_counter() - self._start
+        horizontal = np.linspace(0, 255, self._width, dtype=np.uint8)
+        vertical = np.linspace(0, 255, self._height, dtype=np.uint8).reshape(-1, 1)
+        red = np.tile(horizontal, (self._height, 1))
+        green = np.roll(red, int(elapsed * 10), axis=1)
+        blue = np.tile(vertical, (1, self._width))
+        frame = np.stack([red, green, blue], axis=2)
+        return frame.astype(np.uint8)
+
+
+def create_camera() -> BaseCamera:
+    """Create the camera specified by the environment."""
+
+    choice = os.getenv("REVCAM_CAMERA", "picamera").lower()
+    if choice == "synthetic":
+        return SyntheticCamera()
+    if choice == "opencv":
+        return OpenCVCamera()
+    try:
+        return Picamera2Camera()
+    except CameraError:
+        # Fall back to synthetic frames when running on development machines.
+        return SyntheticCamera()
+
+
+__all__ = [
+    "BaseCamera",
+    "CameraError",
+    "Picamera2Camera",
+    "OpenCVCamera",
+    "SyntheticCamera",
+    "create_camera",
+]

--- a/src/rev_cam/config.py
+++ b/src/rev_cam/config.py
@@ -1,0 +1,80 @@
+"""Configuration management for RevCam."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from threading import Lock
+from typing import Any, Dict, Mapping
+
+
+@dataclass(frozen=True, slots=True)
+class Orientation:
+    """Represents the rotation and flips applied to a frame."""
+
+    rotation: int = 0
+    flip_horizontal: bool = False
+    flip_vertical: bool = False
+
+    def normalise(self) -> "Orientation":
+        """Return a normalised copy with the rotation wrapped to 0-270."""
+
+        rotation = (self.rotation // 90) % 4 * 90
+        return Orientation(rotation, self.flip_horizontal, self.flip_vertical)
+
+
+def _parse_orientation(data: Mapping[str, Any]) -> Orientation:
+    try:
+        rotation_raw = data.get("rotation", 0)
+        if not isinstance(rotation_raw, int):
+            raise ValueError("Rotation must be an integer")
+        if rotation_raw % 90 != 0:
+            raise ValueError("Rotation must be a multiple of 90 degrees")
+        rotation = (rotation_raw // 90) % 4 * 90
+        flip_horizontal = bool(data.get("flip_horizontal", False))
+        flip_vertical = bool(data.get("flip_vertical", False))
+    except Exception as exc:
+        raise ValueError(str(exc)) from exc
+    return Orientation(rotation=rotation, flip_horizontal=flip_horizontal, flip_vertical=flip_vertical)
+
+
+class ConfigManager:
+    """Stores configuration state on disk with thread-safety."""
+
+    def __init__(self, config_path: Path) -> None:
+        self._path = config_path
+        self._lock = Lock()
+        self._ensure_parent()
+        self._data: Orientation = self._load()
+
+    def _ensure_parent(self) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+
+    def _load(self) -> Orientation:
+        if not self._path.exists():
+            return Orientation()
+        try:
+            payload = json.loads(self._path.read_text())
+            if not isinstance(payload, dict):
+                raise ValueError("Configuration file must contain a JSON object")
+            return _parse_orientation(payload)
+        except (OSError, ValueError) as exc:
+            raise RuntimeError(f"Failed to load configuration: {exc}") from exc
+
+    def _save(self, orientation: Orientation) -> None:
+        payload: Dict[str, Any] = asdict(orientation)
+        self._path.write_text(json.dumps(payload, indent=2))
+
+    def get_orientation(self) -> Orientation:
+        with self._lock:
+            return self._data
+
+    def set_orientation(self, data: Mapping[str, Any]) -> Orientation:
+        orientation = _parse_orientation(data)
+        with self._lock:
+            self._data = orientation
+            self._save(orientation)
+        return orientation
+
+
+__all__ = ["ConfigManager", "Orientation"]

--- a/src/rev_cam/pipeline.py
+++ b/src/rev_cam/pipeline.py
@@ -1,0 +1,81 @@
+"""Video frame processing pipeline."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Iterable, List
+
+try:  # pragma: no cover - optional dependency
+    import numpy as _np
+except ImportError:  # pragma: no cover - optional dependency
+    _np = None
+
+from .config import Orientation
+
+FrameLike = Any
+OverlayFn = Callable[[FrameLike], FrameLike]
+
+
+@dataclass
+class FramePipeline:
+    """Applies orientation and overlay transforms to frames."""
+
+    orientation_provider: Callable[[], Orientation]
+    overlays: List[OverlayFn] = field(default_factory=list)
+
+    def add_overlay(self, overlay: OverlayFn) -> None:
+        self.overlays.append(overlay)
+
+    def _apply_orientation(self, frame: FrameLike, orientation: Orientation) -> FrameLike:
+        output = frame
+        k = (orientation.rotation // 90) % 4
+        if k:
+            output = self._rotate(output, k)
+        if orientation.flip_horizontal:
+            output = self._flip_horizontal(output)
+        if orientation.flip_vertical:
+            output = self._flip_vertical(output)
+        return output
+
+    def _apply_overlays(self, frame: FrameLike) -> FrameLike:
+        result = frame
+        for overlay in self.overlays:
+            result = overlay(result)
+        return result
+
+    def process(self, frame: FrameLike) -> FrameLike:
+        orientation = self.orientation_provider().normalise()
+        transformed = self._apply_orientation(frame, orientation)
+        return self._apply_overlays(transformed)
+
+    def _rotate(self, frame: FrameLike, k: int) -> FrameLike:
+        if _np is not None and isinstance(frame, _np.ndarray):  # pragma: no cover - optional path
+            return _np.rot90(frame, k)
+        data = frame
+        for _ in range(k % 4):
+            data = [list(row) for row in zip(*data)][::-1]
+        return data
+
+    def _flip_horizontal(self, frame: FrameLike) -> FrameLike:
+        if _np is not None and isinstance(frame, _np.ndarray):  # pragma: no cover - optional path
+            return _np.flip(frame, axis=1)
+        return [list(reversed(row)) for row in frame]
+
+    def _flip_vertical(self, frame: FrameLike) -> FrameLike:
+        if _np is not None and isinstance(frame, _np.ndarray):  # pragma: no cover - optional path
+            return _np.flip(frame, axis=0)
+        return list(reversed(frame))
+
+
+def compose_overlays(overlays: Iterable[OverlayFn]) -> OverlayFn:
+    """Return a composite overlay function."""
+
+    def _composed(frame: FrameLike) -> FrameLike:
+        output = frame
+        for overlay in overlays:
+            output = overlay(output)
+        return output
+
+    return _composed
+
+
+__all__ = ["FramePipeline", "compose_overlays", "OverlayFn"]

--- a/src/rev_cam/static/index.html
+++ b/src/rev_cam/static/index.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>RevCam Live View</title>
+    <style>
+      body {
+        margin: 0;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background-color: #111;
+        color: #f5f5f5;
+        display: flex;
+        flex-direction: column;
+        min-height: 100vh;
+      }
+      header,
+      footer {
+        padding: 0.75rem 1rem;
+        background: rgba(0, 0, 0, 0.6);
+      }
+      main {
+        flex: 1 1 auto;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 1rem;
+      }
+      video {
+        width: 100%;
+        max-width: 1000px;
+        background: #000;
+        border-radius: 8px;
+      }
+      button {
+        background: #0a84ff;
+        color: #fff;
+        border: none;
+        padding: 0.5rem 1rem;
+        border-radius: 999px;
+        font-size: 1rem;
+      }
+      #status {
+        font-size: 0.9rem;
+        opacity: 0.8;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <strong>RevCam</strong>
+      <div id="status">Initialising…</div>
+    </header>
+    <main>
+      <video id="video" autoplay playsinline muted></video>
+    </main>
+    <footer>
+      <button id="reconnect">Reconnect</button>
+      <a href="/settings" style="color: #0a84ff; margin-left: 1rem;">Settings</a>
+    </footer>
+    <script>
+      const statusLabel = document.getElementById("status");
+      const reconnectButton = document.getElementById("reconnect");
+      const video = document.getElementById("video");
+      let pc;
+
+      async function startStream() {
+        statusLabel.textContent = "Connecting to camera…";
+        if (pc) {
+          pc.close();
+        }
+        pc = new RTCPeerConnection();
+        pc.addTransceiver("video", { direction: "recvonly" });
+        pc.ontrack = (event) => {
+          if (event.streams && event.streams[0]) {
+            video.srcObject = event.streams[0];
+          }
+        };
+        pc.onconnectionstatechange = () => {
+          statusLabel.textContent = `Connection: ${pc.connectionState}`;
+        };
+        const offer = await pc.createOffer();
+        await pc.setLocalDescription(offer);
+        const response = await fetch("/api/offer", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(pc.localDescription),
+        });
+        if (!response.ok) {
+          statusLabel.textContent = "Failed to negotiate WebRTC session";
+          return;
+        }
+        const answer = await response.json();
+        await pc.setRemoteDescription(answer);
+        statusLabel.textContent = "Streaming";
+      }
+
+      reconnectButton.addEventListener("click", () => {
+        startStream().catch((err) => {
+          console.error(err);
+          statusLabel.textContent = "Error: " + err.message;
+        });
+      });
+
+      startStream().catch((err) => {
+        console.error(err);
+        statusLabel.textContent = "Error: " + err.message;
+      });
+    </script>
+  </body>
+</html>

--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>RevCam Settings</title>
+    <style>
+      body {
+        margin: 0;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background-color: #111;
+        color: #f5f5f5;
+        padding: 1.5rem;
+      }
+      h1 {
+        margin-top: 0;
+      }
+      label {
+        display: block;
+        margin-bottom: 1rem;
+      }
+      select,
+      input[type="checkbox"] {
+        margin-top: 0.5rem;
+        font-size: 1rem;
+      }
+      button {
+        background: #0a84ff;
+        color: #fff;
+        border: none;
+        padding: 0.6rem 1.2rem;
+        border-radius: 999px;
+        font-size: 1rem;
+      }
+      #status {
+        margin-top: 1rem;
+        font-size: 0.95rem;
+        opacity: 0.85;
+      }
+      a {
+        color: #0a84ff;
+      }
+    </style>
+  </head>
+  <body>
+    <a href="/">← Back to live view</a>
+    <h1>Camera Orientation</h1>
+    <form id="orientation-form">
+      <label>
+        Rotation
+        <select name="rotation">
+          <option value="0">0°</option>
+          <option value="90">90°</option>
+          <option value="180">180°</option>
+          <option value="270">270°</option>
+        </select>
+      </label>
+      <label>
+        <input type="checkbox" name="flip_horizontal" /> Flip horizontally
+      </label>
+      <label>
+        <input type="checkbox" name="flip_vertical" /> Flip vertically
+      </label>
+      <button type="submit">Save</button>
+      <div id="status">Loading…</div>
+    </form>
+    <script>
+      const form = document.getElementById("orientation-form");
+      const statusLabel = document.getElementById("status");
+
+      async function loadOrientation() {
+        const response = await fetch("/api/orientation");
+        if (!response.ok) {
+          throw new Error("Unable to fetch current orientation");
+        }
+        const data = await response.json();
+        form.rotation.value = data.rotation;
+        form.flip_horizontal.checked = data.flip_horizontal;
+        form.flip_vertical.checked = data.flip_vertical;
+        statusLabel.textContent = "Orientation loaded";
+      }
+
+      form.addEventListener("submit", async (event) => {
+        event.preventDefault();
+        statusLabel.textContent = "Saving…";
+        const payload = {
+          rotation: parseInt(form.rotation.value, 10),
+          flip_horizontal: form.flip_horizontal.checked,
+          flip_vertical: form.flip_vertical.checked,
+        };
+        const response = await fetch("/api/orientation", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+        if (!response.ok) {
+          const error = await response.json();
+          statusLabel.textContent = "Error: " + (error.detail || "Unable to save");
+          return;
+        }
+        statusLabel.textContent = "Settings saved";
+      });
+
+      loadOrientation().catch((err) => {
+        console.error(err);
+        statusLabel.textContent = err.message;
+      });
+    </script>
+  </body>
+</html>

--- a/src/rev_cam/webrtc.py
+++ b/src/rev_cam/webrtc.py
@@ -1,0 +1,72 @@
+"""WebRTC helpers for RevCam."""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from fractions import Fraction
+from typing import Set
+from aiortc import RTCPeerConnection, RTCSessionDescription
+from aiortc.mediastreams import VideoStreamTrack
+from av import VideoFrame
+
+from .camera import BaseCamera
+from .pipeline import FramePipeline
+
+
+class PipelineVideoTrack(VideoStreamTrack):
+    """Video track that pulls frames from a camera via the processing pipeline."""
+
+    def __init__(self, camera: BaseCamera, pipeline: FramePipeline, fps: int = 30) -> None:
+        super().__init__()
+        self._camera = camera
+        self._pipeline = pipeline
+        self._frame_time = Fraction(1, fps)
+
+    async def recv(self) -> VideoFrame:
+        pts, time_base = await self.next_timestamp()
+        frame = await self._camera.get_frame()
+        processed = self._pipeline.process(frame)
+        video_frame = VideoFrame.from_ndarray(processed, format="rgb24")
+        video_frame.pts = pts
+        video_frame.time_base = time_base
+        return video_frame
+
+
+@dataclass
+class WebRTCManager:
+    """Manage WebRTC peer connections."""
+
+    camera: BaseCamera
+    pipeline: FramePipeline
+    connections: Set[RTCPeerConnection] = None
+
+    def __post_init__(self) -> None:
+        if self.connections is None:
+            self.connections = set()
+
+    async def handle_offer(self, offer: RTCSessionDescription) -> RTCSessionDescription:
+        pc = RTCPeerConnection()
+        track = PipelineVideoTrack(self.camera, self.pipeline)
+        pc.addTrack(track)
+
+        @pc.on("connectionstatechange")
+        async def on_state_change() -> None:  # pragma: no cover - logging only
+            if pc.connectionState in {"failed", "closed"}:
+                await self._close_connection(pc)
+
+        await pc.setRemoteDescription(offer)
+        answer = await pc.createAnswer()
+        await pc.setLocalDescription(answer)
+        self.connections.add(pc)
+        return pc.localDescription
+
+    async def _close_connection(self, pc: RTCPeerConnection) -> None:
+        await pc.close()
+        self.connections.discard(pc)
+
+    async def shutdown(self) -> None:
+        await asyncio.gather(*(self._close_connection(pc) for pc in list(self.connections)), return_exceptions=True)
+        self.connections.clear()
+
+
+__all__ = ["PipelineVideoTrack", "WebRTCManager"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+import pytest
+
+from rev_cam.config import ConfigManager, Orientation
+
+
+def test_default_orientation(tmp_path: Path):
+    manager = ConfigManager(tmp_path / "config.json")
+    assert manager.get_orientation() == Orientation()
+
+
+def test_set_orientation_persists(tmp_path: Path):
+    config_file = tmp_path / "config.json"
+    manager = ConfigManager(config_file)
+    updated = manager.set_orientation({"rotation": 90, "flip_horizontal": True, "flip_vertical": False})
+    assert updated.rotation == 90
+    # Reload to ensure persistence
+    reloaded = ConfigManager(config_file)
+    assert reloaded.get_orientation() == updated
+
+
+def test_invalid_orientation_rejected(tmp_path: Path):
+    manager = ConfigManager(tmp_path / "config.json")
+    with pytest.raises(ValueError):
+        manager.set_orientation({"rotation": 45})

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,51 @@
+from rev_cam.config import Orientation
+from rev_cam.pipeline import FramePipeline
+
+
+def make_frame():
+    return [
+        [[0, 0, 0], [1, 1, 1], [2, 2, 2]],
+        [[3, 3, 3], [4, 4, 4], [5, 5, 5]],
+    ]
+
+
+def orientation_provider(rotation=0, flip_h=False, flip_v=False):
+    return Orientation(rotation=rotation, flip_horizontal=flip_h, flip_vertical=flip_v)
+
+
+def test_rotation_90_degrees():
+    frame = make_frame()
+    pipeline = FramePipeline(lambda: orientation_provider(rotation=90))
+    processed = pipeline.process(frame)
+    expected = [
+        [[2, 2, 2], [5, 5, 5]],
+        [[1, 1, 1], [4, 4, 4]],
+        [[0, 0, 0], [3, 3, 3]],
+    ]
+    assert processed == expected
+
+
+def test_horizontal_flip():
+    frame = make_frame()
+    pipeline = FramePipeline(lambda: orientation_provider(flip_h=True))
+    processed = pipeline.process(frame)
+    expected = [
+        [[2, 2, 2], [1, 1, 1], [0, 0, 0]],
+        [[5, 5, 5], [4, 4, 4], [3, 3, 3]],
+    ]
+    assert processed == expected
+
+
+def test_overlay_composition():
+    frame = make_frame()
+    pipeline = FramePipeline(lambda: orientation_provider())
+
+    def increment(data):
+        return [
+            [[min(channel + 1, 255) for channel in pixel] for pixel in row]
+            for row in data
+        ]
+
+    pipeline.add_overlay(increment)
+    processed = pipeline.process(frame)
+    assert processed == increment(frame)


### PR DESCRIPTION
## Summary
- implement FastAPI application with WebRTC signalling, orientation controls, and modular video pipeline
- add camera abstractions and configuration persistence prepared for Raspberry Pi hardware and synthetic sources
- create iOS-friendly viewer/settings pages and unit tests for configuration and frame pipeline

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68caf8bf95b883328c9de83255c4d74d