### PR TITLE
Handle Picamera2 initialisation failures

### DIFF
--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -1,0 +1,64 @@
+"""Tests for camera selection and error handling."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from rev_cam.camera import CameraError, Picamera2Camera, SyntheticCamera, create_camera
+
+
+def test_picamera_initialisation_failure_is_wrapped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Picamera setup errors should raise CameraError and close the device."""
+
+    cleanup: dict[str, object] = {}
+
+    class DummyCamera:
+        def __init__(self) -> None:
+            cleanup["instance"] = self
+            self.stop_called = False
+            self.close_called = False
+
+        def create_video_configuration(self, **_: object) -> object:
+            return object()
+
+        def configure(self, _: object) -> None:
+            return None
+
+        def start(self) -> None:
+            raise RuntimeError("camera start failed")
+
+        def stop(self) -> None:
+            self.stop_called = True
+
+        def close(self) -> None:
+            self.close_called = True
+
+    module = types.SimpleNamespace(Picamera2=DummyCamera)
+    monkeypatch.setitem(sys.modules, "picamera2", module)
+
+    with pytest.raises(CameraError):
+        Picamera2Camera()
+
+    dummy = cleanup["instance"]
+    assert getattr(dummy, "close_called") is True
+    assert getattr(dummy, "stop_called") is False
+
+
+def test_create_camera_falls_back_when_picamera_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """create_camera should fall back to the synthetic camera when Picamera2 fails."""
+
+    class BrokenCamera:
+        def __init__(self) -> None:
+            raise RuntimeError("picamera unavailable")
+
+    module = types.SimpleNamespace(Picamera2=BrokenCamera)
+    monkeypatch.setitem(sys.modules, "picamera2", module)
+    monkeypatch.delenv("REVCAM_CAMERA", raising=False)
+
+    camera = create_camera()
+
+    assert isinstance(camera, SyntheticCamera)
+


### PR DESCRIPTION
## Summary
- wrap Picamera2 initialisation in CameraError so startup can fall back when the hardware is unavailable
- ensure partially constructed Picamera2 instances are closed on failure
- add tests covering Picamera2 failure handling and the synthetic fallback

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb35a3ede08332b1734d7d4f69ae8e