### PR TITLE
Integrate INA219 battery telemetry into RevCam

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ overlays can be injected on the server without major changes.
 - Fast WebRTC video delivery optimised for mobile Safari (iPhone/iPad).
 - Camera orientation controls (rotation and horizontal/vertical flips).
 - Modular frame processing pipeline ready for future overlays (e.g. guidelines).
+- Battery telemetry read from an INA219 power monitor with on-device dashboards.
 - REST API for orientation control and WebRTC signalling.
 
 ## Project layout
@@ -98,6 +99,22 @@ uvicorn rev_cam.app:create_app --factory --host 0.0.0.0 --port 8000
 Then open `http://<pi-address>:8000` on the iOS device to view the stream. Access the
 settings panel at `/settings` to adjust the camera orientation. Changes are persisted
 and applied immediately to the outgoing WebRTC stream.
+
+## Battery monitoring
+
+RevCam can surface battery information from an INA219 sensor. By default the
+application attempts to initialise the sensor and, when unavailable, falls back
+to a synthetic data source useful for development. Configure the behaviour via
+environment variables:
+
+- `REVCAM_BATTERY` – set to `ina219` (default), `synthetic`, or `none` to
+  disable telemetry entirely.
+- `REVCAM_BATTERY_MIN_VOLTAGE` / `REVCAM_BATTERY_MAX_VOLTAGE` – define the
+  expected voltage range so that the reported percentage can be derived
+  correctly (defaults to 11.0–12.6 V).
+
+Battery telemetry is available through the `/api/power` endpoint and displayed
+on both the live view and settings pages.
 
 ## Testing
 

--- a/src/rev_cam/power.py
+++ b/src/rev_cam/power.py
@@ -1,0 +1,196 @@
+"""Battery monitoring helpers for RevCam."""
+from __future__ import annotations
+
+import asyncio
+import math
+import os
+import time
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Callable
+
+
+class BatteryMonitorError(RuntimeError):
+    """Raised when the battery monitor cannot be initialised or queried."""
+
+
+@dataclass(slots=True)
+class BatteryStatus:
+    """Snapshot of the battery telemetry."""
+
+    voltage: float | None
+    current: float | None
+    percentage: float | None
+
+    def to_dict(self) -> dict[str, float | None]:
+        return {
+            "voltage": self.voltage,
+            "current": self.current,
+            "percentage": self.percentage,
+        }
+
+
+class BaseBatteryMonitor(ABC):
+    """Abstract interface for battery monitors."""
+
+    @abstractmethod
+    async def read(self) -> BatteryStatus:  # pragma: no cover - interface only
+        raise NotImplementedError
+
+    async def close(self) -> None:  # pragma: no cover - optional override
+        return None
+
+
+class INA219BatteryMonitor(BaseBatteryMonitor):
+    """Battery monitor backed by an INA219 sensor."""
+
+    def __init__(
+        self,
+        *,
+        address: int = 0x40,
+        shunt_resistance_ohms: float = 0.1,
+        max_expected_amps: float = 2.0,
+        voltage_to_percentage: Callable[[float], float | None] | None = None,
+    ) -> None:
+        try:  # pragma: no cover - hardware dependent
+            import board  # type: ignore
+            import busio  # type: ignore
+            from adafruit_ina219 import INA219  # type: ignore
+        except ImportError as exc:  # pragma: no cover - hardware dependent
+            raise BatteryMonitorError("INA219 dependencies are not installed") from exc
+
+        try:  # pragma: no cover - hardware dependent
+            i2c = busio.I2C(board.SCL, board.SDA)
+        except Exception as exc:  # pragma: no cover - hardware dependent
+            raise BatteryMonitorError("Unable to initialise I2C bus for INA219") from exc
+
+        try:  # pragma: no cover - hardware dependent
+            sensor = INA219(shunt_resistance_ohms, max_expected_amps, i2c, addr=address)
+        except Exception as exc:  # pragma: no cover - hardware dependent
+            raise BatteryMonitorError("Unable to communicate with INA219 sensor") from exc
+
+        self._sensor = sensor
+        self._lock = asyncio.Lock()
+        self._voltage_to_percentage = voltage_to_percentage
+
+    async def read(self) -> BatteryStatus:  # pragma: no cover - hardware dependent
+        async with self._lock:
+            return await asyncio.to_thread(self._read_sync)
+
+    def _read_sync(self) -> BatteryStatus:  # pragma: no cover - hardware dependent
+        try:
+            bus_voltage = float(self._sensor.bus_voltage)
+        except Exception as exc:
+            raise BatteryMonitorError("Failed to read bus voltage from INA219") from exc
+
+        current = None
+        try:
+            current = float(self._sensor.current) / 1000.0
+        except Exception:
+            # Some firmware builds may not expose current sensing – ignore gracefully.
+            current = None
+
+        percentage = None
+        if self._voltage_to_percentage is not None:
+            try:
+                percentage = self._voltage_to_percentage(bus_voltage)
+            except Exception:
+                percentage = None
+
+        return BatteryStatus(voltage=bus_voltage, current=current, percentage=percentage)
+
+
+class SyntheticBatteryMonitor(BaseBatteryMonitor):
+    """Synthetic battery monitor used when hardware is unavailable."""
+
+    def __init__(self, *, min_voltage: float = 11.0, max_voltage: float = 12.6) -> None:
+        self._min = float(min_voltage)
+        self._max = float(max_voltage)
+        if self._max <= self._min:
+            raise BatteryMonitorError("max_voltage must be greater than min_voltage")
+        self._start = time.monotonic()
+
+    async def read(self) -> BatteryStatus:
+        elapsed = time.monotonic() - self._start
+        span = self._max - self._min
+        voltage = self._min + (math.sin(elapsed / 30.0) + 1.0) / 2.0 * span
+        percentage = (voltage - self._min) / span * 100.0
+        return BatteryStatus(voltage=voltage, current=0.0, percentage=percentage)
+
+
+def _build_voltage_percentage_mapper(min_voltage: float, max_voltage: float) -> Callable[[float], float | None]:
+    span = max_voltage - min_voltage
+    if span <= 0:
+        raise BatteryMonitorError("Maximum voltage must be greater than minimum voltage")
+
+    def _mapper(voltage: float) -> float | None:
+        if voltage is None:
+            return None
+        percentage = (voltage - min_voltage) / span * 100.0
+        return max(0.0, min(100.0, percentage))
+
+    return _mapper
+
+
+def _get_voltage_limits() -> tuple[float, float]:
+    min_voltage_env = os.getenv("REVCAM_BATTERY_MIN_VOLTAGE")
+    max_voltage_env = os.getenv("REVCAM_BATTERY_MAX_VOLTAGE")
+
+    def _parse(value: str | None, fallback: float) -> float:
+        if value is None:
+            return fallback
+        try:
+            return float(value)
+        except ValueError as exc:
+            raise BatteryMonitorError(f"Invalid voltage value {value!r}") from exc
+
+    min_voltage = _parse(min_voltage_env, 11.0)
+    max_voltage = _parse(max_voltage_env, 12.6)
+    if max_voltage <= min_voltage:
+        raise BatteryMonitorError("Maximum voltage must exceed minimum voltage")
+    return min_voltage, max_voltage
+
+
+def create_battery_monitor() -> BaseBatteryMonitor | None:
+    """Create the battery monitor selected via configuration."""
+
+    choice = os.getenv("REVCAM_BATTERY", "auto").strip().lower()
+    min_voltage = 11.0
+    max_voltage = 12.6
+    try:
+        min_voltage, max_voltage = _get_voltage_limits()
+    except BatteryMonitorError:
+        # Keep defaults if parsing fails; validation happens later for actual monitors.
+        min_voltage, max_voltage = 11.0, 12.6
+
+    mapper: Callable[[float], float | None] | None = None
+    try:
+        mapper = _build_voltage_percentage_mapper(min_voltage, max_voltage)
+    except BatteryMonitorError:
+        mapper = None
+
+    if choice in {"none", "off", "disable", "disabled"}:
+        return None
+    if choice == "synthetic":
+        return SyntheticBatteryMonitor(min_voltage=min_voltage, max_voltage=max_voltage)
+
+    if choice in {"ina219", "auto", "default"}:
+        try:
+            return INA219BatteryMonitor(voltage_to_percentage=mapper)
+        except BatteryMonitorError:
+            if choice != "auto":
+                raise
+            return SyntheticBatteryMonitor(min_voltage=min_voltage, max_voltage=max_voltage)
+
+    raise BatteryMonitorError(f"Unknown battery monitor selection: {choice}")
+
+
+__all__ = [
+    "BaseBatteryMonitor",
+    "BatteryMonitorError",
+    "BatteryStatus",
+    "INA219BatteryMonitor",
+    "SyntheticBatteryMonitor",
+    "create_battery_monitor",
+]
+

--- a/src/rev_cam/static/index.html
+++ b/src/rev_cam/static/index.html
@@ -19,6 +19,18 @@
         padding: 0.75rem 1rem;
         background: rgba(0, 0, 0, 0.6);
       }
+      header {
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+      }
+      .header-top {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 1rem;
+        flex-wrap: wrap;
+      }
       main {
         flex: 1 1 auto;
         display: flex;
@@ -44,11 +56,18 @@
         font-size: 0.9rem;
         opacity: 0.8;
       }
+      #battery {
+        font-size: 0.9rem;
+        opacity: 0.8;
+      }
     </style>
   </head>
   <body>
     <header>
-      <strong>RevCam</strong>
+      <div class="header-top">
+        <strong>RevCam</strong>
+        <div id="battery">Battery: Loading…</div>
+      </div>
       <div id="status">Initialising…</div>
     </header>
     <main>
@@ -62,7 +81,34 @@
       const statusLabel = document.getElementById("status");
       const reconnectButton = document.getElementById("reconnect");
       const video = document.getElementById("video");
+      const batteryLabel = document.getElementById("battery");
       let pc;
+
+      async function updateBatteryStatus() {
+        try {
+          const response = await fetch("/api/power");
+          if (!response.ok) {
+            throw new Error("Bad response");
+          }
+          const data = await response.json();
+          const parts = [];
+          if (typeof data.voltage === "number") {
+            parts.push(`${data.voltage.toFixed(2)} V`);
+          }
+          if (typeof data.percentage === "number") {
+            parts.push(`${Math.round(data.percentage)}%`);
+          }
+          if (typeof data.current === "number") {
+            const sign = data.current >= 0 ? "" : "−";
+            parts.push(`${sign}${Math.abs(data.current).toFixed(2)} A`);
+          }
+          batteryLabel.textContent = parts.length
+            ? `Battery: ${parts.join(" · ")}`
+            : "Battery: Data unavailable";
+        } catch (err) {
+          batteryLabel.textContent = "Battery: Unavailable";
+        }
+      }
 
       async function startStream() {
         statusLabel.textContent = "Connecting to camera…";
@@ -106,6 +152,8 @@
         console.error(err);
         statusLabel.textContent = "Error: " + err.message;
       });
+      updateBatteryStatus();
+      setInterval(updateBatteryStatus, 10000);
     </script>
   </body>
 </html>

--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -40,6 +40,15 @@
       a {
         color: #0a84ff;
       }
+      .panel {
+        margin-top: 2rem;
+        padding: 1rem;
+        border-radius: 0.75rem;
+        background: rgba(255, 255, 255, 0.05);
+      }
+      .panel h2 {
+        margin-top: 0;
+      }
     </style>
   </head>
   <body>
@@ -64,9 +73,14 @@
       <button type="submit">Save</button>
       <div id="status">Loading…</div>
     </form>
+    <section class="panel">
+      <h2>Battery</h2>
+      <p id="battery-status">Loading…</p>
+    </section>
     <script>
       const form = document.getElementById("orientation-form");
       const statusLabel = document.getElementById("status");
+      const batteryStatusLabel = document.getElementById("battery-status");
 
       async function loadOrientation() {
         const response = await fetch("/api/orientation");
@@ -105,6 +119,35 @@
         console.error(err);
         statusLabel.textContent = err.message;
       });
+
+      async function loadBatteryStatus() {
+        try {
+          const response = await fetch("/api/power");
+          if (!response.ok) {
+            throw new Error("Unable to read battery telemetry");
+          }
+          const data = await response.json();
+          const pieces = [];
+          if (typeof data.voltage === "number") {
+            pieces.push(`${data.voltage.toFixed(2)} V`);
+          }
+          if (typeof data.percentage === "number") {
+            pieces.push(`${Math.round(data.percentage)}%`);
+          }
+          if (typeof data.current === "number") {
+            const prefix = data.current >= 0 ? "" : "−";
+            pieces.push(`${prefix}${Math.abs(data.current).toFixed(2)} A`);
+          }
+          batteryStatusLabel.textContent = pieces.length
+            ? pieces.join(" · ")
+            : "Battery data unavailable";
+        } catch (err) {
+          batteryStatusLabel.textContent = err.message;
+        }
+      }
+
+      loadBatteryStatus();
+      setInterval(loadBatteryStatus, 10000);
     </script>
   </body>
 </html>

--- a/tests/test_power.py
+++ b/tests/test_power.py
@@ -1,0 +1,61 @@
+"""Tests for battery telemetry helpers."""
+from __future__ import annotations
+import asyncio
+
+import pytest
+
+from rev_cam.power import (
+    BatteryMonitorError,
+    BatteryStatus,
+    SyntheticBatteryMonitor,
+    create_battery_monitor,
+)
+
+
+def test_battery_status_to_dict() -> None:
+    status = BatteryStatus(voltage=12.45, current=0.5, percentage=76.0)
+    assert status.to_dict() == {
+        "voltage": pytest.approx(12.45),
+        "current": pytest.approx(0.5),
+        "percentage": pytest.approx(76.0),
+    }
+
+
+def test_synthetic_monitor_within_bounds() -> None:
+    monitor = SyntheticBatteryMonitor(min_voltage=11.5, max_voltage=12.5)
+    status = asyncio.run(monitor.read())
+    assert status.voltage is not None
+    assert 11.5 <= status.voltage <= 12.5
+    assert status.current == 0.0
+    assert status.percentage is not None
+    assert 0.0 <= status.percentage <= 100.0
+
+
+def test_create_battery_monitor_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("REVCAM_BATTERY", "none")
+    assert create_battery_monitor() is None
+
+
+def test_create_battery_monitor_synthetic(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("REVCAM_BATTERY", "synthetic")
+    monitor = create_battery_monitor()
+    assert isinstance(monitor, SyntheticBatteryMonitor)
+
+
+def test_create_battery_monitor_voltage_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("REVCAM_BATTERY", "synthetic")
+    monkeypatch.setenv("REVCAM_BATTERY_MIN_VOLTAGE", "3.0")
+    monkeypatch.setenv("REVCAM_BATTERY_MAX_VOLTAGE", "4.2")
+    monitor = create_battery_monitor()
+    assert isinstance(monitor, SyntheticBatteryMonitor)
+    status = asyncio.run(monitor.read())
+    assert status.voltage is not None
+    assert 3.0 <= status.voltage <= 4.2
+    assert status.percentage is not None
+    assert 0.0 <= status.percentage <= 100.0
+
+
+def test_create_battery_monitor_invalid_choice(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("REVCAM_BATTERY", "mystery")
+    with pytest.raises(BatteryMonitorError):
+        create_battery_monitor()


### PR DESCRIPTION
## Summary
- add a battery monitoring service with INA219 and synthetic fallbacks
- expose `/api/power` and display telemetry on the live and settings pages
- document telemetry configuration and cover it with unit tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cbd563363c8332b44a5c66b29784fb