### PR TITLE
Add Wi-Fi configuration endpoints and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,11 @@ as `motion.local`, so iOS devices can simply browse to
 hotspot's IP address. If development mode is enabled for the hotspot, RevCam
 waits up to 120 seconds for the access point to become fully active before
 rolling back to the previous Wi-Fi profile, giving clients more time to join the
-new network.
+new network. The announcer prefers the pure-Python `zeroconf` package (installed
+automatically when you run `pip install -e .`), but also falls back to Avahi's
+`avahi-publish` CLI. If you upgraded an existing environment, make sure
+`zeroconf` is installed or add `avahi-utils` via `sudo apt install avahi-utils`
+so `motion.local` resolves while the hotspot is active.
 
 ### Copy-paste bootstrap script (development machines)
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ that future driver-assistance overlays can be injected on the server without maj
 - REST API for orientation control and camera management.
 - Optional battery indicator when an INA219 sensor is connected, showing live
   percentage, voltage, and current draw in the viewer.
+- Built-in mDNS advertisement so `motion.local:9000` resolves on iOS clients
+  even when the RevCam hotspot is active.
 
 ## Project layout
 
@@ -164,6 +166,16 @@ EOF
 After reloading the service (or rebooting) `nmcli general permissions` should
 list `yes` for the `org.freedesktop.NetworkManager.*` capabilities and RevCam's
 hotspot toggle will succeed.
+
+### Hotspot hostname and development-mode rollback
+
+When the RevCam hotspot is enabled the server now advertises itself over mDNS
+as `motion.local`, so iOS devices can simply browse to
+[`http://motion.local:9000/`](http://motion.local:9000/) without looking up the
+hotspot's IP address. If development mode is enabled for the hotspot, RevCam
+waits up to 120 seconds for the access point to become fully active before
+rolling back to the previous Wi-Fi profile, giving clients more time to join the
+new network.
 
 ### Copy-paste bootstrap script (development machines)
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,40 @@ source .venv/bin/activate
 pip install -e .[dev]
 ```
 
+### NetworkManager permissions for Wi-Fi control
+
+RevCam drives Wi-Fi and hotspot features through NetworkManager's `nmcli`
+command-line tool. The user account running RevCam therefore needs permission to
+modify Wi-Fi connections and toggle hotspots. When running inside a service
+account (for example under systemd) NetworkManager often denies these actions
+with errors such as:
+
+```
+Error: Failed to setup a Wi-Fi hotspot: Not authorized to control networking.
+```
+
+To grant the necessary access either run RevCam as a user that already has
+network privileges (e.g. the default `pi` account on Raspberry Pi OS) or add a
+Polkit rule allowing your service account to control NetworkManager. A minimal
+rule that authorises members of the `revcam` group looks like this:
+
+```bash
+sudo groupadd -f revcam
+sudo usermod -aG revcam <your-service-user>
+sudo tee /etc/polkit-1/rules.d/10-revcam-nm.rules >/dev/null <<'EOF'
+polkit.addRule(function(action, subject) {
+  if (action.id.indexOf('org.freedesktop.NetworkManager.') === 0 &&
+      subject.isInGroup('revcam')) {
+    return polkit.Result.YES;
+  }
+});
+EOF
+```
+
+After reloading the service (or rebooting) `nmcli general permissions` should
+list `yes` for the `org.freedesktop.NetworkManager.*` capabilities and RevCam's
+hotspot toggle will succeed.
+
 ### Copy-paste bootstrap script (development machines)
 
 Need a single snippet you can drop into a terminal? The commands below clone (or

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ dependencies = [
     "uvicorn[standard]>=0.27",
     "numpy>=1.24",
     "simplejpeg>=2.1",
-    "pydantic>=2.5"
+    "pydantic>=2.5",
+    "zeroconf>=0.39"
 ]
 
 [project.optional-dependencies]

--- a/src/rev_cam/app.py
+++ b/src/rev_cam/app.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
+from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import HTMLResponse, StreamingResponse
 from pydantic import BaseModel
 
@@ -15,6 +16,7 @@ from .config import ConfigManager, Resolution, RESOLUTION_PRESETS
 from .pipeline import FramePipeline
 from .streaming import MJPEGStreamer
 from .version import APP_VERSION
+from .wifi import WiFiError, WiFiManager
 
 STATIC_DIR = Path(__file__).resolve().parent / "static"
 
@@ -37,7 +39,24 @@ class CameraPayload(BaseModel):
     resolution: str | None = None
 
 
-def create_app(config_path: Path | str = Path("data/config.json")) -> FastAPI:
+class WiFiConnectPayload(BaseModel):
+    ssid: str
+    password: str | None = None
+    development_mode: bool = False
+    rollback_seconds: float | None = None
+
+
+class WiFiHotspotPayload(BaseModel):
+    enabled: bool
+    ssid: str | None = None
+    password: str | None = None
+
+
+def create_app(
+    config_path: Path | str = Path("data/config.json"),
+    *,
+    wifi_manager: WiFiManager | None = None,
+) -> FastAPI:
     app = FastAPI(title="RevCam", version=APP_VERSION)
 
     logger = logging.getLogger(__name__)
@@ -56,6 +75,8 @@ def create_app(config_path: Path | str = Path("data/config.json")) -> FastAPI:
         i2c_bus_override = None
 
     battery_monitor = BatteryMonitor(capacity_mah=1000, i2c_bus=i2c_bus_override)
+    wifi_manager = wifi_manager or WiFiManager()
+
     pipeline = FramePipeline(lambda: config_manager.get_orientation())
     camera: BaseCamera | None = None
     streamer: MJPEGStreamer | None = None
@@ -63,6 +84,8 @@ def create_app(config_path: Path | str = Path("data/config.json")) -> FastAPI:
     active_camera_choice: str = "unknown"
     active_resolution: Resolution = config_manager.get_resolution()
     camera_errors: dict[str, str] = {}
+
+    app.state.wifi_manager = wifi_manager
 
     def _record_camera_error(source: str, message: str | None) -> None:
         if message:
@@ -208,6 +231,54 @@ def create_app(config_path: Path | str = Path("data/config.json")) -> FastAPI:
     async def get_battery_status() -> dict[str, object | None]:
         reading = battery_monitor.read()
         return reading.to_dict()
+
+    @app.get("/api/wifi/status")
+    async def get_wifi_status() -> dict[str, object | None]:
+        try:
+            status = await run_in_threadpool(wifi_manager.get_status)
+        except WiFiError as exc:
+            raise HTTPException(status_code=503, detail=str(exc)) from exc
+        return status.to_dict()
+
+    @app.get("/api/wifi/networks")
+    async def list_wifi_networks() -> dict[str, object]:
+        try:
+            networks = await run_in_threadpool(wifi_manager.scan_networks)
+        except WiFiError as exc:
+            raise HTTPException(status_code=503, detail=str(exc)) from exc
+        return {"networks": [network.to_dict() for network in networks]}
+
+    @app.post("/api/wifi/connect")
+    async def connect_wifi(payload: WiFiConnectPayload) -> dict[str, object | None]:
+        try:
+            status = await run_in_threadpool(
+                wifi_manager.connect,
+                payload.ssid,
+                payload.password,
+                development_mode=payload.development_mode,
+                rollback_timeout=payload.rollback_seconds,
+            )
+        except WiFiError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return status.to_dict()
+
+    @app.post("/api/wifi/hotspot")
+    async def configure_wifi_hotspot(payload: WiFiHotspotPayload) -> dict[str, object | None]:
+        if payload.enabled:
+            try:
+                status = await run_in_threadpool(
+                    wifi_manager.enable_hotspot,
+                    payload.ssid or "",
+                    payload.password,
+                )
+            except WiFiError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
+        else:
+            try:
+                status = await run_in_threadpool(wifi_manager.disable_hotspot)
+            except WiFiError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return status.to_dict()
 
     @app.post("/api/camera")
     async def update_camera(payload: CameraPayload) -> dict[str, object]:

--- a/src/rev_cam/app.py
+++ b/src/rev_cam/app.py
@@ -50,6 +50,8 @@ class WiFiHotspotPayload(BaseModel):
     enabled: bool
     ssid: str | None = None
     password: str | None = None
+    development_mode: bool = False
+    rollback_seconds: float | None = None
 
 
 def create_app(
@@ -270,6 +272,8 @@ def create_app(
                     wifi_manager.enable_hotspot,
                     payload.ssid or "",
                     payload.password,
+                    development_mode=payload.development_mode,
+                    rollback_timeout=payload.rollback_seconds,
                 )
             except WiFiError as exc:
                 raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/src/rev_cam/app.py
+++ b/src/rev_cam/app.py
@@ -167,6 +167,8 @@ def create_app(
             await streamer.aclose()
         if camera:
             await camera.close()
+        if hasattr(wifi_manager, "close"):
+            await run_in_threadpool(wifi_manager.close)
 
     @app.get("/", response_class=HTMLResponse)
     async def index() -> str:

--- a/src/rev_cam/mdns.py
+++ b/src/rev_cam/mdns.py
@@ -1,0 +1,131 @@
+"""Simple mDNS advertiser used to expose RevCam services."""
+from __future__ import annotations
+
+import ipaddress
+import logging
+
+try:  # pragma: no cover - import guard for optional dependency failures
+    from zeroconf import InterfaceChoice, ServiceInfo, Zeroconf
+except Exception as exc:  # pragma: no cover - dependency import failure
+    Zeroconf = None  # type: ignore[assignment]
+    ServiceInfo = None  # type: ignore[assignment]
+    InterfaceChoice = None  # type: ignore[assignment]
+    _import_error = exc
+else:
+    _import_error = None
+
+
+logger = logging.getLogger(__name__)
+
+
+class MDNSAdvertiser:
+    """Manage an mDNS advertisement for the RevCam HTTP service."""
+
+    def __init__(
+        self,
+        hostname: str = "motion.local",
+        *,
+        service_name: str = "RevCam",
+        service_type: str = "_http._tcp.local.",
+        port: int = 9000,
+    ) -> None:
+        if _import_error is not None:  # pragma: no cover - environment specific
+            raise RuntimeError(f"zeroconf library unavailable: {_import_error}")
+        cleaned = hostname.strip().rstrip(".")
+        if not cleaned:
+            raise ValueError("mDNS hostname must be provided")
+        if not cleaned.endswith(".local"):
+            cleaned = f"{cleaned}.local"
+        if not service_type.endswith("."):
+            service_type = f"{service_type}."
+        self._hostname = cleaned
+        self._service_name = service_name.strip() or "RevCam"
+        self._service_type = service_type
+        self._port = int(port)
+        self._zeroconf: Zeroconf | None = None
+        self._info: ServiceInfo | None = None
+        self._current_ip: str | None = None
+
+    # ------------------------------ helpers -----------------------------
+    def _ensure_zeroconf(self) -> Zeroconf:
+        if self._zeroconf is None:
+            assert InterfaceChoice is not None  # for type checkers
+            self._zeroconf = Zeroconf(interfaces=InterfaceChoice.All)
+        return self._zeroconf
+
+    def _build_service_info(self, ip: ipaddress._BaseAddress) -> ServiceInfo:
+        service_name = f"{self._service_name}.{self._service_type}"
+        if not service_name.endswith("."):
+            service_name = f"{service_name}."
+        server = f"{self._hostname}."
+        assert ServiceInfo is not None  # for type checkers
+        return ServiceInfo(
+            type_=self._service_type,
+            name=service_name,
+            addresses=[ip.packed],
+            port=self._port,
+            server=server,
+            properties={"path": b"/"},
+        )
+
+    # ------------------------------ control ----------------------------
+    def advertise(self, ip_address: str | None) -> None:
+        """Publish an A/AAAA record for ``hostname`` at ``ip_address``."""
+
+        if ip_address is None:
+            self.clear()
+            return
+        if ip_address == self._current_ip:
+            return
+        try:
+            parsed_ip = ipaddress.ip_address(ip_address)
+        except ValueError:
+            logger.warning("Ignoring invalid IP address for mDNS: %s", ip_address)
+            return
+        try:
+            zeroconf = self._ensure_zeroconf()
+        except OSError as exc:  # pragma: no cover - environment specific
+            logger.warning("Unable to start mDNS announcer: %s", exc)
+            return
+        if self._info is not None:
+            try:
+                zeroconf.unregister_service(self._info)
+            except Exception as exc:  # pragma: no cover - best effort cleanup
+                logger.debug("Ignoring mDNS unregister failure: %s", exc)
+            self._info = None
+        info = self._build_service_info(parsed_ip)
+        try:
+            zeroconf.register_service(info, allow_name_change=False)
+        except Exception as exc:  # pragma: no cover - zeroconf runtime issues
+            logger.warning("Failed to register mDNS service: %s", exc)
+            return
+        self._info = info
+        self._current_ip = ip_address
+
+    def clear(self) -> None:
+        """Withdraw the current advertisement."""
+
+        if self._info is None:
+            self._current_ip = None
+            return
+        zeroconf = self._zeroconf
+        if zeroconf is not None:
+            try:
+                zeroconf.unregister_service(self._info)
+            except Exception as exc:  # pragma: no cover - best effort cleanup
+                logger.debug("Ignoring mDNS unregister failure: %s", exc)
+        self._info = None
+        self._current_ip = None
+
+    def close(self) -> None:
+        """Stop advertising and release the zeroconf socket."""
+
+        self.clear()
+        if self._zeroconf is not None:
+            try:
+                self._zeroconf.close()
+            finally:
+                self._zeroconf = None
+
+
+__all__ = ["MDNSAdvertiser"]

--- a/src/rev_cam/mdns.py
+++ b/src/rev_cam/mdns.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 
 import ipaddress
 import logging
+import shutil
+import subprocess
+import threading
+import time
 
 try:  # pragma: no cover - import guard for optional dependency failures
     from zeroconf import InterfaceChoice, ServiceInfo, Zeroconf
@@ -10,38 +14,44 @@ except Exception as exc:  # pragma: no cover - dependency import failure
     Zeroconf = None  # type: ignore[assignment]
     ServiceInfo = None  # type: ignore[assignment]
     InterfaceChoice = None  # type: ignore[assignment]
-    _import_error = exc
+    _zeroconf_error = exc
 else:
-    _import_error = None
+    _zeroconf_error = None
 
 
 logger = logging.getLogger(__name__)
 
 
-class MDNSAdvertiser:
-    """Manage an mDNS advertisement for the RevCam HTTP service."""
+class _BaseAdvertiser:
+    """Internal protocol for advertiser backends."""
+
+    def advertise(self, ip_address: str | None) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def clear(self) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def close(self) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class _ZeroconfAdvertiser(_BaseAdvertiser):
+    """Advertise ``motion.local`` using the zeroconf Python package."""
 
     def __init__(
         self,
-        hostname: str = "motion.local",
-        *,
-        service_name: str = "RevCam",
-        service_type: str = "_http._tcp.local.",
-        port: int = 9000,
+        hostname: str,
+        service_name: str,
+        service_type: str,
+        port: int,
     ) -> None:
-        if _import_error is not None:  # pragma: no cover - environment specific
-            raise RuntimeError(f"zeroconf library unavailable: {_import_error}")
-        cleaned = hostname.strip().rstrip(".")
-        if not cleaned:
-            raise ValueError("mDNS hostname must be provided")
-        if not cleaned.endswith(".local"):
-            cleaned = f"{cleaned}.local"
-        if not service_type.endswith("."):
-            service_type = f"{service_type}."
-        self._hostname = cleaned
-        self._service_name = service_name.strip() or "RevCam"
+        if Zeroconf is None or ServiceInfo is None or InterfaceChoice is None:
+            reason = _zeroconf_error or "zeroconf library unavailable"
+            raise RuntimeError(reason)
+        self._hostname = hostname
+        self._service_name = service_name
         self._service_type = service_type
-        self._port = int(port)
+        self._port = port
         self._zeroconf: Zeroconf | None = None
         self._info: ServiceInfo | None = None
         self._current_ip: str | None = None
@@ -49,7 +59,6 @@ class MDNSAdvertiser:
     # ------------------------------ helpers -----------------------------
     def _ensure_zeroconf(self) -> Zeroconf:
         if self._zeroconf is None:
-            assert InterfaceChoice is not None  # for type checkers
             self._zeroconf = Zeroconf(interfaces=InterfaceChoice.All)
         return self._zeroconf
 
@@ -58,7 +67,6 @@ class MDNSAdvertiser:
         if not service_name.endswith("."):
             service_name = f"{service_name}."
         server = f"{self._hostname}."
-        assert ServiceInfo is not None  # for type checkers
         return ServiceInfo(
             type_=self._service_type,
             name=service_name,
@@ -70,8 +78,6 @@ class MDNSAdvertiser:
 
     # ------------------------------ control ----------------------------
     def advertise(self, ip_address: str | None) -> None:
-        """Publish an A/AAAA record for ``hostname`` at ``ip_address``."""
-
         if ip_address is None:
             self.clear()
             return
@@ -103,8 +109,6 @@ class MDNSAdvertiser:
         self._current_ip = ip_address
 
     def clear(self) -> None:
-        """Withdraw the current advertisement."""
-
         if self._info is None:
             self._current_ip = None
             return
@@ -118,14 +122,201 @@ class MDNSAdvertiser:
         self._current_ip = None
 
     def close(self) -> None:
-        """Stop advertising and release the zeroconf socket."""
-
         self.clear()
         if self._zeroconf is not None:
             try:
                 self._zeroconf.close()
             finally:
                 self._zeroconf = None
+
+
+class _AvahiAdvertiser(_BaseAdvertiser):
+    """Advertise using the ``avahi-publish`` CLI as a lightweight fallback."""
+
+    def __init__(
+        self,
+        hostname: str,
+        service_name: str,
+        service_type: str,
+        port: int,
+    ) -> None:
+        del service_name, service_type, port  # Service metadata is unused for address records.
+        binary = shutil.which("avahi-publish")
+        if not binary:
+            raise FileNotFoundError("avahi-publish command not found")
+        self._binary = binary
+        self._hostname = hostname
+        self._process: subprocess.Popen[str] | None = None
+        self._current_ip: str | None = None
+        self._lock = threading.Lock()
+
+    def advertise(self, ip_address: str | None) -> None:
+        with self._lock:
+            if ip_address is None:
+                self._stop_process()
+                return
+            if self._process is not None and self._process.poll() is not None:
+                self._drain_process(self._process, unexpected=True)
+                self._process = None
+                self._current_ip = None
+            if ip_address == self._current_ip and self._process is not None:
+                return
+            self._stop_process()
+            self._start_process(ip_address)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._stop_process()
+
+    def close(self) -> None:
+        self.clear()
+
+    # ------------------------------ helpers -----------------------------
+    def _start_process(self, ip_address: str) -> None:
+        command = [self._binary, "-a", "-R", self._hostname, ip_address]
+        try:
+            process = subprocess.Popen(
+                command,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+        except OSError as exc:
+            raise RuntimeError(f"failed to launch avahi-publish: {exc}") from exc
+        # avahi-publish exits immediately when it cannot register the record.
+        time.sleep(0.1)
+        if process.poll() is not None:
+            message = self._read_process_error(process)
+            raise RuntimeError(
+                f"avahi-publish exited with code {process.returncode}: {message}"
+            )
+        self._process = process
+        self._current_ip = ip_address
+
+    def _stop_process(self) -> None:
+        process = self._process
+        if process is None:
+            self._current_ip = None
+            return
+        process.terminate()
+        try:
+            process.wait(timeout=1.0)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=1.0)
+        self._drain_process(process, unexpected=False)
+        self._process = None
+        self._current_ip = None
+
+    def _drain_process(self, process: subprocess.Popen[str], *, unexpected: bool) -> None:
+        message = self._read_process_error(process)
+        if message:
+            if unexpected:
+                logger.warning("avahi-publish exited unexpectedly: %s", message)
+            else:
+                logger.debug("avahi-publish output: %s", message)
+        if process.stderr:
+            try:
+                process.stderr.close()
+            except Exception:  # pragma: no cover - best effort cleanup
+                pass
+
+    @staticmethod
+    def _read_process_error(process: subprocess.Popen[str]) -> str:
+        if process.stderr is None:
+            return ""
+        try:
+            data = process.stderr.read()
+        except Exception:  # pragma: no cover - best effort cleanup
+            return ""
+        return data.strip()
+
+
+class _NullAdvertiser(_BaseAdvertiser):
+    """No-op advertiser used when no backend is available."""
+
+    def advertise(self, ip_address: str | None) -> None:  # pragma: no cover - no behaviour
+        del ip_address
+
+    def clear(self) -> None:  # pragma: no cover - no behaviour
+        return
+
+    def close(self) -> None:  # pragma: no cover - no behaviour
+        return
+
+
+class MDNSAdvertiser(_BaseAdvertiser):
+    """Manage an mDNS advertisement for the RevCam HTTP service."""
+
+    def __init__(
+        self,
+        hostname: str = "motion.local",
+        *,
+        service_name: str = "RevCam",
+        service_type: str = "_http._tcp.local.",
+        port: int = 9000,
+    ) -> None:
+        cleaned = hostname.strip().rstrip(".")
+        if not cleaned:
+            raise ValueError("mDNS hostname must be provided")
+        if not cleaned.endswith(".local"):
+            cleaned = f"{cleaned}.local"
+        if not service_type.endswith("."):
+            service_type = f"{service_type}."
+        self._hostname = cleaned
+        self._service_name = service_name.strip() or "RevCam"
+        self._service_type = service_type
+        self._port = int(port)
+        self._backend = self._select_backend()
+
+    # ------------------------------ helpers -----------------------------
+    def _select_backend(self) -> _BaseAdvertiser:
+        errors: list[str] = []
+        if Zeroconf is not None and ServiceInfo is not None and InterfaceChoice is not None:
+            try:
+                return _ZeroconfAdvertiser(
+                    self._hostname,
+                    self._service_name,
+                    self._service_type,
+                    self._port,
+                )
+            except Exception as exc:  # pragma: no cover - rare runtime error
+                errors.append(f"zeroconf backend failed: {exc}")
+        elif _zeroconf_error is not None:
+            errors.append(f"zeroconf import failed: {_zeroconf_error}")
+        try:
+            return _AvahiAdvertiser(
+                self._hostname,
+                self._service_name,
+                self._service_type,
+                self._port,
+            )
+        except FileNotFoundError:
+            errors.append("avahi-publish utility not available")
+        except Exception as exc:  # pragma: no cover - rare runtime error
+            errors.append(f"avahi backend failed: {exc}")
+        if errors:
+            logger.warning(
+                "mDNS advertising disabled: %s. Install the 'zeroconf' Python package or "
+                "the 'avahi-utils' tools to enable motion.local announcements.",
+                "; ".join(errors),
+            )
+        else:  # pragma: no cover - defensive
+            logger.warning(
+                "mDNS advertising disabled: no backend available. Install the 'zeroconf' "
+                "package or the 'avahi-utils' tools to enable motion.local announcements.",
+            )
+        return _NullAdvertiser()
+
+    # ------------------------------ control ----------------------------
+    def advertise(self, ip_address: str | None) -> None:
+        self._backend.advertise(ip_address)
+
+    def clear(self) -> None:
+        self._backend.clear()
+
+    def close(self) -> None:
+        self._backend.close()
 
 
 __all__ = ["MDNSAdvertiser"]

--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -99,6 +99,97 @@
         font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
         word-break: break-all;
       }
+      #wifi-section {
+        margin: 2rem 0 1.5rem;
+        padding: 1rem;
+        border-radius: 12px;
+        background: rgba(255, 255, 255, 0.04);
+      }
+      #wifi-section h2,
+      #wifi-section h3 {
+        margin-top: 0;
+      }
+      #wifi-summary {
+        margin: 0 0 0.75rem;
+        opacity: 0.85;
+      }
+      #wifi-controls {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 0.75rem;
+        margin-bottom: 0.75rem;
+      }
+      #wifi-controls label {
+        margin: 0;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        font-size: 0.95rem;
+      }
+      #wifi-feedback {
+        min-height: 1.2rem;
+        font-size: 0.9rem;
+        opacity: 0.85;
+      }
+      #wifi-feedback.error {
+        color: #ff6b6b;
+        opacity: 1;
+      }
+      #wifi-network-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+      }
+      .wifi-network {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+        padding: 0.85rem 1rem;
+        border-radius: 12px;
+        background: rgba(0, 0, 0, 0.35);
+      }
+      .wifi-network strong {
+        display: block;
+        font-size: 1rem;
+      }
+      .wifi-network span {
+        font-size: 0.9rem;
+        opacity: 0.8;
+      }
+      .wifi-network .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+      }
+      #wifi-connect-form {
+        margin-top: 1rem;
+        padding: 1rem;
+        border-radius: 12px;
+        background: rgba(255, 255, 255, 0.05);
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+      #wifi-connect-form[hidden] {
+        display: none;
+      }
+      #wifi-hotspot-section {
+        margin-top: 1.5rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+      #wifi-hotspot-section .button-group {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+      }
     </style>
   </head>
   <body>
@@ -125,6 +216,57 @@
         </button>
       </div>
       <code id="stream-url">—</code>
+    </section>
+    <section id="wifi-section">
+      <h2>Wi-Fi</h2>
+      <p id="wifi-summary">Loading…</p>
+      <div id="wifi-controls">
+        <button type="button" id="wifi-refresh" class="secondary-button">Refresh status</button>
+        <button type="button" id="wifi-scan">Scan networks</button>
+        <label>
+          <input type="checkbox" id="wifi-dev-mode" /> Development mode (auto-rollback)
+        </label>
+      </div>
+      <div id="wifi-feedback" role="status" aria-live="polite"></div>
+      <ul id="wifi-network-list"></ul>
+      <form id="wifi-connect-form" hidden>
+        <h3 style="margin: 0;">Connect to network</h3>
+        <p id="wifi-connect-selected" style="margin: 0; opacity: 0.85;"></p>
+        <input type="hidden" name="ssid" />
+        <label>
+          Password
+          <input type="password" name="password" autocomplete="current-password" />
+        </label>
+        <label>
+          Rollback timeout (seconds)
+          <input type="number" name="rollback" min="5" max="180" step="5" value="30" />
+        </label>
+        <div style="display: flex; gap: 0.5rem; flex-wrap: wrap;">
+          <button type="submit">Connect</button>
+          <button type="button" id="wifi-cancel-connect" class="secondary-button">Cancel</button>
+        </div>
+      </form>
+      <section id="wifi-hotspot-section">
+        <h3>Hotspot</h3>
+        <p id="wifi-hotspot-status" style="margin: 0; opacity: 0.85;">Hotspot disabled.</p>
+        <label>
+          Hotspot name
+          <input type="text" id="wifi-hotspot-ssid" placeholder="RevCam Hotspot" autocomplete="ssid" />
+        </label>
+        <label>
+          Hotspot password
+          <input
+            type="password"
+            id="wifi-hotspot-password"
+            placeholder="Optional (min 8 characters)"
+            autocomplete="new-password"
+          />
+        </label>
+        <div class="button-group">
+          <button type="button" id="wifi-enable-hotspot">Enable hotspot</button>
+          <button type="button" id="wifi-disable-hotspot" class="secondary-button">Disable hotspot</button>
+        </div>
+      </section>
     </section>
     <form id="orientation-form">
       <label>
@@ -167,6 +309,29 @@
       const copyStreamButton = document.getElementById("copy-stream-url");
       const copyButtonDefault = copyStreamButton ? copyStreamButton.textContent : "";
       let copyResetTimer = null;
+      const wifiSummary = document.getElementById("wifi-summary");
+      const wifiRefreshButton = document.getElementById("wifi-refresh");
+      const wifiScanButton = document.getElementById("wifi-scan");
+      const wifiFeedback = document.getElementById("wifi-feedback");
+      const wifiNetworkList = document.getElementById("wifi-network-list");
+      const wifiConnectForm = document.getElementById("wifi-connect-form");
+      const wifiConnectSelected = document.getElementById("wifi-connect-selected");
+      const wifiDevToggle = document.getElementById("wifi-dev-mode");
+      const wifiCancelConnect = document.getElementById("wifi-cancel-connect");
+      const wifiHotspotStatus = document.getElementById("wifi-hotspot-status");
+      const wifiHotspotSsid = document.getElementById("wifi-hotspot-ssid");
+      const wifiHotspotPassword = document.getElementById("wifi-hotspot-password");
+      const wifiEnableHotspot = document.getElementById("wifi-enable-hotspot");
+      const wifiDisableHotspot = document.getElementById("wifi-disable-hotspot");
+      const wifiConnectSsidInput = wifiConnectForm
+        ? wifiConnectForm.querySelector('input[name="ssid"]')
+        : null;
+      const wifiConnectPasswordInput = wifiConnectForm
+        ? wifiConnectForm.querySelector('input[name="password"]')
+        : null;
+      const wifiRollbackInput = wifiConnectForm
+        ? wifiConnectForm.querySelector('input[name="rollback"]')
+        : null;
 
       function describeCameraErrors(camera) {
         if (!camera || !camera.errors) {
@@ -190,6 +355,324 @@
           descriptions.push(combined);
         }
         return descriptions;
+      }
+
+      function formatSignalValue(signal) {
+        if (typeof signal !== "number" || Number.isNaN(signal)) {
+          return "—";
+        }
+        return `${signal}%`;
+      }
+
+      function summariseWifiStatus(status) {
+        if (!status) {
+          return "Wi-Fi status unavailable.";
+        }
+        const pieces = [];
+        const name = status.ssid || status.profile || "network";
+        if (status.hotspot_active) {
+          pieces.push(`Hotspot active (${name})`);
+          if (status.ip_address) {
+            pieces.push(`IP ${status.ip_address}`);
+          }
+        } else if (status.connected) {
+          const signalText = formatSignalValue(status.signal);
+          pieces.push(`Connected to ${name}${signalText !== "—" ? ` (${signalText})` : ""}`);
+          if (status.ip_address) {
+            pieces.push(`IP ${status.ip_address}`);
+          }
+        } else {
+          pieces.push("Not connected to Wi-Fi.");
+        }
+        if (status.detail) {
+          pieces.push(status.detail);
+        }
+        if (status.error) {
+          pieces.push(`Error: ${status.error}`);
+        }
+        return pieces.join(" ");
+      }
+
+      function setWifiFeedback(message, isError = false) {
+        if (!wifiFeedback) {
+          return;
+        }
+        wifiFeedback.textContent = message || "";
+        if (isError) {
+          wifiFeedback.classList.add("error");
+        } else {
+          wifiFeedback.classList.remove("error");
+        }
+      }
+
+      function hideWifiConnectForm() {
+        if (!wifiConnectForm) {
+          return;
+        }
+        wifiConnectForm.hidden = true;
+        if (wifiConnectSelected) {
+          wifiConnectSelected.textContent = "";
+        }
+        if (wifiConnectPasswordInput) {
+          wifiConnectPasswordInput.value = "";
+        }
+      }
+
+      function renderWifiNetworks(networks) {
+        if (!wifiNetworkList) {
+          return;
+        }
+        wifiNetworkList.innerHTML = "";
+        if (!Array.isArray(networks) || networks.length === 0) {
+          const empty = document.createElement("li");
+          empty.className = "wifi-network";
+          empty.textContent = "No Wi-Fi networks detected.";
+          wifiNetworkList.appendChild(empty);
+          return;
+        }
+        for (const network of networks) {
+          const item = document.createElement("li");
+          item.className = "wifi-network";
+          const info = document.createElement("div");
+          info.style.minWidth = "12rem";
+          const name = document.createElement("strong");
+          const ssid = typeof network.ssid === "string" && network.ssid.trim()
+            ? network.ssid.trim()
+            : "(hidden network)";
+          name.textContent = ssid;
+          info.appendChild(name);
+          const details = document.createElement("span");
+          const detailParts = [];
+          if (typeof network.signal === "number" && !Number.isNaN(network.signal)) {
+            detailParts.push(`${network.signal}%`);
+          }
+          if (network.security && typeof network.security === "string") {
+            detailParts.push(network.security);
+          }
+          if (network.frequency) {
+            const freqText = `${network.frequency} MHz`;
+            if (network.channel) {
+              detailParts.push(`${freqText} (ch ${network.channel})`);
+            } else {
+              detailParts.push(freqText);
+            }
+          }
+          if (network.known) {
+            detailParts.push("saved");
+          }
+          if (network.active) {
+            detailParts.push("active");
+          }
+          details.textContent = detailParts.length ? detailParts.join(" • ") : "Details unavailable";
+          info.appendChild(details);
+          item.appendChild(info);
+          const actions = document.createElement("div");
+          actions.className = "actions";
+          const connectButton = document.createElement("button");
+          connectButton.type = "button";
+          if (network.active) {
+            connectButton.textContent = "Connected";
+            connectButton.disabled = true;
+          } else if (network.hidden) {
+            connectButton.textContent = "Hidden network";
+            connectButton.disabled = true;
+          } else {
+            connectButton.textContent = "Connect";
+            connectButton.addEventListener("click", () => {
+              if (!wifiConnectForm || !wifiConnectSsidInput || !wifiConnectSelected) {
+                return;
+              }
+              wifiConnectForm.hidden = false;
+              wifiConnectSsidInput.value = ssid;
+              wifiConnectSelected.textContent = `Selected network: ${ssid}`;
+              if (wifiConnectPasswordInput) {
+                wifiConnectPasswordInput.value = "";
+                wifiConnectPasswordInput.placeholder = network.security
+                  ? `Security: ${network.security}`
+                  : "Password (if required)";
+              }
+              if (wifiRollbackInput && typeof wifiRollbackInput.value === "string" && !wifiRollbackInput.value) {
+                wifiRollbackInput.value = "30";
+              }
+            });
+          }
+          actions.appendChild(connectButton);
+          item.appendChild(actions);
+          wifiNetworkList.appendChild(item);
+        }
+      }
+
+      async function refreshWifiStatus() {
+        if (!wifiSummary) {
+          return null;
+        }
+        try {
+          const response = await fetch("/api/wifi/status");
+          if (!response.ok) {
+            throw new Error("Unable to fetch Wi-Fi status");
+          }
+          const status = await response.json();
+          wifiSummary.textContent = summariseWifiStatus(status);
+          if (wifiHotspotStatus) {
+            if (status.hotspot_active) {
+              const hotspotName = status.ssid || status.profile || "Hotspot";
+              wifiHotspotStatus.textContent = `Hotspot active (${hotspotName})`;
+            } else {
+              wifiHotspotStatus.textContent = "Hotspot disabled.";
+            }
+          }
+          if (status.detail) {
+            setWifiFeedback(status.detail, false);
+          } else if (!wifiFeedback || !wifiFeedback.textContent) {
+            setWifiFeedback("", false);
+          }
+          return status;
+        } catch (err) {
+          console.error(err);
+          if (wifiSummary) {
+            const message = err instanceof Error ? err.message : "Wi-Fi status unavailable.";
+            wifiSummary.textContent = message;
+          }
+          return null;
+        }
+      }
+
+      async function scanWifiNetworks() {
+        if (!wifiNetworkList) {
+          return;
+        }
+        setWifiFeedback("Scanning for Wi-Fi networks…");
+        try {
+          const response = await fetch("/api/wifi/networks");
+          if (!response.ok) {
+            throw new Error("Unable to scan Wi-Fi networks");
+          }
+          const data = await response.json();
+          const networks = Array.isArray(data.networks) ? data.networks : [];
+          renderWifiNetworks(networks);
+          if (networks.length) {
+            setWifiFeedback(`Found ${networks.length} network${networks.length === 1 ? "" : "s"}.`);
+          } else {
+            setWifiFeedback("No Wi-Fi networks detected. Try scanning again.");
+          }
+        } catch (err) {
+          console.error(err);
+          setWifiFeedback("Unable to scan Wi-Fi networks.", true);
+        }
+      }
+
+      async function connectToWifi() {
+        if (!wifiConnectForm || !wifiConnectSsidInput) {
+          return;
+        }
+        const ssid = wifiConnectSsidInput.value.trim();
+        if (!ssid) {
+          setWifiFeedback("Select a Wi-Fi network before connecting.", true);
+          return;
+        }
+        const payload = {
+          ssid,
+          development_mode: wifiDevToggle ? !!wifiDevToggle.checked : false,
+        };
+        if (wifiConnectPasswordInput && wifiConnectPasswordInput.value) {
+          payload.password = wifiConnectPasswordInput.value;
+        }
+        if (wifiRollbackInput) {
+          const rollback = parseFloat(wifiRollbackInput.value);
+          if (!Number.isNaN(rollback) && rollback > 0) {
+            payload.rollback_seconds = rollback;
+          }
+        }
+        setWifiFeedback(`Connecting to ${ssid}…`);
+        try {
+          const response = await fetch("/api/wifi/connect", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(payload),
+          });
+          if (!response.ok) {
+            let errorDetail = "Unable to connect to Wi-Fi network.";
+            try {
+              const error = await response.json();
+              if (error && error.detail) {
+                errorDetail = error.detail;
+              }
+            } catch (parseErr) {
+              console.error(parseErr);
+            }
+            setWifiFeedback(errorDetail, true);
+            return;
+          }
+          const status = await response.json();
+          const successMessage = status.detail
+            ? status.detail
+            : `Joined ${status.ssid || ssid}.`;
+          setWifiFeedback(successMessage);
+          hideWifiConnectForm();
+          await refreshWifiStatus();
+          await scanWifiNetworks();
+        } catch (err) {
+          console.error(err);
+          setWifiFeedback("Connection attempt failed.", true);
+        }
+      }
+
+      async function toggleHotspot(enabled) {
+        let payload = { enabled };
+        if (enabled) {
+          const ssidValue = wifiHotspotSsid && typeof wifiHotspotSsid.value === "string"
+            ? wifiHotspotSsid.value.trim()
+            : "";
+          const passwordValue = wifiHotspotPassword && typeof wifiHotspotPassword.value === "string"
+            ? wifiHotspotPassword.value.trim()
+            : "";
+          if (passwordValue && passwordValue.length < 8) {
+            setWifiFeedback("Hotspot password must contain at least 8 characters.", true);
+            return;
+          }
+          payload = {
+            enabled: true,
+            ssid: ssidValue || undefined,
+          };
+          if (passwordValue) {
+            payload.password = passwordValue;
+          }
+          setWifiFeedback("Enabling hotspot…");
+        } else {
+          payload = { enabled: false };
+          setWifiFeedback("Disabling hotspot…");
+        }
+        try {
+          const response = await fetch("/api/wifi/hotspot", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(payload),
+          });
+          if (!response.ok) {
+            let errorDetail = enabled ? "Unable to enable hotspot." : "Unable to disable hotspot.";
+            try {
+              const error = await response.json();
+              if (error && error.detail) {
+                errorDetail = error.detail;
+              }
+            } catch (parseErr) {
+              console.error(parseErr);
+            }
+            setWifiFeedback(errorDetail, true);
+            return;
+          }
+          const status = await response.json();
+          const detailMessage = status.detail
+            ? status.detail
+            : enabled
+            ? "Hotspot enabled."
+            : "Hotspot disabled.";
+          setWifiFeedback(detailMessage);
+          await refreshWifiStatus();
+        } catch (err) {
+          console.error(err);
+          setWifiFeedback(enabled ? "Unable to enable hotspot." : "Unable to disable hotspot.", true);
+        }
       }
 
       function updateVersion(camera) {
@@ -417,6 +900,43 @@
         });
       }
 
+      if (wifiRefreshButton) {
+        wifiRefreshButton.addEventListener("click", () => {
+          refreshWifiStatus().catch((err) => console.error(err));
+        });
+      }
+
+      if (wifiScanButton) {
+        wifiScanButton.addEventListener("click", () => {
+          scanWifiNetworks().catch((err) => console.error(err));
+        });
+      }
+
+      if (wifiCancelConnect) {
+        wifiCancelConnect.addEventListener("click", () => {
+          hideWifiConnectForm();
+        });
+      }
+
+      if (wifiConnectForm) {
+        wifiConnectForm.addEventListener("submit", (event) => {
+          event.preventDefault();
+          connectToWifi().catch((err) => console.error(err));
+        });
+      }
+
+      if (wifiEnableHotspot) {
+        wifiEnableHotspot.addEventListener("click", () => {
+          toggleHotspot(true).catch((err) => console.error(err));
+        });
+      }
+
+      if (wifiDisableHotspot) {
+        wifiDisableHotspot.addEventListener("click", () => {
+          toggleHotspot(false).catch((err) => console.error(err));
+        });
+      }
+
       async function fetchSettings() {
         const [orientationResponse, cameraResponse] = await Promise.all([
           fetch("/api/orientation"),
@@ -512,6 +1032,18 @@
         console.error(err);
         statusLabel.textContent = err.message;
       });
+
+      refreshWifiStatus().catch((err) => {
+        console.error(err);
+        if (wifiSummary) {
+          const message = err instanceof Error ? err.message : "Wi-Fi status unavailable.";
+          wifiSummary.textContent = message;
+        }
+      });
+
+      if (wifiNetworkList) {
+        scanWifiNetworks().catch((err) => console.error(err));
+      }
     </script>
   </body>
 </html>

--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -248,6 +248,9 @@
       </form>
       <section id="wifi-hotspot-section">
         <h3>Hotspot</h3>
+        <p style="margin: 0 0 0.5rem; opacity: 0.75;">
+          Development mode auto-rollback applies when enabling the hotspot.
+        </p>
         <p id="wifi-hotspot-status" style="margin: 0; opacity: 0.85;">Hotspot disabled.</p>
         <label>
           Hotspot name
@@ -633,9 +636,16 @@
           payload = {
             enabled: true,
             ssid: ssidValue || undefined,
+            development_mode: wifiDevToggle ? !!wifiDevToggle.checked : false,
           };
           if (passwordValue) {
             payload.password = passwordValue;
+          }
+          if (wifiRollbackInput) {
+            const rollback = parseFloat(wifiRollbackInput.value);
+            if (!Number.isNaN(rollback) && rollback > 0) {
+              payload.rollback_seconds = rollback;
+            }
           }
           setWifiFeedback("Enabling hotspot…");
         } else {

--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -335,6 +335,8 @@
       const wifiRollbackInput = wifiConnectForm
         ? wifiConnectForm.querySelector('input[name="rollback"]')
         : null;
+      const HOTSPOT_HOSTNAME = "motion.local";
+      const HOTSPOT_DEV_ROLLBACK_DEFAULT = 120;
 
       function describeCameraErrors(camera) {
         if (!camera || !camera.errors) {
@@ -378,6 +380,7 @@
           if (status.ip_address) {
             pieces.push(`IP ${status.ip_address}`);
           }
+          pieces.push(`Visit http://${HOTSPOT_HOSTNAME}:9000/`);
         } else if (status.connected) {
           const signalText = formatSignalValue(status.signal);
           pieces.push(`Connected to ${name}${signalText !== "—" ? ` (${signalText})` : ""}`);
@@ -519,7 +522,12 @@
           if (wifiHotspotStatus) {
             if (status.hotspot_active) {
               const hotspotName = status.ssid || status.profile || "Hotspot";
-              wifiHotspotStatus.textContent = `Hotspot active (${hotspotName})`;
+              const pieces = [`Hotspot active (${hotspotName})`];
+              if (status.ip_address) {
+                pieces.push(`IP ${status.ip_address}`);
+              }
+              pieces.push(`Visit http://${HOTSPOT_HOSTNAME}:9000/`);
+              wifiHotspotStatus.textContent = pieces.join(" • ");
             } else {
               wifiHotspotStatus.textContent = "Hotspot disabled.";
             }
@@ -633,19 +641,31 @@
             setWifiFeedback("Hotspot password must contain at least 8 characters.", true);
             return;
           }
+          const devModeEnabled = wifiDevToggle ? !!wifiDevToggle.checked : false;
           payload = {
             enabled: true,
             ssid: ssidValue || undefined,
-            development_mode: wifiDevToggle ? !!wifiDevToggle.checked : false,
+            development_mode: devModeEnabled,
           };
           if (passwordValue) {
             payload.password = passwordValue;
           }
-          if (wifiRollbackInput) {
-            const rollback = parseFloat(wifiRollbackInput.value);
-            if (!Number.isNaN(rollback) && rollback > 0) {
-              payload.rollback_seconds = rollback;
+          let rollbackSeconds = null;
+          let userProvidedRollback = NaN;
+          if (wifiRollbackInput && wifiRollbackInput.dataset.userEdited === "true") {
+            userProvidedRollback = parseFloat(wifiRollbackInput.value);
+          }
+          if (devModeEnabled) {
+            if (!Number.isNaN(userProvidedRollback) && userProvidedRollback > 0) {
+              rollbackSeconds = userProvidedRollback;
+            } else {
+              rollbackSeconds = HOTSPOT_DEV_ROLLBACK_DEFAULT;
             }
+          } else if (!Number.isNaN(userProvidedRollback) && userProvidedRollback > 0) {
+            rollbackSeconds = userProvidedRollback;
+          }
+          if (typeof rollbackSeconds === "number" && rollbackSeconds > 0) {
+            payload.rollback_seconds = rollbackSeconds;
           }
           setWifiFeedback("Enabling hotspot…");
         } else {
@@ -675,7 +695,7 @@
           const detailMessage = status.detail
             ? status.detail
             : enabled
-            ? "Hotspot enabled."
+            ? `Hotspot enabled. Connect via http://${HOTSPOT_HOSTNAME}:9000/.`
             : "Hotspot disabled.";
           setWifiFeedback(detailMessage);
           await refreshWifiStatus();
@@ -932,6 +952,12 @@
         wifiConnectForm.addEventListener("submit", (event) => {
           event.preventDefault();
           connectToWifi().catch((err) => console.error(err));
+        });
+      }
+
+      if (wifiRollbackInput) {
+        wifiRollbackInput.addEventListener("input", () => {
+          wifiRollbackInput.dataset.userEdited = "true";
         });
       }
 

--- a/src/rev_cam/version.py
+++ b/src/rev_cam/version.py
@@ -1,6 +1,6 @@
 """Application version metadata."""
 
-APP_VERSION = "0.2.0"
+APP_VERSION = "0.2.1"
 """Human readable application version displayed in the UI."""
 
 __all__ = ["APP_VERSION"]

--- a/src/rev_cam/version.py
+++ b/src/rev_cam/version.py
@@ -1,6 +1,6 @@
 """Application version metadata."""
 
-APP_VERSION = "0.2.1"
+APP_VERSION = "0.2.2"
 """Human readable application version displayed in the UI."""
 
 __all__ = ["APP_VERSION"]

--- a/src/rev_cam/wifi.py
+++ b/src/rev_cam/wifi.py
@@ -1,0 +1,450 @@
+"""Wi-Fi management utilities with safe fallbacks for RevCam."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+import subprocess
+import time
+from typing import Iterable, Sequence
+
+
+class WiFiError(RuntimeError):
+    """Raised when Wi-Fi operations fail."""
+
+
+def _channel_from_frequency(freq_mhz: float | None) -> int | None:
+    """Best-effort conversion from MHz to Wi-Fi channel numbers."""
+
+    if freq_mhz is None or freq_mhz <= 0:
+        return None
+    # IEEE 802.11 2.4 GHz channels use a 5 MHz spacing starting at 2412 MHz.
+    if 2400 <= freq_mhz <= 2500:
+        channel = int(round((freq_mhz - 2407) / 5))
+        if 1 <= channel <= 14:
+            return channel
+        return None
+    # 5 GHz allocations start around 5035 MHz depending on the regulatory domain.
+    if 4900 <= freq_mhz <= 5900:
+        channel = int(round((freq_mhz - 5000) / 5))
+        if channel > 0:
+            return channel
+        return None
+    return None
+
+
+@dataclass(slots=True)
+class WiFiNetwork:
+    """Represents a Wi-Fi network discovered during a scan."""
+
+    ssid: str
+    signal: int | None = None
+    security: str | None = None
+    frequency: float | None = None
+    channel: int | None = None
+    known: bool = False
+    active: bool = False
+    hidden: bool = False
+
+    def to_dict(self) -> dict[str, object | None]:
+        return {
+            "ssid": self.ssid,
+            "signal": self.signal,
+            "security": self.security,
+            "frequency": self.frequency,
+            "channel": self.channel,
+            "known": self.known,
+            "active": self.active,
+            "hidden": self.hidden,
+        }
+
+
+@dataclass(slots=True)
+class WiFiStatus:
+    """Represents the current Wi-Fi connection state."""
+
+    connected: bool
+    ssid: str | None
+    signal: int | None
+    ip_address: str | None
+    mode: str = "unknown"
+    hotspot_active: bool = False
+    profile: str | None = None
+    error: str | None = None
+    detail: str | None = None
+
+    def to_dict(self) -> dict[str, object | None]:
+        return {
+            "connected": self.connected,
+            "ssid": self.ssid,
+            "signal": self.signal,
+            "ip_address": self.ip_address,
+            "mode": self.mode,
+            "hotspot_active": self.hotspot_active,
+            "profile": self.profile,
+            "error": self.error,
+            "detail": self.detail,
+        }
+
+
+class WiFiBackend:
+    """Abstract interface for Wi-Fi operations."""
+
+    def get_status(self) -> WiFiStatus:  # pragma: no cover - interface only
+        raise NotImplementedError
+
+    def scan(self) -> Sequence[WiFiNetwork]:  # pragma: no cover - interface only
+        raise NotImplementedError
+
+    def connect(self, ssid: str, password: str | None) -> WiFiStatus:  # pragma: no cover - interface only
+        raise NotImplementedError
+
+    def activate_profile(self, profile: str) -> WiFiStatus:  # pragma: no cover - interface only
+        raise NotImplementedError
+
+    def start_hotspot(self, ssid: str, password: str | None) -> WiFiStatus:  # pragma: no cover - interface only
+        raise NotImplementedError
+
+    def stop_hotspot(self, profile: str | None) -> WiFiStatus:  # pragma: no cover - interface only
+        raise NotImplementedError
+
+
+class NMCLIBackend(WiFiBackend):
+    """Interact with NetworkManager via nmcli commands."""
+
+    def __init__(self, interface: str | None = None, *, timeout: float = 15.0) -> None:
+        self._preferred_interface = interface
+        self._timeout = timeout
+        self._detected_interface: str | None = None
+        self._last_hotspot_profile: str | None = None
+
+    # ------------------------------- helpers -------------------------------
+    def _run(self, args: Sequence[str]) -> str:
+        try:
+            completed = subprocess.run(
+                list(args),
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=self._timeout,
+            )
+        except FileNotFoundError as exc:  # pragma: no cover - environment specific
+            raise WiFiError("nmcli command unavailable") from exc
+        except subprocess.TimeoutExpired as exc:  # pragma: no cover - environment specific
+            raise WiFiError("nmcli command timed out") from exc
+        except subprocess.CalledProcessError as exc:
+            error_output = exc.stderr.strip() or exc.stdout.strip() or str(exc)
+            raise WiFiError(error_output)
+        return completed.stdout
+
+    def _detect_interface(self) -> str:
+        if self._preferred_interface:
+            return self._preferred_interface
+        if self._detected_interface:
+            return self._detected_interface
+        output = self._run(["nmcli", "-t", "-f", "DEVICE,TYPE,STATE", "device"])
+        for line in output.splitlines():
+            if not line.strip():
+                continue
+            parts = line.split(":")
+            if len(parts) < 3:
+                continue
+            device, dev_type, state = parts[:3]
+            if dev_type.strip() == "wifi" and state.strip() != "unavailable":
+                self._detected_interface = device.strip()
+                return self._detected_interface
+        raise WiFiError("No Wi-Fi interface detected")
+
+    def _get_interface(self) -> str:
+        return self._preferred_interface or self._detect_interface()
+
+    def _parse_saved_profiles(self) -> set[str]:
+        try:
+            output = self._run(["nmcli", "-t", "-f", "NAME,TYPE", "connection", "show"])
+        except WiFiError:
+            return set()
+        profiles: set[str] = set()
+        for line in output.splitlines():
+            if not line.strip():
+                continue
+            parts = line.split(":")
+            if len(parts) < 2:
+                continue
+            name, conn_type = parts[0].strip(), parts[1].strip()
+            if conn_type == "802-11-wireless" and name:
+                profiles.add(name)
+        return profiles
+
+    def _scan_output(self, *, rescan: bool = False) -> Iterable[WiFiNetwork]:
+        interface = self._get_interface()
+        args = [
+            "nmcli",
+            "-t",
+            "-f",
+            "IN-USE,SSID,SIGNAL,SECURITY,FREQ",
+            "device",
+            "wifi",
+            "list",
+            "ifname",
+            interface,
+        ]
+        if rescan:
+            args.extend(["--rescan", "yes"])
+        output = self._run(args)
+        saved = self._parse_saved_profiles()
+        for line in output.splitlines():
+            if not line.strip():
+                continue
+            parts = line.split(":")
+            while len(parts) < 5:
+                parts.append("")
+            in_use, ssid_raw, signal_raw, security_raw, freq_raw = parts[:5]
+            ssid = ssid_raw.strip()
+            hidden = not bool(ssid)
+            if hidden:
+                ssid = "(hidden network)"
+            signal = None
+            if signal_raw.strip():
+                try:
+                    signal = int(float(signal_raw.strip()))
+                except ValueError:
+                    signal = None
+            frequency = None
+            if freq_raw.strip():
+                freq_text = freq_raw.strip().split()[0]
+                try:
+                    frequency = float(freq_text)
+                except ValueError:
+                    frequency = None
+            security = security_raw.strip() or "unknown"
+            network = WiFiNetwork(
+                ssid=ssid,
+                signal=signal,
+                security=security,
+                frequency=frequency,
+                channel=_channel_from_frequency(frequency),
+                known=ssid_raw.strip() in saved,
+                active=in_use.strip() in {"*", "yes"},
+                hidden=hidden,
+            )
+            yield network
+
+    # ---------------------------- interface impl ---------------------------
+    def get_status(self) -> WiFiStatus:
+        interface = self._get_interface()
+        output = self._run(
+            [
+                "nmcli",
+                "-t",
+                "-f",
+                "GENERAL.STATE,GENERAL.CONNECTION,IP4.ADDRESS",
+                "device",
+                "show",
+                interface,
+            ]
+        )
+        details: dict[str, str] = {}
+        for line in output.splitlines():
+            if ":" not in line:
+                continue
+            key, value = line.split(":", 1)
+            details[key.strip()] = value.strip()
+        state_text = details.get("GENERAL.STATE", "")
+        connected = "connected" in state_text.lower() or state_text.startswith("100")
+        connection_name = details.get("GENERAL.CONNECTION") or None
+        ip_raw = details.get("IP4.ADDRESS[1]") or details.get("IP4.ADDRESS")
+        ip_address = None
+        if ip_raw:
+            ip_address = ip_raw.split("/")[0].strip()
+        signal = None
+        ssid = connection_name
+        for network in self._scan_output(rescan=False):
+            if network.active:
+                ssid = network.ssid if not network.hidden else connection_name
+                signal = network.signal
+                break
+        mode = "unknown"
+        hotspot_active = False
+        if connection_name:
+            try:
+                mode_output = self._run(
+                    [
+                        "nmcli",
+                        "-t",
+                        "-f",
+                        "802-11-wireless.mode",
+                        "connection",
+                        "show",
+                        connection_name,
+                    ]
+                )
+            except WiFiError:
+                mode_output = ""
+            for line in mode_output.splitlines():
+                if line.startswith("802-11-wireless.mode:"):
+                    mode_value = line.split(":", 1)[1].strip().lower()
+                    if mode_value == "ap":
+                        mode = "access-point"
+                        hotspot_active = True
+                    elif mode_value:
+                        mode = "station"
+                    break
+        status = WiFiStatus(
+            connected=connected,
+            ssid=ssid,
+            signal=signal,
+            ip_address=ip_address,
+            mode=mode,
+            hotspot_active=hotspot_active,
+            profile=connection_name,
+        )
+        if hotspot_active and connection_name:
+            self._last_hotspot_profile = connection_name
+        return status
+
+    def scan(self) -> Sequence[WiFiNetwork]:
+        return list(self._scan_output(rescan=True))
+
+    def connect(self, ssid: str, password: str | None) -> WiFiStatus:
+        interface = self._get_interface()
+        args = ["nmcli", "device", "wifi", "connect", ssid]
+        if password:
+            args.extend(["password", password])
+        args.extend(["ifname", interface])
+        self._run(args)
+        return self.get_status()
+
+    def activate_profile(self, profile: str) -> WiFiStatus:
+        interface = self._get_interface()
+        args = ["nmcli", "connection", "up", profile]
+        args.extend(["ifname", interface])
+        self._run(args)
+        return self.get_status()
+
+    def start_hotspot(self, ssid: str, password: str | None) -> WiFiStatus:
+        interface = self._get_interface()
+        connection_name = "RevCam Hotspot"
+        args = [
+            "nmcli",
+            "device",
+            "wifi",
+            "hotspot",
+            "ifname",
+            interface,
+            "con-name",
+            connection_name,
+            "ssid",
+            ssid,
+        ]
+        if password:
+            args.extend(["password", password])
+        self._run(args)
+        status = self.get_status()
+        status.profile = connection_name
+        status.mode = "access-point"
+        status.hotspot_active = True
+        self._last_hotspot_profile = connection_name
+        return status
+
+    def stop_hotspot(self, profile: str | None) -> WiFiStatus:
+        connection_name = profile or self._last_hotspot_profile or "RevCam Hotspot"
+        try:
+            self._run(["nmcli", "connection", "down", connection_name])
+        except WiFiError:
+            # If the connection is already down, ignore and continue with status refresh.
+            pass
+        status = self.get_status()
+        if not status.hotspot_active:
+            self._last_hotspot_profile = None
+        return status
+
+
+class WiFiManager:
+    """High-level orchestration with rollback for development mode."""
+
+    def __init__(
+        self,
+        backend: WiFiBackend | None = None,
+        *,
+        rollback_timeout: float = 30.0,
+        poll_interval: float = 1.0,
+    ) -> None:
+        self._backend = backend or NMCLIBackend()
+        self._rollback_timeout = rollback_timeout
+        self._poll_interval = max(0.1, poll_interval)
+        self._hotspot_profile: str | None = None
+
+    # ------------------------------ operations -----------------------------
+    def get_status(self) -> WiFiStatus:
+        return self._backend.get_status()
+
+    def scan_networks(self) -> Sequence[WiFiNetwork]:
+        return self._backend.scan()
+
+    def connect(
+        self,
+        ssid: str,
+        password: str | None = None,
+        *,
+        development_mode: bool = False,
+        rollback_timeout: float | None = None,
+    ) -> WiFiStatus:
+        if not isinstance(ssid, str) or not ssid.strip():
+            raise WiFiError("SSID must be a non-empty string")
+        cleaned_ssid = ssid.strip()
+        previous_status = self._backend.get_status()
+        previous_profile = previous_status.profile if previous_status.connected else None
+        status = self._backend.connect(cleaned_ssid, password)
+        if not development_mode:
+            return status
+        timeout = self._rollback_timeout if rollback_timeout is None else max(0.0, rollback_timeout)
+        if timeout <= 0:
+            return status
+        if status.connected and (status.ssid == cleaned_ssid or status.profile == cleaned_ssid):
+            return status
+        if not previous_profile:
+            detail = status.detail or ""
+            status.detail = (
+                f"{detail + ' ' if detail else ''}Development rollback skipped; previous network unknown."
+            )
+            return status
+        deadline = time.monotonic() + timeout
+        current = status
+        while time.monotonic() < deadline:
+            if current.connected and (current.ssid == cleaned_ssid or current.profile == cleaned_ssid):
+                return current
+            time.sleep(self._poll_interval)
+            current = self._backend.get_status()
+        restored = self._backend.activate_profile(previous_profile)
+        restored.detail = (
+            f"Connection to {cleaned_ssid} did not establish within {int(math.ceil(timeout))}s; "
+            f"restored {previous_status.ssid or previous_profile}."
+        )
+        return restored
+
+    def enable_hotspot(self, ssid: str, password: str | None = None) -> WiFiStatus:
+        if not isinstance(ssid, str) or not ssid.strip():
+            raise WiFiError("Hotspot SSID must be provided")
+        cleaned_ssid = ssid.strip()
+        if password is not None and password.strip() and len(password.strip()) < 8:
+            raise WiFiError("Hotspot password must be at least 8 characters")
+        cleaned_password = password.strip() if isinstance(password, str) and password.strip() else None
+        status = self._backend.start_hotspot(cleaned_ssid, cleaned_password)
+        self._hotspot_profile = status.profile or self._hotspot_profile
+        return status
+
+    def disable_hotspot(self) -> WiFiStatus:
+        status = self._backend.stop_hotspot(self._hotspot_profile)
+        if not status.hotspot_active:
+            self._hotspot_profile = None
+        return status
+
+
+__all__ = [
+    "WiFiError",
+    "WiFiNetwork",
+    "WiFiStatus",
+    "WiFiBackend",
+    "NMCLIBackend",
+    "WiFiManager",
+]

--- a/tests/test_app_wifi.py
+++ b/tests/test_app_wifi.py
@@ -1,0 +1,177 @@
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("httpx")
+
+from fastapi.testclient import TestClient
+
+from rev_cam.app import create_app
+from rev_cam.wifi import WiFiManager, WiFiNetwork, WiFiStatus
+
+
+class FakeWiFiBackend:
+    def __init__(self) -> None:
+        self.connect_attempts: list[tuple[str, str | None]] = []
+        self.status = WiFiStatus(
+            connected=True,
+            ssid="Home",
+            signal=75,
+            ip_address="192.168.1.10",
+            mode="station",
+            hotspot_active=False,
+            profile="Home",
+            detail="Connected",
+        )
+        self.networks = [
+            WiFiNetwork(
+                ssid="Home",
+                signal=75,
+                security="WPA2",
+                frequency=2412.0,
+                channel=1,
+                known=True,
+                active=True,
+            ),
+            WiFiNetwork(
+                ssid="Guest",
+                signal=55,
+                security="WPA2",
+                frequency=2417.0,
+                channel=2,
+                known=False,
+                active=False,
+            ),
+        ]
+
+    def get_status(self) -> WiFiStatus:
+        return self.status
+
+    def scan(self) -> list[WiFiNetwork]:
+        return list(self.networks)
+
+    def connect(self, ssid: str, password: str | None) -> WiFiStatus:
+        self.connect_attempts.append((ssid, password))
+        if ssid == "Guest":
+            # Simulate an authentication issue that leaves us disconnected.
+            self.status = WiFiStatus(
+                connected=False,
+                ssid=None,
+                signal=None,
+                ip_address=None,
+                mode="station",
+                hotspot_active=False,
+                profile=None,
+                detail="Authentication failed",
+            )
+        else:
+            self.status = WiFiStatus(
+                connected=True,
+                ssid=ssid,
+                signal=60,
+                ip_address="192.168.1.20",
+                mode="station",
+                hotspot_active=False,
+                profile=ssid,
+                detail=f"Connected to {ssid}",
+            )
+        return self.status
+
+    def activate_profile(self, profile: str) -> WiFiStatus:
+        # Record the rollback attempt.
+        self.connect_attempts.append((profile, None))
+        self.status = WiFiStatus(
+            connected=True,
+            ssid="Home",
+            signal=80,
+            ip_address="192.168.1.10",
+            mode="station",
+            hotspot_active=False,
+            profile="Home",
+            detail="Restored previous connection",
+        )
+        return self.status
+
+    def start_hotspot(self, ssid: str, password: str | None) -> WiFiStatus:
+        self.status = WiFiStatus(
+            connected=True,
+            ssid=ssid or "RevCam Hotspot",
+            signal=None,
+            ip_address="192.168.4.1",
+            mode="access-point",
+            hotspot_active=True,
+            profile="rev-hotspot",
+            detail="Hotspot enabled",
+        )
+        return self.status
+
+    def stop_hotspot(self, profile: str | None) -> WiFiStatus:
+        self.status = WiFiStatus(
+            connected=False,
+            ssid=None,
+            signal=None,
+            ip_address=None,
+            mode="station",
+            hotspot_active=False,
+            profile=None,
+            detail="Hotspot disabled",
+        )
+        return self.status
+
+
+@pytest.fixture
+def wifi_backend() -> FakeWiFiBackend:
+    return FakeWiFiBackend()
+
+
+@pytest.fixture
+def client(tmp_path: Path, wifi_backend: FakeWiFiBackend) -> TestClient:
+    manager = WiFiManager(backend=wifi_backend, rollback_timeout=0.05, poll_interval=0.005)
+    app = create_app(tmp_path / "config.json", wifi_manager=manager)
+    with TestClient(app) as test_client:
+        test_client.backend = wifi_backend
+        yield test_client
+
+
+def test_wifi_status_endpoint(client: TestClient) -> None:
+    response = client.get("/api/wifi/status")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["connected"] is True
+    assert payload["ssid"] == "Home"
+    assert payload["hotspot_active"] is False
+
+
+def test_wifi_scan_endpoint(client: TestClient) -> None:
+    response = client.get("/api/wifi/networks")
+    assert response.status_code == 200
+    payload = response.json()
+    assert "networks" in payload
+    assert any(network.get("active") for network in payload["networks"])
+
+
+def test_wifi_connect_development_mode_rolls_back(client: TestClient) -> None:
+    response = client.post(
+        "/api/wifi/connect",
+        json={"ssid": "Guest", "development_mode": True, "rollback_seconds": 0.05},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert "restored" in (payload.get("detail") or "").lower()
+    backend = getattr(client, "backend", None)
+    assert backend is not None
+    assert backend.connect_attempts[0][0] == "Guest"
+    assert backend.connect_attempts[1][0] == "Home"
+
+
+def test_wifi_hotspot_toggle(client: TestClient) -> None:
+    enable = client.post(
+        "/api/wifi/hotspot",
+        json={"enabled": True, "ssid": "RevCam-AP", "password": "secret123"},
+    )
+    assert enable.status_code == 200
+    assert enable.json()["hotspot_active"] is True
+
+    disable = client.post("/api/wifi/hotspot", json={"enabled": False})
+    assert disable.status_code == 200
+    assert disable.json()["hotspot_active"] is False


### PR DESCRIPTION
## Summary
- add a Wi-Fi management module with an nmcli-backed backend, rollback-aware connection logic, and hotspot helpers
- expose Wi-Fi status, network scan, connection, and hotspot FastAPI endpoints and wire them into the app factory
- expand the settings page with Wi-Fi controls, automatic status refresh, and development-mode rollback handling plus new API tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce9e943c7c83328f8e7b192201812f