### PR TITLE
Add camera snapshot endpoint and viewer download control

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ that future driver-assistance overlays can be injected on the server without maj
 - REST API for orientation control and camera management.
 - Optional battery indicator when an INA219 sensor is connected, showing live
   percentage, voltage, and current draw in the viewer.
+- One-tap snapshot capture via REST endpoint and the live viewer download
+  control.
 - Built-in mDNS advertisement so `motion.local:9000` resolves on iOS clients
   even when the RevCam hotspot is active.
 
@@ -83,8 +85,23 @@ building everything from PyPI. Follow these steps on the Pi:
    pip install --prefer-binary --extra-index-url https://www.piwheels.org/simple -e .
    ```
 
-   The `--prefer-binary` flag asks `pip` to fetch pre-built wheels when
-   available, and the PiWheels index provides ARM builds for most dependencies.
+The `--prefer-binary` flag asks `pip` to fetch pre-built wheels when
+available, and the PiWheels index provides ARM builds for most dependencies.
+
+### Saving snapshots
+
+The live view footer includes a **Save snapshot** button that fetches a still
+image without interrupting the MJPEG stream. RevCam exposes the same capture
+functionality via two HTTP endpoints:
+
+- `GET /api/camera/snapshot` returns a JPEG with headers suitable for API
+  clients and short-term caching disabled.
+- `GET /snapshot.jpg` provides the same image with a friendlier path for direct
+  browser access.
+
+Both endpoints run the captured frame through the configured pipeline and
+return the processed output, so overlays and orientation adjustments are
+preserved in the saved image.
 
 ### Battery monitoring requirements
 

--- a/src/rev_cam/static/index.html
+++ b/src/rev_cam/static/index.html
@@ -154,6 +154,7 @@
       <div class="control-group">
         <button id="toggle-stream" type="button" aria-pressed="false">Pause stream</button>
         <button id="reconnect" type="button">Reconnect</button>
+        <button id="save-snapshot" type="button">Save snapshot</button>
       </div>
       <a class="settings-link" href="/settings">Settings</a>
     </footer>
@@ -162,6 +163,7 @@
       const reconnectButton = document.getElementById("reconnect");
       const streamElement = document.getElementById("stream");
       const toggleButton = document.getElementById("toggle-stream");
+      const snapshotButton = document.getElementById("save-snapshot");
       const batteryIndicator = document.getElementById("battery-indicator");
       const batteryIcon = document.getElementById("battery-icon");
       const batteryLevel = document.getElementById("battery-level");
@@ -301,6 +303,58 @@
         toggleButton.setAttribute("aria-pressed", "false");
       }
 
+      async function saveSnapshot() {
+        if (!snapshotButton) {
+          return;
+        }
+        const previousStatus = statusLabel ? statusLabel.textContent : "";
+        const originalLabel = snapshotButton.textContent;
+        snapshotButton.disabled = true;
+        snapshotButton.textContent = "Saving…";
+        if (statusLabel) {
+          statusLabel.textContent = "Capturing snapshot…";
+        }
+
+        try {
+          const response = await fetch("/api/camera/snapshot", { cache: "no-store" });
+          if (!response.ok) {
+            throw new Error(`Snapshot request failed with ${response.status}`);
+          }
+          const blob = await response.blob();
+          const url = URL.createObjectURL(blob);
+          const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+          const anchor = document.createElement("a");
+          anchor.href = url;
+          anchor.download = `revcam-${timestamp}.jpg`;
+          anchor.style.display = "none";
+          document.body.appendChild(anchor);
+          anchor.click();
+          document.body.removeChild(anchor);
+          setTimeout(() => URL.revokeObjectURL(url), 1000);
+          if (statusLabel) {
+            statusLabel.textContent = "Snapshot saved";
+            setTimeout(() => {
+              if (statusLabel.textContent === "Snapshot saved") {
+                statusLabel.textContent = previousStatus || (shouldStream ? "Streaming" : "Streaming paused");
+              }
+            }, 2000);
+          }
+        } catch (error) {
+          console.error("Snapshot error", error);
+          if (statusLabel) {
+            statusLabel.textContent = "Snapshot failed";
+            setTimeout(() => {
+              if (statusLabel.textContent === "Snapshot failed") {
+                statusLabel.textContent = previousStatus || (shouldStream ? "Streaming" : "Streaming paused");
+              }
+            }, 2500);
+          }
+        } finally {
+          snapshotButton.disabled = false;
+          snapshotButton.textContent = originalLabel;
+        }
+      }
+
       streamElement.addEventListener("load", () => {
         if (!shouldStream) {
           return;
@@ -329,6 +383,12 @@
           startStream();
         }
       });
+
+      if (snapshotButton) {
+        snapshotButton.addEventListener("click", () => {
+          saveSnapshot().catch((error) => console.error("Snapshot handler error", error));
+        });
+      }
 
       window.addEventListener("beforeunload", () => {
         clearReconnectTimer();


### PR DESCRIPTION
## Summary
- extract a reusable helper for JPEG encoding from the MJPEG streamer
- add camera snapshot HTTP endpoints and hook them up to the viewer UI
- cover the new behaviour with integration tests and document the feature

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf17736db4833286507a04f56746a5