### PR TITLE
Improve camera auto-selection

### DIFF
--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -299,12 +299,7 @@
 
         if (data.error) {
           cameraStatusText.textContent = `Camera unavailable: ${data.error}`;
-          cameraFallbacksWrapper.hidden = true;
-          cameraFallbacksList.innerHTML = "";
-          return;
-        }
-
-        if (data.active_backend) {
+        } else if (data.active_backend) {
           const backendText = backendLabel(data.active_backend);
           if (requested === "auto") {
             if (data.active_backend === "synthetic") {

--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -10,6 +10,25 @@
         font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
         background-color: #111;
         color: #f5f5f5;
+      }
+      .top-bar {
+        background: #001a3d;
+        padding: 1rem 1.5rem;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+      }
+      .top-bar a {
+        color: #8ab4ff;
+        text-decoration: none;
+        font-weight: 600;
+      }
+      .top-bar__title {
+        font-size: 1.1rem;
+        font-weight: 600;
+      }
+      main {
         padding: 1.5rem;
       }
       h1 {
@@ -43,27 +62,32 @@
     </style>
   </head>
   <body>
-    <a href="/">← Back to live view</a>
-    <h1>Camera Orientation</h1>
-    <form id="orientation-form">
-      <label>
-        Rotation
-        <select name="rotation">
-          <option value="0">0°</option>
-          <option value="90">90°</option>
-          <option value="180">180°</option>
-          <option value="270">270°</option>
-        </select>
-      </label>
-      <label>
-        <input type="checkbox" name="flip_horizontal" /> Flip horizontally
-      </label>
-      <label>
-        <input type="checkbox" name="flip_vertical" /> Flip vertically
-      </label>
-      <button type="submit">Save</button>
-      <div id="status">Loading…</div>
-    </form>
+    <header class="top-bar">
+      <a href="/">← Back to live view</a>
+      <span class="top-bar__title">Settings</span>
+    </header>
+    <main>
+      <h1>Camera Orientation</h1>
+      <form id="orientation-form">
+        <label>
+          Rotation
+          <select name="rotation">
+            <option value="0">0°</option>
+            <option value="90">90°</option>
+            <option value="180">180°</option>
+            <option value="270">270°</option>
+          </select>
+        </label>
+        <label>
+          <input type="checkbox" name="flip_horizontal" /> Flip horizontally
+        </label>
+        <label>
+          <input type="checkbox" name="flip_vertical" /> Flip vertically
+        </label>
+        <button type="submit">Save</button>
+        <div id="status">Loading…</div>
+      </form>
+    </main>
     <script>
       const form = document.getElementById("orientation-form");
       const statusLabel = document.getElementById("status");

--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -31,8 +31,23 @@
       main {
         padding: 1.5rem;
       }
-      h1 {
+      .card {
+        background: #1b1b1d;
+        border-radius: 16px;
+        padding: 1.5rem;
+        margin-bottom: 1.5rem;
+        box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+      }
+      .card h1,
+      .card h2 {
         margin-top: 0;
+        margin-bottom: 0.75rem;
+      }
+      h1 {
+        font-size: 1.4rem;
+      }
+      h2 {
+        font-size: 1.2rem;
       }
       label {
         display: block;
@@ -56,6 +71,29 @@
         font-size: 0.95rem;
         opacity: 0.85;
       }
+      .muted {
+        color: #b0b0c0;
+        font-size: 0.95rem;
+        margin: 0.25rem 0 0.75rem;
+      }
+      .status-line {
+        margin: 0.25rem 0 0.5rem;
+        font-size: 1rem;
+      }
+      .fallback-wrapper {
+        margin-top: 0.75rem;
+      }
+      .fallback-wrapper p {
+        margin: 0 0 0.25rem;
+        font-size: 0.9rem;
+        color: #a0a0b8;
+      }
+      .fallback-list {
+        margin: 0;
+        padding-left: 1.2rem;
+        font-size: 0.9rem;
+        color: #d0d0e0;
+      }
       a {
         color: #0a84ff;
       }
@@ -67,30 +105,47 @@
       <span class="top-bar__title">Settings</span>
     </header>
     <main>
-      <h1>Camera Orientation</h1>
-      <form id="orientation-form">
-        <label>
-          Rotation
-          <select name="rotation">
-            <option value="0">0°</option>
-            <option value="90">90°</option>
-            <option value="180">180°</option>
-            <option value="270">270°</option>
-          </select>
-        </label>
-        <label>
-          <input type="checkbox" name="flip_horizontal" /> Flip horizontally
-        </label>
-        <label>
-          <input type="checkbox" name="flip_vertical" /> Flip vertically
-        </label>
-        <button type="submit">Save</button>
-        <div id="status">Loading…</div>
-      </form>
+      <section class="card">
+        <h1>Camera Source</h1>
+        <p class="muted">Configured mode: <span id="camera-mode">Loading…</span></p>
+        <p id="camera-status-text" class="status-line">Checking camera status…</p>
+        <div id="camera-fallbacks-wrapper" class="fallback-wrapper" hidden>
+          <p>Unavailable sources:</p>
+          <ul id="camera-fallbacks" class="fallback-list"></ul>
+        </div>
+      </section>
+      <section class="card">
+        <h2>Camera Orientation</h2>
+        <form id="orientation-form">
+          <label>
+            Rotation
+            <select name="rotation">
+              <option value="0">0°</option>
+              <option value="90">90°</option>
+              <option value="180">180°</option>
+              <option value="270">270°</option>
+            </select>
+          </label>
+          <label>
+            <input type="checkbox" name="flip_horizontal" /> Flip horizontally
+          </label>
+          <label>
+            <input type="checkbox" name="flip_vertical" /> Flip vertically
+          </label>
+          <button type="submit">Save</button>
+          <div id="status">Loading…</div>
+        </form>
+      </section>
     </main>
     <script>
       const form = document.getElementById("orientation-form");
       const statusLabel = document.getElementById("status");
+      const cameraModeLabel = document.getElementById("camera-mode");
+      const cameraStatusText = document.getElementById("camera-status-text");
+      const cameraFallbacksWrapper = document.getElementById(
+        "camera-fallbacks-wrapper"
+      );
+      const cameraFallbacksList = document.getElementById("camera-fallbacks");
 
       async function loadOrientation() {
         const response = await fetch("/api/orientation");
@@ -125,9 +180,90 @@
         statusLabel.textContent = "Settings saved";
       });
 
+      function backendLabel(name) {
+        switch (name) {
+          case "picamera2":
+            return "Picamera2 camera";
+          case "opencv":
+            return "OpenCV camera";
+          case "synthetic":
+            return "synthetic test feed";
+          default:
+            return name;
+        }
+      }
+
+      function modeLabel(mode) {
+        switch (mode) {
+          case "auto":
+            return "auto";
+          case "picamera":
+          case "picamera2":
+            return "picamera2";
+          default:
+            return mode || "auto";
+        }
+      }
+
+      async function loadCameraStatus() {
+        const response = await fetch("/api/camera");
+        if (!response.ok) {
+          throw new Error("Unable to fetch camera status");
+        }
+        const data = await response.json();
+        const requested = modeLabel(data.requested);
+        cameraModeLabel.textContent = requested;
+
+        if (data.error) {
+          cameraStatusText.textContent = `Camera unavailable: ${data.error}`;
+          cameraFallbacksWrapper.hidden = true;
+          cameraFallbacksList.innerHTML = "";
+          return;
+        }
+
+        if (data.active_backend) {
+          const backendText = backendLabel(data.active_backend);
+          if (requested === "auto") {
+            if (data.active_backend === "synthetic") {
+              cameraStatusText.textContent =
+                "Auto mode is showing the synthetic test feed.";
+            } else {
+              cameraStatusText.textContent = `Auto mode selected the ${backendText}.`;
+            }
+          } else if (requested === "synthetic") {
+            cameraStatusText.textContent = "Synthetic test feed is in use.";
+          } else {
+            cameraStatusText.textContent = `Using the ${backendText}.`;
+          }
+        } else {
+          cameraStatusText.textContent = "Camera has not been initialised yet.";
+        }
+
+        const fallbacks = Array.isArray(data.fallbacks) ? data.fallbacks : [];
+        if (fallbacks.length > 0) {
+          cameraFallbacksWrapper.hidden = false;
+          cameraFallbacksList.innerHTML = "";
+          for (const reason of fallbacks) {
+            const item = document.createElement("li");
+            item.textContent = reason;
+            cameraFallbacksList.appendChild(item);
+          }
+        } else {
+          cameraFallbacksWrapper.hidden = true;
+          cameraFallbacksList.innerHTML = "";
+        }
+      }
+
       loadOrientation().catch((err) => {
         console.error(err);
         statusLabel.textContent = err.message;
+      });
+
+      loadCameraStatus().catch((err) => {
+        console.error(err);
+        cameraStatusText.textContent = err.message;
+        cameraFallbacksWrapper.hidden = true;
+        cameraFallbacksList.innerHTML = "";
       });
     </script>
   </body>

--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -43,6 +43,26 @@
         margin-top: 0;
         margin-bottom: 0.75rem;
       }
+      .camera-form {
+        margin-top: 1rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+      .camera-form label {
+        font-size: 0.95rem;
+      }
+      .camera-form select {
+        width: 100%;
+        max-width: 320px;
+      }
+      .camera-form button {
+        align-self: flex-start;
+      }
+      .form-status {
+        font-size: 0.9rem;
+        color: #8ab4ff;
+      }
       h1 {
         font-size: 1.4rem;
       }
@@ -113,6 +133,19 @@
           <p>Unavailable sources:</p>
           <ul id="camera-fallbacks" class="fallback-list"></ul>
         </div>
+        <form id="camera-form" class="camera-form">
+          <label for="camera-mode-select">
+            Camera mode
+            <select id="camera-mode-select" name="mode">
+              <option value="auto">Auto (prefer Picamera2)</option>
+              <option value="picamera2">Picamera2 only</option>
+              <option value="opencv">OpenCV (USB)</option>
+              <option value="synthetic">Synthetic test feed</option>
+            </select>
+          </label>
+          <button type="submit">Apply</button>
+          <div id="camera-form-status" class="form-status" hidden></div>
+        </form>
       </section>
       <section class="card">
         <h2>Camera Orientation</h2>
@@ -146,6 +179,9 @@
         "camera-fallbacks-wrapper"
       );
       const cameraFallbacksList = document.getElementById("camera-fallbacks");
+      const cameraForm = document.getElementById("camera-form");
+      const cameraSelect = document.getElementById("camera-mode-select");
+      const cameraFormStatus = document.getElementById("camera-form-status");
 
       async function loadOrientation() {
         const response = await fetch("/api/orientation");
@@ -205,14 +241,61 @@
         }
       }
 
-      async function loadCameraStatus() {
-        const response = await fetch("/api/camera");
-        if (!response.ok) {
-          throw new Error("Unable to fetch camera status");
+      function populateCameraModes(modes) {
+        if (!cameraSelect || !Array.isArray(modes)) {
+          return;
         }
-        const data = await response.json();
-        const requested = modeLabel(data.requested);
-        cameraModeLabel.textContent = requested;
+        const seen = new Set();
+        cameraSelect.innerHTML = "";
+        for (const mode of modes) {
+          const value = (mode || "").toLowerCase();
+          if (!value || seen.has(value)) {
+            continue;
+          }
+          const option = document.createElement("option");
+          option.value = value;
+          switch (value) {
+            case "auto":
+              option.textContent = "Auto (prefer Picamera2)";
+              break;
+            case "picamera2":
+              option.textContent = "Picamera2 only";
+              break;
+            case "opencv":
+              option.textContent = "OpenCV (USB)";
+              break;
+            case "synthetic":
+              option.textContent = "Synthetic test feed";
+              break;
+            default:
+              option.textContent = value;
+          }
+          cameraSelect.appendChild(option);
+          seen.add(value);
+        }
+      }
+
+      function applyCameraStatus(data) {
+        const configured = (data.mode || data.requested || "auto").toLowerCase();
+        const requested = (data.requested || configured || "auto").toLowerCase();
+        cameraModeLabel.textContent = modeLabel(configured);
+
+        if (cameraSelect) {
+          if (Array.isArray(data.modes)) {
+            populateCameraModes(data.modes);
+          }
+          if (
+            configured &&
+            cameraSelect.querySelector(`option[value="${configured}"]`)
+          ) {
+            cameraSelect.value = configured;
+          }
+        }
+
+        if (cameraFormStatus) {
+          cameraFormStatus.hidden = true;
+          cameraFormStatus.textContent = "";
+        }
 
         if (data.error) {
           cameraStatusText.textContent = `Camera unavailable: ${data.error}`;
@@ -254,6 +337,15 @@
         }
       }
 
+      async function loadCameraStatus() {
+        const response = await fetch("/api/camera");
+        if (!response.ok) {
+          throw new Error("Unable to fetch camera status");
+        }
+        const data = await response.json();
+        applyCameraStatus(data);
+      }
+
       loadOrientation().catch((err) => {
         console.error(err);
         statusLabel.textContent = err.message;
@@ -265,6 +357,55 @@
         cameraFallbacksWrapper.hidden = true;
         cameraFallbacksList.innerHTML = "";
       });
+
+      if (cameraForm) {
+        cameraForm.addEventListener("submit", async (event) => {
+          event.preventDefault();
+          if (!cameraSelect) {
+            return;
+          }
+          if (cameraFormStatus) {
+            cameraFormStatus.hidden = false;
+            cameraFormStatus.textContent = "Saving…";
+          }
+          const payload = {
+            mode: cameraSelect.value,
+          };
+          try {
+            const response = await fetch("/api/camera", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(payload),
+            });
+            if (!response.ok) {
+              let detail = "Unable to update camera";
+              try {
+                const error = await response.json();
+                detail = error.detail || detail;
+              } catch (jsonError) {
+                console.error(jsonError);
+              }
+              if (cameraFormStatus) {
+                cameraFormStatus.hidden = false;
+                cameraFormStatus.textContent = `Error: ${detail}`;
+              }
+              return;
+            }
+            const data = await response.json();
+            applyCameraStatus(data);
+            if (cameraFormStatus) {
+              cameraFormStatus.hidden = false;
+              cameraFormStatus.textContent = "Camera mode updated";
+            }
+          } catch (err) {
+            console.error(err);
+            if (cameraFormStatus) {
+              cameraFormStatus.hidden = false;
+              cameraFormStatus.textContent = err.message;
+            }
+          }
+        });
+      }
     </script>
   </body>
 </html>

--- a/src/rev_cam/video.py
+++ b/src/rev_cam/video.py
@@ -1,0 +1,107 @@
+"""Asynchronous video source management for the camera pipeline."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Optional
+
+import numpy as np
+
+from .camera import BaseCamera, CameraError
+from .pipeline import FramePipeline
+
+
+logger = logging.getLogger(__name__)
+
+
+class VideoSource:
+    """Continuously pulls frames from the active camera through the pipeline."""
+
+    def __init__(self, pipeline: FramePipeline, fps: int = 30) -> None:
+        self._pipeline = pipeline
+        self._frame_interval = 1.0 / fps
+        self._camera_lock = asyncio.Lock()
+        self._camera_ready = asyncio.Event()
+        self._frame_event = asyncio.Event()
+        self._shutdown_event = asyncio.Event()
+        self._frame: Optional[np.ndarray] = None
+        self._task: Optional[asyncio.Task[None]] = None
+        self._camera: Optional[BaseCamera] = None
+
+    async def start(self) -> None:
+        """Begin processing frames from the active camera."""
+
+        if self._task is not None:
+            return
+        self._shutdown_event.clear()
+        self._task = asyncio.create_task(self._run(), name="rev-cam-video-source")
+
+    async def stop(self) -> None:
+        """Stop processing and release any active camera."""
+
+        self._shutdown_event.set()
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+        await self.set_camera(None)
+        self._frame_event.set()
+
+    async def set_camera(self, camera: BaseCamera | None) -> None:
+        """Switch to a new camera, closing any previous instance."""
+
+        async with self._camera_lock:
+            previous = self._camera
+            self._camera = camera
+            if camera is None:
+                self._camera_ready.clear()
+            else:
+                self._camera_ready.set()
+
+        if previous is not None and previous is not camera:
+            try:
+                await previous.close()
+            except Exception as exc:  # pragma: no cover - best effort cleanup
+                logger.warning("Failed to close previous camera: %s", exc)
+
+    async def get_frame(self) -> np.ndarray:
+        """Return the most recent processed frame, waiting if necessary."""
+
+        while True:
+            await self._frame_event.wait()
+            self._frame_event.clear()
+            if self._frame is None:
+                if self._shutdown_event.is_set():
+                    raise CameraError("Video source has been stopped")
+                continue
+            return self._frame
+
+    async def _run(self) -> None:
+        try:
+            while not self._shutdown_event.is_set():
+                await self._camera_ready.wait()
+                async with self._camera_lock:
+                    camera = self._camera
+                if camera is None:
+                    await asyncio.sleep(self._frame_interval)
+                    continue
+                try:
+                    frame = await camera.get_frame()
+                except Exception as exc:  # pragma: no cover - hardware dependent
+                    logger.error("Failed to read frame from camera: %s", exc)
+                    await asyncio.sleep(self._frame_interval)
+                    continue
+                processed = self._pipeline.process(frame)
+                self._frame = processed
+                self._frame_event.set()
+                await asyncio.sleep(self._frame_interval)
+        except asyncio.CancelledError:  # pragma: no cover - task shutdown
+            pass
+        finally:
+            self._frame_event.set()
+
+
+__all__ = ["VideoSource"]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,48 @@
+"""Tests for application startup behaviour."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from fastapi import HTTPException
+
+from rev_cam import app as app_module
+from rev_cam.camera import CameraError
+
+
+def test_app_startup_survives_camera_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The API should start even when the camera fails to initialise."""
+
+    def raise_camera_error() -> None:
+        raise CameraError("camera failed to initialise")
+
+    monkeypatch.setattr(app_module, "create_camera", raise_camera_error)
+
+    application = app_module.create_app()
+
+    loop = asyncio.new_event_loop()
+    try:
+        asyncio.set_event_loop(loop)
+
+        for handler in application.router.on_startup:
+            loop.run_until_complete(handler())
+
+        assert application.state.camera is None
+        assert isinstance(application.state.camera_error, CameraError)
+
+        offer_route = next(route for route in application.router.routes if getattr(route, "path", None) == "/api/offer")
+
+        with pytest.raises(HTTPException) as excinfo:
+            loop.run_until_complete(offer_route.endpoint(app_module.OfferPayload(sdp="", type="offer")))
+
+        assert excinfo.value.status_code == 503
+        assert "camera failed to initialise" in excinfo.value.detail
+
+        for handler in application.router.on_shutdown:
+            loop.run_until_complete(handler())
+    finally:
+        asyncio.set_event_loop(None)
+        loop.close()
+

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -9,7 +9,15 @@ import pytest
 from fastapi import HTTPException
 
 from rev_cam import app as app_module
+from rev_cam import camera as camera_module
 from rev_cam.camera import CameraError
+
+
+@pytest.fixture(autouse=True)
+def reset_camera_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure camera selection cache does not leak between tests."""
+
+    monkeypatch.setattr(camera_module, "_LAST_SELECTION", None)
 
 
 def test_app_startup_survives_camera_error(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -31,6 +39,10 @@ def test_app_startup_survives_camera_error(monkeypatch: pytest.MonkeyPatch) -> N
 
         assert application.state.camera is None
         assert isinstance(application.state.camera_error, CameraError)
+        status = application.state.camera_status
+        assert status is not None
+        assert status["error"] == "camera failed to initialise"
+        assert status["requested"] == "auto"
 
         offer_route = next(route for route in application.router.routes if getattr(route, "path", None) == "/api/offer")
 
@@ -39,6 +51,55 @@ def test_app_startup_survives_camera_error(monkeypatch: pytest.MonkeyPatch) -> N
 
         assert excinfo.value.status_code == 503
         assert "camera failed to initialise" in excinfo.value.detail
+
+        camera_route = next(route for route in application.router.routes if getattr(route, "path", None) == "/api/camera")
+        camera_payload = loop.run_until_complete(camera_route.endpoint())
+        assert camera_payload["error"] == "camera failed to initialise"
+        assert camera_payload["requested"] == "auto"
+        assert camera_payload["active_backend"] is None
+
+        for handler in application.router.on_shutdown:
+            loop.run_until_complete(handler())
+    finally:
+        asyncio.set_event_loop(None)
+        loop.close()
+
+
+def test_camera_status_endpoint_reports_fallbacks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Expose the fallback chain when the synthetic feed is in use."""
+
+    def broken_picamera() -> None:
+        raise CameraError("picamera offline")
+
+    def broken_opencv(*_: object, **__: object) -> None:
+        raise CameraError("opencv offline")
+
+    monkeypatch.setattr(camera_module, "Picamera2Camera", broken_picamera)
+    monkeypatch.setattr(camera_module, "OpenCVCamera", broken_opencv)
+    monkeypatch.delenv("REVCAM_CAMERA", raising=False)
+
+    application = app_module.create_app()
+
+    loop = asyncio.new_event_loop()
+    try:
+        asyncio.set_event_loop(loop)
+
+        for handler in application.router.on_startup:
+            loop.run_until_complete(handler())
+
+        status = application.state.camera_status
+        assert status is not None
+        assert status["requested"] == "auto"
+        assert status["active_backend"] == "synthetic"
+        assert status["error"] is None
+        assert status["fallbacks"] == [
+            "Picamera2: picamera offline",
+            "OpenCV: opencv offline",
+        ]
+
+        camera_route = next(route for route in application.router.routes if getattr(route, "path", None) == "/api/camera")
+        payload = loop.run_until_complete(camera_route.endpoint())
+        assert payload == status
 
         for handler in application.router.on_shutdown:
             loop.run_until_complete(handler())

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 
+import numpy as np
 import pytest
 
 from fastapi import HTTPException
 
 from rev_cam import app as app_module
 from rev_cam import camera as camera_module
-from rev_cam.camera import CameraError
+from rev_cam.camera import CameraError, CameraSelection
 
 
 @pytest.fixture(autouse=True)
@@ -20,15 +22,26 @@ def reset_camera_status(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(camera_module, "_LAST_SELECTION", None)
 
 
-def test_app_startup_survives_camera_error(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_app_startup_survives_camera_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     """The API should start even when the camera fails to initialise."""
 
-    def raise_camera_error() -> None:
-        raise CameraError("camera failed to initialise")
+    error = CameraError("camera failed to initialise")
 
-    monkeypatch.setattr(app_module, "create_camera", raise_camera_error)
+    def fake_select(choice: str | None = None) -> CameraSelection:
+        requested = (choice or "auto").strip().lower() or "auto"
+        return CameraSelection(
+            requested=requested,
+            active_backend=None,
+            camera=None,
+            fallbacks=[],
+            error=error,
+        )
 
-    application = app_module.create_app()
+    monkeypatch.setattr(app_module, "select_camera", fake_select)
+
+    application = app_module.create_app(tmp_path / "config.json")
 
     loop = asyncio.new_event_loop()
     try:
@@ -44,7 +57,11 @@ def test_app_startup_survives_camera_error(monkeypatch: pytest.MonkeyPatch) -> N
         assert status["error"] == "camera failed to initialise"
         assert status["requested"] == "auto"
 
-        offer_route = next(route for route in application.router.routes if getattr(route, "path", None) == "/api/offer")
+        offer_route = next(
+            route
+            for route in application.router.routes
+            if getattr(route, "path", None) == "/api/offer"
+        )
 
         with pytest.raises(HTTPException) as excinfo:
             loop.run_until_complete(offer_route.endpoint(app_module.OfferPayload(sdp="", type="offer")))
@@ -52,11 +69,17 @@ def test_app_startup_survives_camera_error(monkeypatch: pytest.MonkeyPatch) -> N
         assert excinfo.value.status_code == 503
         assert "camera failed to initialise" in excinfo.value.detail
 
-        camera_route = next(route for route in application.router.routes if getattr(route, "path", None) == "/api/camera")
+        camera_route = next(
+            route
+            for route in application.router.routes
+            if getattr(route, "path", None) == "/api/camera" and "GET" in getattr(route, "methods", set())
+        )
         camera_payload = loop.run_until_complete(camera_route.endpoint())
         assert camera_payload["error"] == "camera failed to initialise"
         assert camera_payload["requested"] == "auto"
         assert camera_payload["active_backend"] is None
+        assert "modes" in camera_payload
+        assert camera_payload["mode"] == "auto"
 
         for handler in application.router.on_shutdown:
             loop.run_until_complete(handler())
@@ -65,7 +88,9 @@ def test_app_startup_survives_camera_error(monkeypatch: pytest.MonkeyPatch) -> N
         loop.close()
 
 
-def test_camera_status_endpoint_reports_fallbacks(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_camera_status_endpoint_reports_fallbacks(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     """Expose the fallback chain when the synthetic feed is in use."""
 
     def broken_picamera() -> None:
@@ -78,7 +103,7 @@ def test_camera_status_endpoint_reports_fallbacks(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setattr(camera_module, "OpenCVCamera", broken_opencv)
     monkeypatch.delenv("REVCAM_CAMERA", raising=False)
 
-    application = app_module.create_app()
+    application = app_module.create_app(tmp_path / "config.json")
 
     loop = asyncio.new_event_loop()
     try:
@@ -97,9 +122,119 @@ def test_camera_status_endpoint_reports_fallbacks(monkeypatch: pytest.MonkeyPatc
             "OpenCV: opencv offline",
         ]
 
-        camera_route = next(route for route in application.router.routes if getattr(route, "path", None) == "/api/camera")
+        camera_route = next(
+            route
+            for route in application.router.routes
+            if getattr(route, "path", None) == "/api/camera" and "GET" in getattr(route, "methods", set())
+        )
         payload = loop.run_until_complete(camera_route.endpoint())
-        assert payload == status
+        expected = {
+            **status,
+            "modes": app_module.get_available_camera_modes(),
+            "mode": "auto",
+        }
+        assert payload == expected
+
+        for handler in application.router.on_shutdown:
+            loop.run_until_complete(handler())
+    finally:
+        asyncio.set_event_loop(None)
+        loop.close()
+
+
+def test_camera_update_endpoint_switches_mode(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """POST /api/camera should reconfigure the backend when requested."""
+
+    class DummyCamera:
+        def __init__(self, name: str) -> None:
+            self.name = name
+            self.closed = False
+
+        async def get_frame(self) -> np.ndarray:
+            return np.zeros((1, 1, 3), dtype=np.uint8)
+
+        async def close(self) -> None:
+            self.closed = True
+
+    def fake_select(choice: str | None = None) -> CameraSelection:
+        requested = (choice or "auto").strip().lower() or "auto"
+        if requested == "synthetic":
+            camera = DummyCamera("synthetic")
+            return camera_module._remember_selection(
+                CameraSelection(
+                    requested=requested,
+                    active_backend="synthetic",
+                    camera=camera,
+                    fallbacks=[],
+                    error=None,
+                )
+            )
+        if requested == "opencv":
+            camera = DummyCamera("opencv")
+            return camera_module._remember_selection(
+                CameraSelection(
+                    requested=requested,
+                    active_backend="opencv",
+                    camera=camera,
+                    fallbacks=[],
+                    error=None,
+                )
+            )
+        return camera_module._remember_selection(
+            CameraSelection(
+                requested=requested,
+                active_backend=None,
+                camera=None,
+                fallbacks=[],
+                error=CameraError(f"Unsupported mode: {requested}"),
+            )
+        )
+
+    monkeypatch.setattr(app_module, "select_camera", fake_select)
+
+    application = app_module.create_app(tmp_path / "config.json")
+
+    loop = asyncio.new_event_loop()
+    try:
+        asyncio.set_event_loop(loop)
+
+        for handler in application.router.on_startup:
+            loop.run_until_complete(handler())
+
+        camera_update_route = next(
+            route
+            for route in application.router.routes
+            if getattr(route, "path", None) == "/api/camera" and "POST" in getattr(route, "methods", set())
+        )
+
+        # Switch to OpenCV mode successfully.
+        payload = loop.run_until_complete(
+            camera_update_route.endpoint(
+                app_module.CameraUpdatePayload(mode="opencv")
+            )
+        )
+        assert payload["active_backend"] == "opencv"
+        assert payload["mode"] == "opencv"
+
+        # Requesting an unknown mode should raise a validation error.
+        with pytest.raises(HTTPException) as excinfo:
+            loop.run_until_complete(
+                camera_update_route.endpoint(
+                    app_module.CameraUpdatePayload(mode="unknown")
+                )
+            )
+        assert excinfo.value.status_code == 400
+
+        # Requesting a failing mode should surface as a 503.
+        with pytest.raises(HTTPException) as excinfo:
+            loop.run_until_complete(
+                camera_update_route.endpoint(
+                    app_module.CameraUpdatePayload(mode="auto")
+                )
+            )
+        assert excinfo.value.status_code == 503
 
         for handler in application.router.on_shutdown:
             loop.run_until_complete(handler())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,26 +1,40 @@
+import json
 from pathlib import Path
-
-import pytest
 
 from rev_cam.config import ConfigManager, Orientation
 
 
-def test_default_orientation(tmp_path: Path):
-    manager = ConfigManager(tmp_path / "config.json")
+def test_config_manager_defaults(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    manager = ConfigManager(config_path)
     assert manager.get_orientation() == Orientation()
+    assert manager.get_camera_mode() == "auto"
 
 
-def test_set_orientation_persists(tmp_path: Path):
-    config_file = tmp_path / "config.json"
-    manager = ConfigManager(config_file)
-    updated = manager.set_orientation({"rotation": 90, "flip_horizontal": True, "flip_vertical": False})
-    assert updated.rotation == 90
-    # Reload to ensure persistence
-    reloaded = ConfigManager(config_file)
-    assert reloaded.get_orientation() == updated
+def test_config_manager_persists_camera_mode(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    manager = ConfigManager(config_path)
+
+    mode = manager.set_camera_mode("Picamera2")
+    assert mode == "picamera2"
+    assert manager.get_camera_mode() == "picamera2"
+
+    payload = json.loads(config_path.read_text())
+    assert payload["camera"]["mode"] == "picamera2"
+
+    manager.set_orientation({"rotation": 90, "flip_horizontal": True})
+    stored = json.loads(config_path.read_text())
+    assert stored["orientation"]["rotation"] == 90
+    assert stored["orientation"]["flip_horizontal"] is True
 
 
-def test_invalid_orientation_rejected(tmp_path: Path):
-    manager = ConfigManager(tmp_path / "config.json")
-    with pytest.raises(ValueError):
-        manager.set_orientation({"rotation": 45})
+def test_config_manager_loads_legacy_format(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"rotation": 180, "flip_vertical": True}))
+
+    manager = ConfigManager(config_path)
+    orientation = manager.get_orientation()
+
+    assert orientation.rotation == 180
+    assert orientation.flip_vertical is True
+    assert manager.get_camera_mode() == "auto"

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -1,0 +1,38 @@
+import asyncio
+
+import numpy as np
+import pytest
+
+from rev_cam.config import Orientation
+from rev_cam.pipeline import FramePipeline
+from rev_cam.video import VideoSource
+
+
+class DummyCamera:
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def get_frame(self) -> np.ndarray:
+        return np.ones((2, 2, 3), dtype=np.uint8)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def test_video_source_emits_frames() -> None:
+    async def runner() -> None:
+        pipeline = FramePipeline(lambda: Orientation())
+        source = VideoSource(pipeline, fps=5)
+
+        await source.start()
+        camera = DummyCamera()
+        await source.set_camera(camera)
+
+        frame = await asyncio.wait_for(source.get_frame(), timeout=1)
+        assert frame.shape == (2, 2, 3)
+        assert np.array_equal(frame, np.ones((2, 2, 3), dtype=np.uint8))
+
+        await source.stop()
+        assert camera.closed is True
+
+    asyncio.run(runner())


### PR DESCRIPTION
## Summary
- normalise camera backend selection and introduce an auto mode that prefers Picamera2, then OpenCV before falling back to the synthetic feed
- raise a CameraError for unknown REVCAM_CAMERA values instead of silently choosing the test pattern
- expand camera selection tests to cover the new OpenCV fallback and invalid configuration handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cc466ea4a08332b49408e6f0653593