### PR TITLE
Handle missing aiortc dependency gracefully

### DIFF
--- a/src/rev_cam/webrtc.py
+++ b/src/rev_cam/webrtc.py
@@ -4,25 +4,57 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass
 from fractions import Fraction
-from typing import Set
-from aiortc import RTCPeerConnection, RTCSessionDescription
-from aiortc.mediastreams import VideoStreamTrack
+from typing import TYPE_CHECKING, Set
+
 from av import VideoFrame
 
 from .camera import BaseCamera
 from .pipeline import FramePipeline
 
+if TYPE_CHECKING:  # pragma: no cover - imported for type checkers only
+    from aiortc import RTCPeerConnection, RTCSessionDescription
+    from aiortc.mediastreams import VideoStreamTrack
 
-class PipelineVideoTrack(VideoStreamTrack):
+try:  # pragma: no cover - optional dependency
+    from aiortc import RTCPeerConnection as _RTCPeerConnection
+    from aiortc import RTCSessionDescription as _RTCSessionDescription
+    from aiortc.mediastreams import VideoStreamTrack as _VideoStreamTrack
+except ImportError as exc:  # pragma: no cover - handled at runtime
+    _RTCPeerConnection = None  # type: ignore[assignment]
+    _RTCSessionDescription = None  # type: ignore[assignment]
+    _AIORTC_IMPORT_ERROR = exc
+
+    class _VideoStreamTrack:  # type: ignore[no-redef]
+        """Stub base class used when aiortc is unavailable."""
+
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            super().__init__()
+
+else:  # pragma: no cover - executed when dependency is installed
+    _AIORTC_IMPORT_ERROR = None
+
+
+def _ensure_aiortc_available() -> None:
+    """Raise a helpful error when the optional aiortc dependency is missing."""
+
+    if _AIORTC_IMPORT_ERROR is not None:
+        raise RuntimeError(
+            "aiortc is required for WebRTC functionality. Install the 'aiortc' package to enable streaming."
+        ) from _AIORTC_IMPORT_ERROR
+
+
+class PipelineVideoTrack(_VideoStreamTrack):
     """Video track that pulls frames from a camera via the processing pipeline."""
 
     def __init__(self, camera: BaseCamera, pipeline: FramePipeline, fps: int = 30) -> None:
+        _ensure_aiortc_available()
         super().__init__()
         self._camera = camera
         self._pipeline = pipeline
         self._frame_time = Fraction(1, fps)
 
     async def recv(self) -> VideoFrame:
+        _ensure_aiortc_available()
         pts, time_base = await self.next_timestamp()
         frame = await self._camera.get_frame()
         processed = self._pipeline.process(frame)
@@ -38,14 +70,16 @@ class WebRTCManager:
 
     camera: BaseCamera
     pipeline: FramePipeline
-    connections: Set[RTCPeerConnection] = None
+    connections: Set[RTCPeerConnection] | None = None
 
     def __post_init__(self) -> None:
+        _ensure_aiortc_available()
         if self.connections is None:
             self.connections = set()
 
     async def handle_offer(self, offer: RTCSessionDescription) -> RTCSessionDescription:
-        pc = RTCPeerConnection()
+        _ensure_aiortc_available()
+        pc = _RTCPeerConnection()
         track = PipelineVideoTrack(self.camera, self.pipeline)
         pc.addTrack(track)
 
@@ -65,8 +99,9 @@ class WebRTCManager:
         self.connections.discard(pc)
 
     async def shutdown(self) -> None:
-        await asyncio.gather(*(self._close_connection(pc) for pc in list(self.connections)), return_exceptions=True)
-        self.connections.clear()
+        await asyncio.gather(*(self._close_connection(pc) for pc in list(self.connections or [])), return_exceptions=True)
+        if self.connections is not None:
+            self.connections.clear()
 
 
 __all__ = ["PipelineVideoTrack", "WebRTCManager"]

--- a/tests/test_webrtc_optional.py
+++ b/tests/test_webrtc_optional.py
@@ -1,0 +1,50 @@
+"""Tests covering graceful handling of the optional aiortc dependency."""
+
+from __future__ import annotations
+
+import builtins
+import importlib
+import sys
+
+import numpy as np
+import pytest
+
+from rev_cam.camera import BaseCamera
+from rev_cam.config import Orientation
+from rev_cam.pipeline import FramePipeline
+
+
+class DummyCamera(BaseCamera):
+    async def get_frame(self) -> np.ndarray:  # pragma: no cover - trivial implementation
+        return np.zeros((1, 1, 3), dtype=np.uint8)
+
+
+def _simulate_missing_aiortc(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch the import machinery so that aiortc appears to be unavailable."""
+
+    real_import = builtins.__import__
+
+    def fake_import(name: str, globals: dict | None = None, locals: dict | None = None, fromlist=(), level: int = 0):
+        if name.startswith("aiortc"):
+            raise ModuleNotFoundError("No module named 'aiortc'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    for module in list(sys.modules):
+        if module.startswith("aiortc"):
+            monkeypatch.delitem(sys.modules, module, raising=False)
+
+
+def test_webrtc_import_succeeds_without_aiortc(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Importing the WebRTC helpers should not crash when aiortc is missing."""
+
+    _simulate_missing_aiortc(monkeypatch)
+    monkeypatch.delitem(sys.modules, "rev_cam.webrtc", raising=False)
+
+    module = importlib.import_module("rev_cam.webrtc")
+
+    pipeline = FramePipeline(lambda: Orientation())
+
+    with pytest.raises(RuntimeError, match="aiortc is required"):
+        module.WebRTCManager(camera=DummyCamera(), pipeline=pipeline)
+


### PR DESCRIPTION
## Summary
- guard the WebRTC helpers so they raise a clear error when aiortc is unavailable instead of failing at import time
- make the FastAPI wiring degrade gracefully by deferring the aiortc import and logging when WebRTC is disabled
- add a regression test that simulates a missing aiortc installation and verifies the new behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc59779a3c83328ea67398cd419384