### PR TITLE
Add installation convenience script

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,13 @@ building everything from PyPI. Follow these steps on the Pi:
 3. Install RevCam from the source tree. On Pi hardware some wheels still need to
    be built locally (`aiortc`, `pylibsrtp`, `av`), so this step can take several
    minutes. Seeing a long list ending with `Successfully installed ...` means
-   the step finished successfully:
+   the step finished successfully. You can either run the convenience script:
+
+   ```bash
+   ./scripts/install.sh --pi
+   ```
+
+   or execute `pip` manually:
 
    ```bash
    pip install --prefer-binary --extra-index-url https://www.piwheels.org/simple -e .
@@ -72,9 +78,16 @@ For local development on non-Pi machines a regular virtual environment is
 sufficient:
 
 ```bash
+./scripts/install.sh --dev
+```
+
+Under the hood the script creates a `.venv` virtual environment and installs the
+project in editable mode. If you prefer to perform the steps manually, run:
+
+```bash
 python -m venv .venv
 source .venv/bin/activate
-pip install -e .
+pip install -e .[dev]
 ```
 
 ### Camera back-ends

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage: scripts/install.sh [options]
+
+Create a Python virtual environment for RevCam and install the project.
+
+Options:
+  --python PATH           Python interpreter to use (default: python3)
+  --venv PATH             Virtual environment directory (default: .venv)
+  --pi                    Optimise installation for Raspberry Pi OS. Creates the
+                          virtual environment with --system-site-packages and
+                          installs dependencies through PiWheels when possible.
+  --dev                   Install the development dependencies defined in
+                          pyproject.toml.
+  --recreate              Delete any existing virtual environment before
+                          creating a new one.
+  -h, --help              Show this help message and exit.
+USAGE
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PYTHON="${PYTHON:-python3}"
+VENV_DIR="$PROJECT_ROOT/.venv"
+USE_PI=false
+WITH_DEV=false
+RECREATE=false
+
+VENV_FLAGS=()
+PIP_FLAGS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --python)
+            [[ $# -ge 2 ]] || { echo "--python requires a value" >&2; exit 1; }
+            PYTHON="$2"
+            shift 2
+            ;;
+        --venv)
+            [[ $# -ge 2 ]] || { echo "--venv requires a value" >&2; exit 1; }
+            case "$2" in
+                /*) VENV_DIR="$2" ;;
+                *) VENV_DIR="$PROJECT_ROOT/$2" ;;
+            esac
+            shift 2
+            ;;
+        --pi)
+            USE_PI=true
+            shift
+            ;;
+        --dev)
+            WITH_DEV=true
+            shift
+            ;;
+        --recreate)
+            RECREATE=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if ! command -v "$PYTHON" >/dev/null 2>&1; then
+    echo "Python interpreter not found: $PYTHON" >&2
+    exit 1
+fi
+
+if ! "$PYTHON" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 11) else 1)'; then
+    echo "RevCam requires Python 3.11 or newer." >&2
+    exit 1
+fi
+
+if [[ "$USE_PI" == true ]]; then
+    VENV_FLAGS+=(--system-site-packages)
+    PIP_FLAGS+=(--prefer-binary --extra-index-url "https://www.piwheels.org/simple")
+fi
+
+if [[ "$RECREATE" == true && -d "$VENV_DIR" ]]; then
+    echo "Removing existing virtual environment at $VENV_DIR"
+    rm -rf "$VENV_DIR"
+fi
+
+if [[ ! -d "$VENV_DIR" ]]; then
+    echo "Creating virtual environment in $VENV_DIR"
+    "$PYTHON" -m venv "${VENV_FLAGS[@]}" "$VENV_DIR"
+else
+    echo "Using existing virtual environment in $VENV_DIR"
+fi
+
+# shellcheck source=/dev/null
+source "$VENV_DIR/bin/activate"
+
+if [[ "$USE_PI" == true ]]; then
+    echo "Enabling Raspberry Pi friendly installation options"
+fi
+
+"$VENV_DIR/bin/python" -m pip install --upgrade pip
+
+INSTALL_TARGET="."
+if [[ "$WITH_DEV" == true ]]; then
+    INSTALL_TARGET=".[dev]"
+fi
+
+pushd "$PROJECT_ROOT" >/dev/null
+trap 'popd >/dev/null' EXIT
+
+set -x
+"$VENV_DIR/bin/python" -m pip install "${PIP_FLAGS[@]}" -e "$INSTALL_TARGET"
+set +x
+
+trap - EXIT
+popd >/dev/null
+
+cat <<SUMMARY
+
+Installation complete.
+Activate the virtual environment with:
+  source "$VENV_DIR/bin/activate"
+
+SUMMARY


### PR DESCRIPTION
## Summary
- add a configurable `scripts/install.sh` helper for creating a virtual environment and installing RevCam
- document the new installation script in the README and note how to install dev extras manually

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbe1155bc08332ad095c46cd8bce90