### PR TITLE
Fix remote stream attachment for WebRTC viewer

### DIFF
--- a/src/rev_cam/static/index.html
+++ b/src/rev_cam/static/index.html
@@ -72,8 +72,18 @@
         pc = new RTCPeerConnection();
         pc.addTransceiver("video", { direction: "recvonly" });
         pc.ontrack = (event) => {
-          if (event.streams && event.streams[0]) {
-            video.srcObject = event.streams[0];
+          let stream = event.streams && event.streams[0];
+          if (!stream) {
+            stream = new MediaStream([event.track]);
+          }
+          if (video.srcObject !== stream) {
+            video.srcObject = stream;
+          }
+          const playPromise = video.play();
+          if (playPromise !== undefined) {
+            playPromise.catch((err) => {
+              console.warn("Autoplay failed", err);
+            });
           }
         };
         pc.onconnectionstatechange = () => {


### PR DESCRIPTION
## Summary
- ensure the viewer attaches remote WebRTC tracks even when the `ontrack` event does not expose a stream
- trigger playback after attaching the stream and surface autoplay failures for easier diagnosis

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cc466ea4a08332b49408e6f0653593