### PR TITLE
Clarify Raspberry Pi installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,46 @@ src/
 
 ## Getting started
 
-The project targets Python 3.11+. On development machines install the dependencies with
+RevCam targets Python 3.11+.
+
+### Raspberry Pi installation
+
+The Raspberry Pi wheels for Picamera2 and its native dependencies are shipped
+through Raspberry Pi OS. Using them is much faster and more reliable than
+building everything from PyPI. Follow these steps on the Pi:
+
+1. Install the packaged Picamera2 stack and its helpers:
+
+   ```bash
+   sudo apt update
+   sudo apt install python3-picamera2 python3-prctl
+   ```
+
+2. Create a virtual environment that can see the system packages you just
+   installed (this prevents `pip` from trying to rebuild Picamera2 and PiDNG):
+
+   ```bash
+   python3 -m venv --system-site-packages .venv
+   source .venv/bin/activate
+   python -m pip install --upgrade pip
+   ```
+
+3. Install RevCam from the source tree. On Pi hardware some wheels still need to
+   be built locally (`aiortc`, `pylibsrtp`, `av`), so this step can take several
+   minutes. Seeing a long list ending with `Successfully installed ...` means
+   the step finished successfully:
+
+   ```bash
+   pip install --prefer-binary --extra-index-url https://www.piwheels.org/simple -e .
+   ```
+
+   The `--prefer-binary` flag asks `pip` to fetch pre-built wheels when
+   available, and the PiWheels index provides ARM builds for most dependencies.
+
+### Development machine installation
+
+For local development on non-Pi machines a regular virtual environment is
+sufficient:
 
 ```bash
 python -m venv .venv
@@ -38,18 +77,13 @@ source .venv/bin/activate
 pip install -e .
 ```
 
+### Camera back-ends
+
 Camera support is pluggable:
 
-- **Raspberry Pi camera** – Install the system packages provided by Raspberry Pi
-  OS instead of pulling `picamera2` from PyPI. This avoids the `python-prctl`
-  build dependency on `libcap` headers. On a Pi run:
-
-  ```bash
-  sudo apt install python3-picamera2 python3-prctl
-  ```
-
-  The packaged build already bundles the compiled dependencies required by
-  Picamera2, so no additional Python packages are needed.
+- **Raspberry Pi camera** – With the apt packages installed above the Picamera2
+  backend is available inside the virtual environment (thanks to
+  `--system-site-packages`). No additional Python packages are required.
 - **OpenCV USB camera** – Install `opencv-python` manually and set
   `REVCAM_CAMERA=opencv`.
 - **Synthetic frames** – For development without camera hardware set

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -1,0 +1,64 @@
+"""Tests for camera selection and error handling."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from rev_cam.camera import CameraError, Picamera2Camera, SyntheticCamera, create_camera
+
+
+def test_picamera_initialisation_failure_is_wrapped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Picamera setup errors should raise CameraError and close the device."""
+
+    cleanup: dict[str, object] = {}
+
+    class DummyCamera:
+        def __init__(self) -> None:
+            cleanup["instance"] = self
+            self.stop_called = False
+            self.close_called = False
+
+        def create_video_configuration(self, **_: object) -> object:
+            return object()
+
+        def configure(self, _: object) -> None:
+            return None
+
+        def start(self) -> None:
+            raise RuntimeError("camera start failed")
+
+        def stop(self) -> None:
+            self.stop_called = True
+
+        def close(self) -> None:
+            self.close_called = True
+
+    module = types.SimpleNamespace(Picamera2=DummyCamera)
+    monkeypatch.setitem(sys.modules, "picamera2", module)
+
+    with pytest.raises(CameraError):
+        Picamera2Camera()
+
+    dummy = cleanup["instance"]
+    assert getattr(dummy, "close_called") is True
+    assert getattr(dummy, "stop_called") is False
+
+
+def test_create_camera_falls_back_when_picamera_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """create_camera should fall back to the synthetic camera when Picamera2 fails."""
+
+    class BrokenCamera:
+        def __init__(self) -> None:
+            raise RuntimeError("picamera unavailable")
+
+    module = types.SimpleNamespace(Picamera2=BrokenCamera)
+    monkeypatch.setitem(sys.modules, "picamera2", module)
+    monkeypatch.delenv("REVCAM_CAMERA", raising=False)
+
+    camera = create_camera()
+
+    assert isinstance(camera, SyntheticCamera)
+


### PR DESCRIPTION
## Summary
- document the Raspberry Pi specific installation flow that uses the packaged Picamera2 stack
- explain how to create a virtual environment with system packages and prefer PiWheels binaries so `pip install -e .` completes reliably
- keep a separate quick-start snippet for development machines

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb35a3ede08332b1734d7d4f69ae8e