### PR TITLE
Add Wi-Fi forget network support

### DIFF
--- a/src/rev_cam/app.py
+++ b/src/rev_cam/app.py
@@ -55,6 +55,10 @@ class WiFiHotspotPayload(BaseModel):
     rollback_seconds: float | None = None
 
 
+class WiFiForgetPayload(BaseModel):
+    identifier: str
+
+
 class DistanceZonesPayload(BaseModel):
     caution: float
     warning: float
@@ -412,6 +416,17 @@ def create_app(
                 status = await run_in_threadpool(wifi_manager.disable_hotspot)
             except WiFiError as exc:
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return status.to_dict()
+
+    @app.post("/api/wifi/forget")
+    async def forget_wifi_network(payload: WiFiForgetPayload) -> dict[str, object | None]:
+        try:
+            status = await run_in_threadpool(
+                wifi_manager.forget_network,
+                payload.identifier,
+            )
+        except WiFiError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
         return status.to_dict()
 
     @app.post("/api/camera")

--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -1783,9 +1783,8 @@
           const info = document.createElement("div");
           info.style.minWidth = "12rem";
           const name = document.createElement("strong");
-          const ssid = typeof network.ssid === "string" && network.ssid.trim()
-            ? network.ssid.trim()
-            : "(hidden network)";
+          const identifier = typeof network.ssid === "string" ? network.ssid.trim() : "";
+          const ssid = identifier ? identifier : "(hidden network)";
           name.textContent = ssid;
           info.appendChild(name);
           const details = document.createElement("span");
@@ -1844,6 +1843,21 @@
             });
           }
           actions.appendChild(connectButton);
+          if (network.known) {
+            const forgetButton = document.createElement("button");
+            forgetButton.type = "button";
+            forgetButton.className = "secondary-button";
+            forgetButton.textContent = "Forget";
+            if (!identifier) {
+              forgetButton.disabled = true;
+              forgetButton.title = "Unable to forget hidden networks.";
+            } else {
+              forgetButton.addEventListener("click", () => {
+                forgetSavedNetwork(identifier);
+              });
+            }
+            actions.appendChild(forgetButton);
+          }
           item.appendChild(actions);
           wifiNetworkList.appendChild(item);
         }
@@ -1966,6 +1980,49 @@
         } catch (err) {
           console.error(err);
           setWifiFeedback("Connection attempt failed.", true);
+        }
+      }
+
+      async function forgetSavedNetwork(identifier) {
+        const target = typeof identifier === "string" ? identifier.trim() : "";
+        if (!target) {
+          setWifiFeedback("Unable to forget unnamed network.", true);
+          return;
+        }
+        setWifiFeedback(`Forgetting ${target}…`);
+        try {
+          const response = await fetch("/api/wifi/forget", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ identifier: target }),
+          });
+          if (!response.ok) {
+            let errorDetail = "Unable to forget saved network.";
+            try {
+              const error = await response.json();
+              if (error && error.detail) {
+                errorDetail = error.detail;
+              }
+            } catch (parseErr) {
+              console.error(parseErr);
+            }
+            setWifiFeedback(errorDetail, true);
+            return;
+          }
+          const status = await response.json();
+          hideWifiConnectForm();
+          await refreshWifiStatus();
+          await scanWifiNetworks();
+          let detailMessage = "";
+          if (status && typeof status.detail === "string" && status.detail.trim()) {
+            detailMessage = status.detail.trim();
+          } else {
+            detailMessage = `Removed saved network ${target}.`;
+          }
+          setWifiFeedback(detailMessage);
+        } catch (err) {
+          console.error(err);
+          setWifiFeedback("Unable to forget saved network.", true);
         }
       }
 


### PR DESCRIPTION
## Summary
- add a forget operation to the Wi-Fi backend and manager so saved profiles can be removed safely
- expose a /api/wifi/forget endpoint and surface a Forget action in the settings UI
- cover the new flow with FastAPI integration tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf1e98ff6483328d95e27993d458c6