### PR TITLE
Add configurable camera source with settings UI

### DIFF
--- a/PRReadme.txt
+++ b/PRReadme.txt
@@ -1,0 +1,103 @@
+PR Installation Guide
+======================
+
+This document provides a copy-paste friendly checklist for installing and running
+this pull request build of RevCam on a Raspberry Pi running Raspberry Pi OS
+(Bookworm). Follow the steps in order to ensure Picamera2, aiortc, and other
+native dependencies are available to the application.
+
+Prerequisites
+-------------
+* Raspberry Pi OS (Bookworm) with camera firmware enabled via `raspi-config`.
+* Internet connectivity (APT + GitHub + PiWheels).
+* Python 3.11 (the default on Raspberry Pi OS Bookworm).
+
+1. Update the base system and install Raspberry Pi camera packages
+-----------------------------------------------------------------
+```bash
+sudo apt update
+sudo apt install -y \
+  git python3 python3-venv python3-pip \
+  python3-picamera2 python3-prctl \
+  libatlas-base-dev libavformat-dev libavcodec-dev libavdevice-dev \
+  libavutil-dev libswscale-dev libswresample-dev libopus-dev libvpx-dev \
+  libsrtp2-dev pkg-config
+```
+These packages provide the official Picamera2 stack and the headers/libraries
+required to compile `aiortc`, `pylibsrtp`, and `av` when PiWheels does not offer
+compatible wheels.
+
+2. Clone (or update) the RevCam repository
+-----------------------------------------
+```bash
+REVCAM_REPO="https://github.com/soler2000/RevCam.git"
+REVCAM_REF="pull/<PR_NUMBER>/head"  # replace <PR_NUMBER> with the PR you want to test
+
+if [ ! -d RevCam ]; then
+  git clone "$REVCAM_REPO" RevCam
+fi
+
+cd RevCam
+
+git fetch "$REVCAM_REPO" "$REVCAM_REF"
+git checkout FETCH_HEAD
+```
+Replace `REVCAM_REF` with the branch or PR ref you want to test (for example,
+`pull/123/head`).
+
+3. Create a virtual environment with system Picamera2 access
+-----------------------------------------------------------
+```bash
+python3 -m venv --system-site-packages .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+```
+The `--system-site-packages` flag exposes the APT-installed Picamera2 modules to
+the virtual environment so RevCam can import them without rebuilding.
+
+4. Install RevCam and Python dependencies (including aiortc)
+-----------------------------------------------------------
+```bash
+pip install --prefer-binary --extra-index-url https://www.piwheels.org/simple -e .
+```
+The PiWheels index provides pre-built ARM wheels for heavy packages such as
+`aiortc`. When a wheel is not available, the system libraries installed in step
+1 allow `pip` to build the modules locally.
+
+5. Verify camera availability before launching
+----------------------------------------------
+Busy cameras (often caused by the legacy MMAL stack) will prevent Picamera2 from
+starting. Run the diagnostics helper to confirm the device is free:
+```bash
+python -m rev_cam.diagnostics
+```
+If the output lists `kworker/R-mmal-vchiq` threads or other processes, disable
+the legacy camera interface using `sudo raspi-config` → Interface Options →
+Legacy Camera (set to *Disabled*), remove `start_x=1` from `/boot/config.txt`,
+and reboot. Stop any conflicting services (for example, `libcamera-vid` or
+`libcamera-still`) before launching RevCam.
+
+6. Launch the RevCam server
+---------------------------
+```bash
+uvicorn rev_cam.app:create_app --factory --host 0.0.0.0 --port 9000
+```
+Open `http://<pi-ip>:9000` in your browser. The settings page exposes a camera
+source dropdown—select *PiCamera2* to use the hardware camera once diagnostics
+report it as available.
+
+7. Optional: enable the service on boot
+--------------------------------------
+Follow the instructions in `README.md` to create a systemd service or use a
+process manager of your choice. Ensure the service activates the virtual
+environment before launching `uvicorn`.
+
+Troubleshooting
+---------------
+* **`ModuleNotFoundError: picamera2`** – confirm steps 1 and 3 were executed so
+  the virtual environment can see the system Picamera2 packages.
+* **Busy camera errors** – re-run `python -m rev_cam.diagnostics` to identify
+  lingering processes. Disable the legacy camera interface and reboot if
+  `kworker/R-mmal-vchiq` threads are reported.
+* **`aiortc` missing** – re-run step 4. If compilation fails, verify the APT
+  packages listed in step 1 are installed.

--- a/PRReadme.txt
+++ b/PRReadme.txt
@@ -25,7 +25,8 @@ sudo apt install -y \
 ```
 These packages provide the official Picamera2 stack and the headers/libraries
 required to compile `aiortc`, `pylibsrtp`, and `av` when PiWheels does not offer
-compatible wheels.
+compatible wheels. The same set is available through `./scripts/install_prereqs.sh`
+if you prefer a reusable helper.
 
 2. Clone (or update) the RevCam repository
 -----------------------------------------

--- a/README.md
+++ b/README.md
@@ -267,6 +267,13 @@ mentions kernel threads named `kworker/R-mmal-vchiq`, the legacy camera
 interface is enabled. Disable it via `sudo raspi-config` (Interface Options →
 Legacy Camera) or remove `start_x=1` from `/boot/config.txt`, then reboot.
 
+Need a quick status report? Run the diagnostics helper to print detected
+services and processes:
+
+```bash
+python -m rev_cam.diagnostics
+```
+
 #### Uvicorn reports "address already in use"
 
 Another RevCam instance is already bound to the requested port. Stop the

--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ building everything from PyPI. Follow these steps on the Pi:
    sudo apt install python3-picamera2 python3-prctl
    ```
 
+   Prefer a single command? Run the bundled helper, which also installs
+   build prerequisites for `aiortc` and other native wheels:
+
+   ```bash
+   ./scripts/install_prereqs.sh
+   ```
+
 2. Create a virtual environment that can see the system packages you just
    installed (this prevents `pip` from trying to rebuild Picamera2 and PiDNG):
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rev-cam"
-version = "0.1.2"
+version = "0.1.3"
 description = "Low-latency Raspberry Pi reversing camera WebRTC server"
 readme = "README.md"
 authors = [{name = "RevCam Team"}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rev-cam"
-version = "0.1.3"
+version = "0.1.4"
 description = "Low-latency Raspberry Pi reversing camera WebRTC server"
 readme = "README.md"
 authors = [{name = "RevCam Team"}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rev-cam"
-version = "0.1.1"
+version = "0.1.2"
 description = "Low-latency Raspberry Pi reversing camera WebRTC server"
 readme = "README.md"
 authors = [{name = "RevCam Team"}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rev-cam"
-version = "0.1.4"
+version = "0.1.5"
 description = "Low-latency Raspberry Pi reversing camera WebRTC server"
 readme = "README.md"
 authors = [{name = "RevCam Team"}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rev-cam"
-version = "0.1.0"
+version = "0.1.1"
 description = "Low-latency Raspberry Pi reversing camera WebRTC server"
 readme = "README.md"
 authors = [{name = "RevCam Team"}]

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage: scripts/install_prereqs.sh [options]
+
+Install Raspberry Pi OS packages required for RevCam.
+
+Options:
+  --no-update   Skip running "apt update" before installing packages.
+  -h, --help    Show this help message and exit.
+USAGE
+}
+
+RUN_UPDATE=true
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --no-update)
+            RUN_UPDATE=false
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if ! command -v apt >/dev/null 2>&1; then
+    echo "This script requires apt (Raspberry Pi OS / Debian-based systems)." >&2
+    exit 1
+fi
+
+if [[ $EUID -ne 0 ]]; then
+    SUDO="sudo"
+else
+    SUDO=""
+fi
+
+packages=(
+    git
+    python3
+    python3-venv
+    python3-pip
+    python3-picamera2
+    python3-prctl
+    libatlas-base-dev
+    libavcodec-dev
+    libavdevice-dev
+    libavformat-dev
+    libavutil-dev
+    libswresample-dev
+    libswscale-dev
+    libopus-dev
+    libvpx-dev
+    libsrtp2-dev
+    pkg-config
+)
+
+if [[ "$RUN_UPDATE" == true ]]; then
+    echo "Updating package lists..."
+    $SUDO apt update
+fi
+
+echo "Installing prerequisites: ${packages[*]}"
+$SUDO apt install -y "${packages[@]}"
+
+echo "Prerequisite installation complete."

--- a/src/rev_cam/__init__.py
+++ b/src/rev_cam/__init__.py
@@ -2,6 +2,8 @@
 
 from typing import Any
 
+from .version import APP_VERSION
+
 
 def create_app(*args: Any, **kwargs: Any):
     from .app import create_app as _create_app
@@ -9,4 +11,4 @@ def create_app(*args: Any, **kwargs: Any):
     return _create_app(*args, **kwargs)
 
 
-__all__ = ["create_app"]
+__all__ = ["create_app", "APP_VERSION"]

--- a/src/rev_cam/app.py
+++ b/src/rev_cam/app.py
@@ -13,6 +13,7 @@ from .camera import CAMERA_SOURCES, BaseCamera, CameraError, create_camera, iden
 from .config import ConfigManager
 from .pipeline import FramePipeline
 from .webrtc import WebRTCManager
+from .version import APP_VERSION
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
     from aiortc import RTCSessionDescription
@@ -43,7 +44,7 @@ class CameraPayload(BaseModel):
 
 
 def create_app(config_path: Path | str = Path("data/config.json")) -> FastAPI:
-    app = FastAPI(title="RevCam", version="0.1.0")
+    app = FastAPI(title="RevCam", version=APP_VERSION)
 
     config_manager = ConfigManager(Path(config_path))
     pipeline = FramePipeline(lambda: config_manager.get_orientation())
@@ -146,6 +147,7 @@ def create_app(config_path: Path | str = Path("data/config.json")) -> FastAPI:
             "active": active_camera_choice,
             "options": options,
             "errors": errors,
+            "version": APP_VERSION,
         }
 
     @app.post("/api/camera")
@@ -173,7 +175,7 @@ def create_app(config_path: Path | str = Path("data/config.json")) -> FastAPI:
             webrtc_manager.camera = camera
         if old_camera is not None:
             await old_camera.close()
-        return {"selected": selection, "active": active_camera_choice}
+        return {"selected": selection, "active": active_camera_choice, "version": APP_VERSION}
 
     @app.post("/api/offer")
     async def webrtc_offer(payload: OfferPayload) -> dict[str, str]:

--- a/src/rev_cam/app.py
+++ b/src/rev_cam/app.py
@@ -9,7 +9,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
 
-from .camera import BaseCamera, create_camera
+from .camera import CAMERA_SOURCES, BaseCamera, CameraError, create_camera, identify_camera
 from .config import ConfigManager
 from .pipeline import FramePipeline
 from .webrtc import WebRTCManager
@@ -38,6 +38,10 @@ class OrientationPayload(BaseModel):
     flip_vertical: bool = False
 
 
+class CameraPayload(BaseModel):
+    source: str
+
+
 def create_app(config_path: Path | str = Path("data/config.json")) -> FastAPI:
     app = FastAPI(title="RevCam", version="0.1.0")
 
@@ -45,12 +49,23 @@ def create_app(config_path: Path | str = Path("data/config.json")) -> FastAPI:
     pipeline = FramePipeline(lambda: config_manager.get_orientation())
     camera: BaseCamera | None = None
     webrtc_manager: WebRTCManager | None = None
+    active_camera_choice: str = "unknown"
     logger = logging.getLogger(__name__)
 
     @app.on_event("startup")
     async def startup() -> None:  # pragma: no cover - framework hook
-        nonlocal camera, webrtc_manager
-        camera = create_camera()
+        nonlocal camera, webrtc_manager, active_camera_choice
+        selection = config_manager.get_camera()
+        try:
+            camera = create_camera(selection)
+        except CameraError as exc:
+            logger.warning("Failed to initialise camera '%s': %s", selection, exc)
+            try:
+                camera = create_camera("synthetic")
+            except CameraError as fallback_exc:  # pragma: no cover - synthetic should always succeed
+                logger.error("Synthetic camera initialisation failed: %s", fallback_exc)
+                raise
+        active_camera_choice = identify_camera(camera)
         try:
             webrtc_manager = WebRTCManager(camera=camera, pipeline=pipeline)
         except RuntimeError as exc:
@@ -92,6 +107,41 @@ def create_app(config_path: Path | str = Path("data/config.json")) -> FastAPI:
             "flip_horizontal": orientation.flip_horizontal,
             "flip_vertical": orientation.flip_vertical,
         }
+
+    @app.get("/api/camera")
+    async def get_camera_config() -> dict[str, object]:
+        options = [{"value": value, "label": label} for value, label in CAMERA_SOURCES.items()]
+        return {
+            "selected": config_manager.get_camera(),
+            "active": active_camera_choice,
+            "options": options,
+        }
+
+    @app.post("/api/camera")
+    async def update_camera(payload: CameraPayload) -> dict[str, object]:
+        nonlocal camera, webrtc_manager, active_camera_choice
+        selection = payload.source.strip().lower()
+        if selection not in CAMERA_SOURCES:
+            raise HTTPException(status_code=400, detail="Unknown camera source")
+        try:
+            new_camera = create_camera(selection)
+        except CameraError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        old_camera = camera
+        camera = new_camera
+        active_camera_choice = identify_camera(new_camera)
+        config_manager.set_camera(selection)
+        if webrtc_manager is None:
+            try:
+                webrtc_manager = WebRTCManager(camera=camera, pipeline=pipeline)
+            except RuntimeError as exc:
+                logger.warning("WebRTC disabled: %s", exc)
+                webrtc_manager = None
+        else:
+            webrtc_manager.camera = camera
+        if old_camera is not None:
+            await old_camera.close()
+        return {"selected": selection, "active": active_camera_choice}
 
     @app.post("/api/offer")
     async def webrtc_offer(payload: OfferPayload) -> dict[str, str]:

--- a/src/rev_cam/camera.py
+++ b/src/rev_cam/camera.py
@@ -228,6 +228,11 @@ def _detect_camera_conflicts() -> list[str]:
         hints.append(
             f"Processes currently using the camera: {formatted}. Stop these processes to free the device."
         )
+        lower_processes = [process.lower() for process in processes]
+        if any("kworker" in text and "mmal" in text for text in lower_processes):
+            hints.append(
+                "Kernel threads named kworker/R-mmal-vchiq indicate the legacy camera interface is still enabled. Disable the legacy camera (e.g. via `sudo raspi-config` -> Interface Options -> Legacy Camera, or remove `start_x=1` from `/boot/config.txt`) and reboot to free the device."
+            )
     return hints
 
 

--- a/src/rev_cam/camera.py
+++ b/src/rev_cam/camera.py
@@ -48,7 +48,11 @@ class Picamera2Camera(BaseCamera):
         try:
             from picamera2 import Picamera2
         except ImportError as exc:  # pragma: no cover - hardware dependent
-            raise CameraError("picamera2 is not available") from exc
+            message = "picamera2 is not available"
+            detail = str(exc).strip()
+            if detail:
+                message = f"{message}: {detail}"
+            raise CameraError(message) from exc
 
         self._camera = None
         started = False
@@ -71,7 +75,11 @@ class Picamera2Camera(BaseCamera):
                     camera.close()
                 except Exception:
                     pass
-            raise CameraError("Failed to initialise Picamera2 camera") from exc
+            detail = str(exc).strip()
+            message = "Failed to initialise Picamera2 camera"
+            if detail:
+                message = f"{message}: {detail}"
+            raise CameraError(message) from exc
 
     async def get_frame(self) -> np.ndarray:  # pragma: no cover - hardware dependent
         return await asyncio.to_thread(self._camera.capture_array)

--- a/src/rev_cam/camera.py
+++ b/src/rev_cam/camera.py
@@ -101,8 +101,16 @@ class Picamera2Camera(BaseCamera):
                     pass
             detail = _summarise_exception(exc)
             message = "Failed to initialise Picamera2 camera"
+            hints: list[str] = []
             if detail:
+                lower_detail = detail.lower()
+                if "device or resource busy" in lower_detail:
+                    hints.append(
+                        "Another process is using the camera. Close libcamera-* applications or stop conflicting services (e.g. `sudo systemctl stop libcamera-apps`)."
+                    )
                 message = f"{message}: {detail}"
+            if hints:
+                message = f"{message}. {' '.join(hints)}"
             raise CameraError(message) from exc
 
     async def get_frame(self) -> np.ndarray:  # pragma: no cover - hardware dependent

--- a/src/rev_cam/camera.py
+++ b/src/rev_cam/camera.py
@@ -65,11 +65,26 @@ def _summarise_exception(exc: BaseException) -> str:
     return " | ".join(details)
 
 
+class _NullSync:
+    """Context manager used by :class:`_NullAllocator`."""
+
+    def __enter__(self) -> "_NullSync":  # pragma: no cover - defensive shim
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: object | None,
+    ) -> bool:  # pragma: no cover - defensive shim
+        return False
+
+
 class _NullAllocator:
     """Fallback allocator used when Picamera2 initialisation fails early."""
 
-    def sync(self, *args: object, **kwargs: object) -> None:  # pragma: no cover - defensive shim
-        return None
+    def sync(self, *args: object, **kwargs: object) -> _NullSync:  # pragma: no cover - defensive shim
+        return _NullSync()
 
     def acquire(self, *args: object, **kwargs: object) -> None:  # pragma: no cover - defensive shim
         return None

--- a/src/rev_cam/camera.py
+++ b/src/rev_cam/camera.py
@@ -62,6 +62,13 @@ def _summarise_exception(exc: BaseException) -> str:
     return " | ".join(details)
 
 
+class _NullAllocator:
+    """Fallback allocator used when Picamera2 initialisation fails early."""
+
+    def sync(self, *args: object, **kwargs: object) -> None:  # pragma: no cover - defensive shim
+        return None
+
+
 class Picamera2Camera(BaseCamera):
     """Camera implementation using the Picamera2 stack."""
 
@@ -96,6 +103,8 @@ class Picamera2Camera(BaseCamera):
                 except Exception:
                     pass
                 try:
+                    if not hasattr(camera, "allocator"):
+                        setattr(camera, "allocator", _NullAllocator())
                     camera.close()
                 except Exception:
                     pass

--- a/src/rev_cam/camera.py
+++ b/src/rev_cam/camera.py
@@ -71,6 +71,19 @@ class _NullAllocator:
     def sync(self, *args: object, **kwargs: object) -> None:  # pragma: no cover - defensive shim
         return None
 
+    def acquire(self, *args: object, **kwargs: object) -> None:  # pragma: no cover - defensive shim
+        return None
+
+    def release(self, *args: object, **kwargs: object) -> None:  # pragma: no cover - defensive shim
+        return None
+
+    def __getattr__(self, name: str):  # pragma: no cover - defensive shim
+        def _noop(*args: object, **kwargs: object) -> None:
+            logger.debug("_NullAllocator ignoring %s call", name)
+            return None
+
+        return _noop
+
 
 _NULL_ALLOCATOR = _NullAllocator()
 

--- a/src/rev_cam/camera.py
+++ b/src/rev_cam/camera.py
@@ -213,7 +213,7 @@ def _list_camera_processes() -> list[str]:
     return matches
 
 
-def _detect_camera_conflicts() -> list[str]:
+def _collect_camera_conflicts() -> list[str]:
     """Return human-readable hints about known camera conflicts."""
 
     hints: list[str] = []
@@ -234,6 +234,12 @@ def _detect_camera_conflicts() -> list[str]:
                 "Kernel threads named kworker/R-mmal-vchiq indicate the legacy camera interface is still enabled. Disable the legacy camera (e.g. via `sudo raspi-config` -> Interface Options -> Legacy Camera, or remove `start_x=1` from `/boot/config.txt`) and reboot to free the device."
             )
     return hints
+
+
+def diagnose_camera_conflicts() -> list[str]:
+    """Public helper used by diagnostics tooling to surface camera conflicts."""
+
+    return _collect_camera_conflicts()
 
 
 class Picamera2Camera(BaseCamera):
@@ -302,7 +308,7 @@ class Picamera2Camera(BaseCamera):
                     hints.append(
                         "Another process is using the camera. Close libcamera-* applications or stop conflicting services (e.g. `sudo systemctl stop libcamera-apps`)."
                     )
-                    hints.extend(_detect_camera_conflicts())
+                    hints.extend(_collect_camera_conflicts())
                 message = f"{message}: {detail}"
             if hints:
                 message = f"{message}. {' '.join(hints)}"
@@ -415,6 +421,7 @@ __all__ = [
     "BaseCamera",
     "CameraError",
     "identify_camera",
+    "diagnose_camera_conflicts",
     "Picamera2Camera",
     "OpenCVCamera",
     "SyntheticCamera",

--- a/src/rev_cam/camera.py
+++ b/src/rev_cam/camera.py
@@ -246,7 +246,9 @@ class Picamera2Camera(BaseCamera):
             detail = _summarise_exception(exc)
             message = (
                 "picamera2 is not available. Install the 'python3-picamera2' package "
-                "and ensure the application can access system packages"
+                "and ensure the application can access system packages (for example "
+                "recreate the virtual environment with `python3 -m venv --system-"
+                "site-packages .venv` or run `./scripts/install.sh --pi`)."
             )
             if detail:
                 message = f"{message} ({detail})"

--- a/src/rev_cam/config.py
+++ b/src/rev_cam/config.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from threading import Lock
 from typing import Any, Dict, Mapping
 
+from .camera import CAMERA_SOURCES, DEFAULT_CAMERA_CHOICE
+
 
 @dataclass(frozen=True, slots=True)
 class Orientation:
@@ -45,36 +47,66 @@ class ConfigManager:
         self._path = config_path
         self._lock = Lock()
         self._ensure_parent()
-        self._data: Orientation = self._load()
+        self._orientation, self._camera = self._load()
 
     def _ensure_parent(self) -> None:
         self._path.parent.mkdir(parents=True, exist_ok=True)
 
-    def _load(self) -> Orientation:
+    def _load(self) -> tuple[Orientation, str]:
         if not self._path.exists():
-            return Orientation()
+            return Orientation(), DEFAULT_CAMERA_CHOICE
         try:
             payload = json.loads(self._path.read_text())
             if not isinstance(payload, dict):
                 raise ValueError("Configuration file must contain a JSON object")
-            return _parse_orientation(payload)
+            if "orientation" in payload and isinstance(payload["orientation"], Mapping):
+                orientation_payload = payload["orientation"]
+            else:
+                orientation_payload = payload
+            orientation = _parse_orientation(orientation_payload)
+            camera_raw = payload.get("camera", DEFAULT_CAMERA_CHOICE)
+            if isinstance(camera_raw, str) and camera_raw.strip():
+                camera = camera_raw.strip().lower()
+                if camera not in CAMERA_SOURCES:
+                    camera = DEFAULT_CAMERA_CHOICE
+            else:
+                camera = DEFAULT_CAMERA_CHOICE
+            return orientation, camera
         except (OSError, ValueError) as exc:
             raise RuntimeError(f"Failed to load configuration: {exc}") from exc
 
-    def _save(self, orientation: Orientation) -> None:
-        payload: Dict[str, Any] = asdict(orientation)
+    def _save(self) -> None:
+        payload: Dict[str, Any] = {
+            "orientation": asdict(self._orientation),
+            "camera": self._camera,
+        }
         self._path.write_text(json.dumps(payload, indent=2))
 
     def get_orientation(self) -> Orientation:
         with self._lock:
-            return self._data
+            return self._orientation
 
     def set_orientation(self, data: Mapping[str, Any]) -> Orientation:
         orientation = _parse_orientation(data)
         with self._lock:
-            self._data = orientation
-            self._save(orientation)
+            self._orientation = orientation
+            self._save()
         return orientation
+
+    def get_camera(self) -> str:
+        with self._lock:
+            return self._camera
+
+    def set_camera(self, camera: str) -> str:
+        if not isinstance(camera, str) or not camera.strip():
+            raise ValueError("Camera selection must be a non-empty string")
+        normalised = camera.strip().lower()
+        if normalised not in CAMERA_SOURCES:
+            raise ValueError(f"Unknown camera selection: {camera}")
+        with self._lock:
+            self._camera = normalised
+            self._save()
+        return normalised
 
 
 __all__ = ["ConfigManager", "Orientation"]

--- a/src/rev_cam/diagnostics.py
+++ b/src/rev_cam/diagnostics.py
@@ -1,0 +1,71 @@
+"""Command-line helpers for RevCam diagnostics."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Sequence
+
+from .camera import diagnose_camera_conflicts
+from .version import APP_VERSION
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Return the argument parser for the diagnostics CLI."""
+
+    parser = argparse.ArgumentParser(
+        prog="python -m rev_cam.diagnostics",
+        description="RevCam diagnostics helpers",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit results as JSON for scripting.",
+    )
+    return parser
+
+
+def run(argv: Sequence[str] | None = None) -> int:
+    """Execute the diagnostics CLI with *argv* arguments."""
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    hints = diagnose_camera_conflicts()
+    payload = {
+        "version": APP_VERSION,
+        "camera_conflicts": hints,
+    }
+
+    if args.json:
+        json.dump(payload, sys.stdout)
+        sys.stdout.write("\n")
+        return 0
+
+    print(f"RevCam diagnostics (version {APP_VERSION})")
+    if hints:
+        print("Detected potential PiCamera2 conflicts:")
+        for hint in hints:
+            print(f" - {hint}")
+    else:
+        print("No conflicting services or processes were detected.")
+        print(
+            "If the camera still reports 'Device or resource busy', double-check"
+            " for external processes or legacy camera settings."
+        )
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point used by `python -m rev_cam.diagnostics`."""
+
+    return run(argv)
+
+
+__all__ = ["build_parser", "run", "main"]
+
+
+if __name__ == "__main__":  # pragma: no cover - module behaviour
+    import sys
+
+    sys.exit(main())

--- a/src/rev_cam/diagnostics.py
+++ b/src/rev_cam/diagnostics.py
@@ -2,12 +2,33 @@
 from __future__ import annotations
 
 import argparse
+import importlib
 import json
 import sys
 from typing import Sequence
 
-from .camera import diagnose_camera_conflicts
+from .camera import (
+    NUMPY_ABI_HINT,
+    detect_numpy_abi_mismatch,
+    diagnose_camera_conflicts,
+    summarise_exception,
+)
 from .version import APP_VERSION
+
+PICAMERA_INSTALL_HINT = (
+    "Install the Raspberry Pi OS Picamera2 packages with `sudo apt install python3-picamera2` "
+    "and recreate the virtual environment with `python3 -m venv --system-site-packages .venv` "
+    "or run `./scripts/install.sh --pi`."
+)
+
+NUMPY_INSTALL_HINT = (
+    "Install NumPy inside the active environment (for example `pip install numpy` or rerun "
+    "`./scripts/install.sh --pi`)."
+)
+
+PICAMERA_REINSTALL_HINT = (
+    "Reinstall the Raspberry Pi OS Picamera2 stack (`sudo apt install --reinstall python3-picamera2 simplejpeg`)."
+)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -25,6 +46,61 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def diagnose_picamera_stack() -> dict[str, object]:
+    """Return diagnostic details about the Picamera2 Python stack."""
+
+    status = "ok"
+    details: list[str] = []
+    hints: list[str] = []
+    numpy_version: str | None = None
+
+    def mark_error(detail: str) -> None:
+        nonlocal status
+        status = "error"
+        details.append(detail)
+
+    def add_hint(text: str) -> None:
+        if text not in hints:
+            hints.append(text)
+
+    try:
+        numpy_module = importlib.import_module("numpy")
+    except ModuleNotFoundError:
+        mark_error("numpy module not found.")
+        add_hint(NUMPY_INSTALL_HINT)
+    except Exception as exc:  # pragma: no cover - defensive guard
+        detail = summarise_exception(exc)
+        mark_error(f"numpy import failed: {detail}")
+        if detect_numpy_abi_mismatch(detail):
+            add_hint(NUMPY_ABI_HINT)
+    else:
+        numpy_version = getattr(numpy_module, "__version__", None)
+
+    try:
+        importlib.import_module("picamera2")
+    except ModuleNotFoundError:
+        mark_error("picamera2 module not found.")
+        add_hint(PICAMERA_INSTALL_HINT)
+    except Exception as exc:  # pragma: no cover - depends on runtime environment
+        detail = summarise_exception(exc)
+        mark_error(f"picamera2 import failed: {detail}")
+        lower_detail = detail.lower()
+        if detect_numpy_abi_mismatch(detail):
+            add_hint(NUMPY_ABI_HINT)
+        if "simplejpeg" in lower_detail:
+            add_hint(PICAMERA_REINSTALL_HINT)
+    else:
+        # Import succeeded, nothing else to record
+        pass
+
+    payload: dict[str, object] = {"status": status, "details": details}
+    if hints:
+        payload["hints"] = hints
+    if numpy_version:
+        payload["numpy_version"] = numpy_version
+    return payload
+
+
 def run(argv: Sequence[str] | None = None) -> int:
     """Execute the diagnostics CLI with *argv* arguments."""
 
@@ -32,9 +108,11 @@ def run(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     hints = diagnose_camera_conflicts()
+    picamera_stack = diagnose_picamera_stack()
     payload = {
         "version": APP_VERSION,
         "camera_conflicts": hints,
+        "picamera": picamera_stack,
     }
 
     if args.json:
@@ -53,6 +131,20 @@ def run(argv: Sequence[str] | None = None) -> int:
             "If the camera still reports 'Device or resource busy', double-check"
             " for external processes or legacy camera settings."
         )
+
+    if picamera_stack["status"] == "ok":
+        print("Picamera2 Python stack: OK")
+        if "numpy_version" in picamera_stack:
+            print(f" - NumPy version: {picamera_stack['numpy_version']}")
+    else:
+        print("Picamera2 Python stack issues detected:")
+        for detail in picamera_stack["details"]:
+            print(f" - {detail}")
+        hints_payload = picamera_stack.get("hints")
+        if hints_payload:
+            print("Hints:")
+            for hint in hints_payload:
+                print(f" * {hint}")
     return 0
 
 
@@ -62,10 +154,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     return run(argv)
 
 
-__all__ = ["build_parser", "run", "main"]
+__all__ = ["build_parser", "diagnose_picamera_stack", "run", "main"]
 
 
 if __name__ == "__main__":  # pragma: no cover - module behaviour
-    import sys
-
     sys.exit(main())

--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -164,6 +164,19 @@
           }
           return true;
         });
+        if (camera.webrtc && camera.webrtc.error) {
+          const webrtcDetail = String(camera.webrtc.error).trim();
+          if (webrtcDetail) {
+            const webrtcMessage = `WebRTC disabled: ${webrtcDetail}`;
+            const webrtcLower = webrtcMessage.toLowerCase();
+            const alreadyIncluded =
+              statusLower.includes(webrtcLower) ||
+              errorMessages.some((detail) => detail.toLowerCase() === webrtcLower);
+            if (!alreadyIncluded) {
+              errorMessages.push(webrtcMessage);
+            }
+          }
+        }
         if (errorMessages.length) {
           status += ` • ${errorMessages.join(" • ")}`;
         }

--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -45,6 +45,9 @@
   <body>
     <a href="/">← Back to live view</a>
     <h1>Camera Settings</h1>
+    <p id="app-version" style="margin-top: -0.5rem; opacity: 0.75;">
+      Version <span id="version-value">Loading…</span>
+    </p>
     <form id="orientation-form">
       <label>
         Camera source
@@ -72,6 +75,7 @@
     <script>
       const form = document.getElementById("orientation-form");
       const statusLabel = document.getElementById("status");
+      const versionValue = document.getElementById("version-value");
       const cameraLabels = new Map();
 
       function describeCameraErrors(camera) {
@@ -98,10 +102,20 @@
         return descriptions;
       }
 
+      function updateVersion(camera) {
+        if (!versionValue) {
+          return;
+        }
+        const version = camera && camera.version ? String(camera.version).trim() : "";
+        versionValue.textContent = version || "Unknown";
+      }
+
       function applySettings(orientation, camera, message = "Settings loaded") {
         form.rotation.value = orientation.rotation;
         form.flip_horizontal.checked = orientation.flip_horizontal;
         form.flip_vertical.checked = orientation.flip_vertical;
+
+        updateVersion(camera);
 
         const cameraSelect = form.elements.namedItem("camera");
         if (!(cameraSelect instanceof HTMLSelectElement)) {

--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -79,12 +79,21 @@
           return [];
         }
         const descriptions = [];
+        const seen = new Set();
         for (const [source, detail] of Object.entries(camera.errors)) {
           if (!detail) {
             continue;
           }
           const label = cameraLabels.get(source) || source;
-          descriptions.push(`${label}: ${detail}`);
+          const combined = `${label}: ${detail}`;
+          const dedupeKey = detail.trim().toLowerCase();
+          if (dedupeKey && seen.has(dedupeKey)) {
+            continue;
+          }
+          if (dedupeKey) {
+            seen.add(dedupeKey);
+          }
+          descriptions.push(combined);
         }
         return descriptions;
       }
@@ -120,11 +129,26 @@
           const activeLabel = cameraLabels.get(camera.active) || camera.active;
           status += ` (active: ${activeLabel})`;
         }
+        const statusLower = typeof status === "string" ? status.toLowerCase() : "";
         const errorMessages = describeCameraErrors(camera).filter((detail) => {
-          if (typeof status !== "string") {
+          if (!statusLower) {
             return true;
           }
-          return !status.toLowerCase().includes(detail.toLowerCase());
+          const detailLower = detail.toLowerCase();
+          if (statusLower.includes(detailLower)) {
+            return false;
+          }
+          const colonIndex = detail.indexOf(":");
+          if (colonIndex !== -1) {
+            const tail = detail
+              .slice(colonIndex + 1)
+              .trim()
+              .toLowerCase();
+            if (tail && statusLower.includes(tail)) {
+              return false;
+            }
+          }
+          return true;
         });
         if (errorMessages.length) {
           status += ` • ${errorMessages.join(" • ")}`;

--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -120,7 +120,12 @@
           const activeLabel = cameraLabels.get(camera.active) || camera.active;
           status += ` (active: ${activeLabel})`;
         }
-        const errorMessages = describeCameraErrors(camera);
+        const errorMessages = describeCameraErrors(camera).filter((detail) => {
+          if (typeof status !== "string") {
+            return true;
+          }
+          return !status.toLowerCase().includes(detail.toLowerCase());
+        });
         if (errorMessages.length) {
           status += ` • ${errorMessages.join(" • ")}`;
         }

--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -44,8 +44,13 @@
   </head>
   <body>
     <a href="/">← Back to live view</a>
-    <h1>Camera Orientation</h1>
+    <h1>Camera Settings</h1>
     <form id="orientation-form">
+      <label>
+        Camera source
+        <select name="camera"></select>
+      </label>
+      <h2 style="margin-bottom: 0.5rem; margin-top: 1.5rem;">Orientation</h2>
       <label>
         Rotation
         <select name="rotation">
@@ -67,17 +72,63 @@
     <script>
       const form = document.getElementById("orientation-form");
       const statusLabel = document.getElementById("status");
+      const cameraLabels = new Map();
 
-      async function loadOrientation() {
-        const response = await fetch("/api/orientation");
-        if (!response.ok) {
+      function applySettings(orientation, camera, message = "Settings loaded") {
+        form.rotation.value = orientation.rotation;
+        form.flip_horizontal.checked = orientation.flip_horizontal;
+        form.flip_vertical.checked = orientation.flip_vertical;
+
+        const cameraSelect = form.elements.namedItem("camera");
+        if (!(cameraSelect instanceof HTMLSelectElement)) {
+          throw new Error("Camera select element missing");
+        }
+        cameraSelect.innerHTML = "";
+        cameraLabels.clear();
+        for (const option of camera.options || []) {
+          const opt = document.createElement("option");
+          opt.value = option.value;
+          opt.textContent = option.label;
+          cameraSelect.appendChild(opt);
+          cameraLabels.set(option.value, option.label);
+        }
+        if (camera.selected && cameraLabels.has(camera.selected)) {
+          cameraSelect.value = camera.selected;
+        }
+
+        let status = message;
+        if (
+          !status.toLowerCase().startsWith("error") &&
+          camera.active &&
+          camera.active !== camera.selected
+        ) {
+          const activeLabel = cameraLabels.get(camera.active) || camera.active;
+          status += ` (active: ${activeLabel})`;
+        }
+        statusLabel.textContent = status;
+      }
+
+      async function fetchSettings() {
+        const [orientationResponse, cameraResponse] = await Promise.all([
+          fetch("/api/orientation"),
+          fetch("/api/camera"),
+        ]);
+        if (!orientationResponse.ok) {
           throw new Error("Unable to fetch current orientation");
         }
-        const data = await response.json();
-        form.rotation.value = data.rotation;
-        form.flip_horizontal.checked = data.flip_horizontal;
-        form.flip_vertical.checked = data.flip_vertical;
-        statusLabel.textContent = "Orientation loaded";
+        if (!cameraResponse.ok) {
+          throw new Error("Unable to fetch camera configuration");
+        }
+        const [orientationData, cameraData] = await Promise.all([
+          orientationResponse.json(),
+          cameraResponse.json(),
+        ]);
+        return { orientation: orientationData, camera: cameraData };
+      }
+
+      async function loadSettings() {
+        const data = await fetchSettings();
+        applySettings(data.orientation, data.camera);
       }
 
       form.addEventListener("submit", async (event) => {
@@ -88,20 +139,59 @@
           flip_horizontal: form.flip_horizontal.checked,
           flip_vertical: form.flip_vertical.checked,
         };
-        const response = await fetch("/api/orientation", {
+        const orientationResponse = await fetch("/api/orientation", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(payload),
         });
-        if (!response.ok) {
-          const error = await response.json();
-          statusLabel.textContent = "Error: " + (error.detail || "Unable to save");
+        if (!orientationResponse.ok) {
+          let errorDetail = "Unable to save orientation";
+          try {
+            const error = await orientationResponse.json();
+            errorDetail = error.detail || errorDetail;
+          } catch (err) {
+            console.error(err);
+          }
+          statusLabel.textContent = "Error: " + errorDetail;
           return;
         }
-        statusLabel.textContent = "Settings saved";
+        const cameraSelect = form.elements.namedItem("camera");
+        if (!(cameraSelect instanceof HTMLSelectElement)) {
+          statusLabel.textContent = "Error: camera selector missing";
+          return;
+        }
+        const cameraResponse = await fetch("/api/camera", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ source: cameraSelect.value }),
+        });
+        if (!cameraResponse.ok) {
+          let errorDetail = "Unable to update camera";
+          try {
+            const error = await cameraResponse.json();
+            errorDetail = error.detail || errorDetail;
+          } catch (err) {
+            console.error(err);
+          }
+          statusLabel.textContent = "Error: " + errorDetail;
+          try {
+            const data = await fetchSettings();
+            applySettings(data.orientation, data.camera, statusLabel.textContent);
+          } catch (err) {
+            console.error(err);
+          }
+          return;
+        }
+        try {
+          const data = await fetchSettings();
+          applySettings(data.orientation, data.camera, "Settings saved");
+        } catch (err) {
+          console.error(err);
+          statusLabel.textContent = "Settings saved";
+        }
       });
 
-      loadOrientation().catch((err) => {
+      loadSettings().catch((err) => {
         console.error(err);
         statusLabel.textContent = err.message;
       });

--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -74,6 +74,21 @@
       const statusLabel = document.getElementById("status");
       const cameraLabels = new Map();
 
+      function describeCameraErrors(camera) {
+        if (!camera || !camera.errors) {
+          return [];
+        }
+        const descriptions = [];
+        for (const [source, detail] of Object.entries(camera.errors)) {
+          if (!detail) {
+            continue;
+          }
+          const label = cameraLabels.get(source) || source;
+          descriptions.push(`${label}: ${detail}`);
+        }
+        return descriptions;
+      }
+
       function applySettings(orientation, camera, message = "Settings loaded") {
         form.rotation.value = orientation.rotation;
         form.flip_horizontal.checked = orientation.flip_horizontal;
@@ -104,6 +119,10 @@
         ) {
           const activeLabel = cameraLabels.get(camera.active) || camera.active;
           status += ` (active: ${activeLabel})`;
+        }
+        const errorMessages = describeCameraErrors(camera);
+        if (errorMessages.length) {
+          status += ` • ${errorMessages.join(" • ")}`;
         }
         statusLabel.textContent = status;
       }

--- a/src/rev_cam/version.py
+++ b/src/rev_cam/version.py
@@ -1,6 +1,6 @@
 """Application version metadata."""
 
-APP_VERSION = "0.1.4"
+APP_VERSION = "0.1.5"
 """Human readable application version displayed in the UI."""
 
 __all__ = ["APP_VERSION"]

--- a/src/rev_cam/version.py
+++ b/src/rev_cam/version.py
@@ -1,6 +1,6 @@
 """Application version metadata."""
 
-APP_VERSION = "0.1.1"
+APP_VERSION = "0.1.2"
 """Human readable application version displayed in the UI."""
 
 __all__ = ["APP_VERSION"]

--- a/src/rev_cam/version.py
+++ b/src/rev_cam/version.py
@@ -1,6 +1,6 @@
 """Application version metadata."""
 
-APP_VERSION = "0.1.3"
+APP_VERSION = "0.1.4"
 """Human readable application version displayed in the UI."""
 
 __all__ = ["APP_VERSION"]

--- a/src/rev_cam/version.py
+++ b/src/rev_cam/version.py
@@ -1,0 +1,6 @@
+"""Application version metadata."""
+
+APP_VERSION = "0.1.1"
+"""Human readable application version displayed in the UI."""
+
+__all__ = ["APP_VERSION"]

--- a/src/rev_cam/version.py
+++ b/src/rev_cam/version.py
@@ -1,6 +1,6 @@
 """Application version metadata."""
 
-APP_VERSION = "0.1.2"
+APP_VERSION = "0.1.3"
 """Human readable application version displayed in the UI."""
 
 __all__ = ["APP_VERSION"]

--- a/tests/test_app_camera.py
+++ b/tests/test_app_camera.py
@@ -12,6 +12,7 @@ from fastapi.testclient import TestClient
 
 from rev_cam.app import create_app
 from rev_cam.camera import CameraError
+from rev_cam.version import APP_VERSION
 
 
 class _BrokenPicamera:
@@ -37,6 +38,7 @@ def test_camera_endpoint_reports_picamera_error(client: TestClient) -> None:
     assert payload["active"] == "synthetic"
     assert "picamera" in payload["errors"]
     assert "picamera backend unavailable" in payload["errors"]["picamera"]
+    assert payload["version"] == APP_VERSION
 
 
 def test_camera_update_surfaces_failure(client: TestClient) -> None:
@@ -47,3 +49,4 @@ def test_camera_update_surfaces_failure(client: TestClient) -> None:
 
     refreshed = client.get("/api/camera").json()
     assert "picamera backend unavailable" in refreshed["errors"]["picamera"]
+    assert refreshed["version"] == APP_VERSION

--- a/tests/test_app_camera.py
+++ b/tests/test_app_camera.py
@@ -1,0 +1,49 @@
+"""Integration tests covering camera API error reporting."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("httpx")
+
+from fastapi.testclient import TestClient
+
+from rev_cam.app import create_app
+from rev_cam.camera import CameraError
+
+
+class _BrokenPicamera:
+    """Stub Picamera implementation that always fails."""
+
+    def __init__(self) -> None:
+        raise CameraError("picamera backend unavailable")
+
+
+@pytest.fixture
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setattr("rev_cam.camera.Picamera2Camera", _BrokenPicamera)
+    app = create_app(tmp_path / "config.json")
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def test_camera_endpoint_reports_picamera_error(client: TestClient) -> None:
+    response = client.get("/api/camera")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["selected"] == "auto"
+    assert payload["active"] == "synthetic"
+    assert "picamera" in payload["errors"]
+    assert "picamera backend unavailable" in payload["errors"]["picamera"]
+
+
+def test_camera_update_surfaces_failure(client: TestClient) -> None:
+    response = client.post("/api/camera", json={"source": "picamera"})
+    assert response.status_code == 400
+    payload = response.json()
+    assert "picamera backend unavailable" in payload["detail"]
+
+    refreshed = client.get("/api/camera").json()
+    assert "picamera backend unavailable" in refreshed["errors"]["picamera"]

--- a/tests/test_app_camera.py
+++ b/tests/test_app_camera.py
@@ -39,6 +39,8 @@ def test_camera_endpoint_reports_picamera_error(client: TestClient) -> None:
     assert "picamera" in payload["errors"]
     assert "picamera backend unavailable" in payload["errors"]["picamera"]
     assert payload["version"] == APP_VERSION
+    assert payload["webrtc"]["enabled"] is False
+    assert "aiortc" in payload["webrtc"]["error"].lower()
 
 
 def test_camera_update_surfaces_failure(client: TestClient) -> None:
@@ -50,3 +52,5 @@ def test_camera_update_surfaces_failure(client: TestClient) -> None:
     refreshed = client.get("/api/camera").json()
     assert "picamera backend unavailable" in refreshed["errors"]["picamera"]
     assert refreshed["version"] == APP_VERSION
+    assert refreshed["webrtc"]["enabled"] is False
+    assert "aiortc" in refreshed["webrtc"]["error"].lower()

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -209,6 +209,13 @@ def test_null_allocator_provides_expected_methods() -> None:
     assert hasattr(allocator, "sync")
     assert hasattr(allocator, "acquire")
     assert hasattr(allocator, "release")
+    sync_context = allocator.sync(object(), object(), False)
+    assert hasattr(sync_context, "__enter__")
+    assert hasattr(sync_context, "__exit__")
+    assert sync_context.__enter__() is sync_context
+    assert sync_context.__exit__(None, None, None) is False
+    with allocator.sync(object(), object(), False):
+        pass
     assert allocator.acquire(object()) is None
     assert allocator.release(object()) is None
     # Unknown attributes should be safely ignored

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -274,6 +274,8 @@ def test_import_failure_surface_details(monkeypatch: pytest.MonkeyPatch) -> None
     message = str(excinfo.value)
     assert "numpy ABI mismatch" in message
     assert "python3-picamera2" in message
+    assert "--system-site-packages" in message
+    assert "scripts/install.sh --pi" in message
 
 
 def test_picamera_initialisation_error_includes_cause(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pytest
 
+from rev_cam.camera import DEFAULT_CAMERA_CHOICE
 from rev_cam.config import ConfigManager, Orientation
 
 
@@ -24,3 +25,24 @@ def test_invalid_orientation_rejected(tmp_path: Path):
     manager = ConfigManager(tmp_path / "config.json")
     with pytest.raises(ValueError):
         manager.set_orientation({"rotation": 45})
+
+
+def test_default_camera(tmp_path: Path):
+    manager = ConfigManager(tmp_path / "config.json")
+    assert manager.get_camera() == DEFAULT_CAMERA_CHOICE
+
+
+def test_camera_persistence(tmp_path: Path):
+    config_file = tmp_path / "config.json"
+    manager = ConfigManager(config_file)
+    manager.set_camera("synthetic")
+    reloaded = ConfigManager(config_file)
+    assert reloaded.get_camera() == "synthetic"
+
+
+def test_camera_requires_non_empty_string(tmp_path: Path):
+    manager = ConfigManager(tmp_path / "config.json")
+    with pytest.raises(ValueError):
+        manager.set_camera("")
+    with pytest.raises(ValueError):
+        manager.set_camera("unknown")

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import rev_cam.diagnostics as diagnostics
+
+
+def test_run_outputs_conflicts(capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(diagnostics, "diagnose_camera_conflicts", lambda: ["service running"])
+
+    exit_code = diagnostics.run([])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "service running" in out
+    assert diagnostics.APP_VERSION in out
+
+
+def test_run_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(diagnostics, "diagnose_camera_conflicts", lambda: ["process"])
+
+    buffer: list[str] = []
+
+    class DummyIO:
+        def write(self, data: str) -> int:
+            buffer.append(data)
+            return len(data)
+
+    monkeypatch.setattr(diagnostics.sys, "stdout", DummyIO())
+
+    exit_code = diagnostics.run(["--json"])
+
+    assert exit_code == 0
+    payload = json.loads("".join(buffer))
+    assert payload["camera_conflicts"] == ["process"]
+    assert payload["version"] == diagnostics.APP_VERSION

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 
+import types
+
 import pytest
 
 import rev_cam.diagnostics as diagnostics
@@ -9,17 +11,29 @@ import rev_cam.diagnostics as diagnostics
 
 def test_run_outputs_conflicts(capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(diagnostics, "diagnose_camera_conflicts", lambda: ["service running"])
+    monkeypatch.setattr(
+        diagnostics,
+        "diagnose_picamera_stack",
+        lambda: {"status": "error", "details": ["picamera2 module not found."], "hints": ["install"]},
+    )
 
     exit_code = diagnostics.run([])
 
     assert exit_code == 0
     out = capsys.readouterr().out
     assert "service running" in out
+    assert "Picamera2 Python stack issues detected:" in out
+    assert "picamera2 module not found." in out
     assert diagnostics.APP_VERSION in out
 
 
 def test_run_json(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(diagnostics, "diagnose_camera_conflicts", lambda: ["process"])
+    monkeypatch.setattr(
+        diagnostics,
+        "diagnose_picamera_stack",
+        lambda: {"status": "ok", "details": [], "numpy_version": "1.26.1"},
+    )
 
     buffer: list[str] = []
 
@@ -36,3 +50,36 @@ def test_run_json(monkeypatch: pytest.MonkeyPatch) -> None:
     payload = json.loads("".join(buffer))
     assert payload["camera_conflicts"] == ["process"]
     assert payload["version"] == diagnostics.APP_VERSION
+    assert payload["picamera"] == {"status": "ok", "details": [], "numpy_version": "1.26.1"}
+
+
+def test_diagnose_picamera_stack_numpy_mismatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_import(name: str):
+        if name == "numpy":
+            return types.SimpleNamespace(__version__="1.26.2")
+        if name == "picamera2":
+            raise ValueError("numpy.dtype size changed, may indicate binary incompatibility")
+        raise ModuleNotFoundError(name)
+
+    monkeypatch.setattr(diagnostics.importlib, "import_module", fake_import)
+
+    result = diagnostics.diagnose_picamera_stack()
+
+    assert result["status"] == "error"
+    assert any("picamera2 import failed" in detail for detail in result["details"])
+    assert diagnostics.NUMPY_ABI_HINT in result["hints"]
+
+
+def test_diagnose_picamera_stack_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_import(name: str):
+        if name == "numpy":
+            return types.SimpleNamespace(__version__="1.26.2")
+        if name == "picamera2":
+            return object()
+        raise ModuleNotFoundError(name)
+
+    monkeypatch.setattr(diagnostics.importlib, "import_module", fake_import)
+
+    result = diagnostics.diagnose_picamera_stack()
+
+    assert result == {"status": "ok", "details": [], "numpy_version": "1.26.2"}


### PR DESCRIPTION
## Summary
- add camera source metadata and helpers to control selection at runtime
- persist the selected camera in the configuration manager and expose REST endpoints to read or update it
- extend the settings page with a camera selector dropdown and adapt tests for the new behaviour

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc8b4ac60c8332a9681de226f33559