### PR TITLE
Add configurable MJPEG streaming settings

### DIFF
--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -189,6 +189,38 @@
         font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
         word-break: break-all;
       }
+      .stream-settings {
+        margin-top: 1.25rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+      }
+      .stream-settings-grid {
+        display: grid;
+        gap: 1rem;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      }
+      .stream-settings label {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        margin-bottom: 0;
+        font-size: 0.95rem;
+      }
+      .stream-settings input[type="range"] {
+        width: 100%;
+      }
+      .stream-quality-control {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+      }
+      .stream-quality-display {
+        min-width: 2.5rem;
+        text-align: right;
+        font-weight: 600;
+        font-variant-numeric: tabular-nums;
+      }
       #orientation-form {
         display: flex;
         flex-direction: column;
@@ -555,6 +587,42 @@
               </button>
             </div>
             <code id="stream-url">—</code>
+            <form id="stream-settings-form" class="stream-settings">
+              <div class="stream-settings-grid">
+                <label>
+                  Frames per second
+                  <input
+                    type="number"
+                    name="fps"
+                    id="stream-fps"
+                    min="1"
+                    max="60"
+                    step="1"
+                    inputmode="numeric"
+                    value="20"
+                  />
+                </label>
+                <label>
+                  JPEG quality
+                  <div class="stream-quality-control">
+                    <input
+                      type="range"
+                      name="jpeg_quality"
+                      id="stream-quality"
+                      min="1"
+                      max="100"
+                      step="1"
+                      value="85"
+                    />
+                    <span class="stream-quality-display" id="stream-quality-display">85</span>
+                  </div>
+                </label>
+              </div>
+              <div class="form-actions">
+                <button type="submit">Save streaming settings</button>
+                <span id="stream-settings-status" class="muted"></span>
+              </div>
+            </form>
           </section>
 
           <form id="orientation-form" class="card">
@@ -913,6 +981,16 @@
       const copyStreamButton = document.getElementById("copy-stream-url");
       const copyButtonDefault = copyStreamButton ? copyStreamButton.textContent : "";
       let copyResetTimer = null;
+      const streamSettingsForm = document.getElementById("stream-settings-form");
+      const streamFpsInput = streamSettingsForm
+        ? streamSettingsForm.querySelector('input[name="fps"]')
+        : null;
+      const streamQualityInput = streamSettingsForm
+        ? streamSettingsForm.querySelector('input[name="jpeg_quality"]')
+        : null;
+      const streamQualityDisplay = document.getElementById("stream-quality-display");
+      const streamSettingsStatus = document.getElementById("stream-settings-status");
+      let streamSettingsStatusTimer = null;
       const wifiSummary = document.getElementById("wifi-summary");
       const wifiRefreshButton = document.getElementById("wifi-refresh");
       const wifiScanButton = document.getElementById("wifi-scan");
@@ -938,6 +1016,71 @@
         : null;
       const HOTSPOT_HOSTNAME = "motion.local";
       const HOTSPOT_DEV_ROLLBACK_DEFAULT = 120;
+
+      function clearStreamSettingsStatus() {
+        if (streamSettingsStatus) {
+          streamSettingsStatus.textContent = "";
+        }
+        if (streamSettingsStatusTimer) {
+          clearTimeout(streamSettingsStatusTimer);
+          streamSettingsStatusTimer = null;
+        }
+      }
+
+      function setStreamQualityDisplay(value) {
+        if (!streamQualityDisplay) {
+          return;
+        }
+        if (typeof value === "number" && Number.isFinite(value)) {
+          streamQualityDisplay.textContent = String(Math.round(value));
+        } else if (
+          streamQualityInput &&
+          typeof streamQualityInput.value === "string" &&
+          streamQualityInput.value
+        ) {
+          streamQualityDisplay.textContent = streamQualityInput.value;
+        } else {
+          streamQualityDisplay.textContent = "—";
+        }
+      }
+
+      function updateStreamInputs(settings, options = {}) {
+        if (!streamSettingsForm) {
+          return;
+        }
+        const forceUpdate = options.force === true;
+        const fpsValue = settings && typeof settings.fps === "number" ? settings.fps : null;
+        const qualityValue =
+          settings && typeof settings.jpeg_quality === "number"
+            ? settings.jpeg_quality
+            : null;
+        if (streamFpsInput) {
+          if (!forceUpdate && streamFpsInput.dataset.userEdited === "true") {
+            // Keep user-entered value.
+          } else if (fpsValue !== null && Number.isFinite(fpsValue)) {
+            streamFpsInput.value = String(Math.round(fpsValue));
+            delete streamFpsInput.dataset.userEdited;
+          } else {
+            streamFpsInput.value = "";
+            delete streamFpsInput.dataset.userEdited;
+          }
+        }
+        if (streamQualityInput) {
+          if (!forceUpdate && streamQualityInput.dataset.userEdited === "true") {
+            setStreamQualityDisplay(null);
+          } else if (qualityValue !== null && Number.isFinite(qualityValue)) {
+            const rounded = Math.min(100, Math.max(1, Math.round(qualityValue)));
+            streamQualityInput.value = String(rounded);
+            delete streamQualityInput.dataset.userEdited;
+            setStreamQualityDisplay(rounded);
+          } else {
+            delete streamQualityInput.dataset.userEdited;
+            setStreamQualityDisplay(null);
+          }
+        }
+      }
+
+      setStreamQualityDisplay(null);
 
       function formatDistance(value) {
         if (typeof value !== "number" || Number.isNaN(value)) {
@@ -2116,15 +2259,46 @@
           return;
         }
         const stream = camera && camera.stream ? camera.stream : null;
+        const configuredSettings =
+          stream && stream.settings && typeof stream.settings === "object"
+            ? stream.settings
+            : null;
+        const activeSettings =
+          stream && stream.active && typeof stream.active === "object"
+            ? stream.active
+            : null;
+        updateStreamInputs(configuredSettings, { force: true });
         if (copyStreamButton) {
           copyStreamButton.textContent = copyButtonDefault;
         }
         if (!stream || stream.enabled === false) {
           if (streamSummary) {
             const detail = stream && stream.error ? String(stream.error).trim() : "";
-            streamSummary.textContent = detail
+            const configuredParts = [];
+            const configuredFps =
+              configuredSettings && typeof configuredSettings.fps === "number"
+                ? Math.round(configuredSettings.fps)
+                : null;
+            const configuredQuality =
+              configuredSettings && typeof configuredSettings.jpeg_quality === "number"
+                ? Math.round(configuredSettings.jpeg_quality)
+                : null;
+            if (configuredFps !== null && Number.isFinite(configuredFps)) {
+              configuredParts.push(`${configuredFps} fps`);
+            }
+            if (configuredQuality !== null && Number.isFinite(configuredQuality)) {
+              configuredParts.push(`quality ${configuredQuality}`);
+            }
+            const configSummary =
+              configuredParts.length > 0
+                ? `Configured for ${configuredParts.join(" · ")}.`
+                : "";
+            const baseMessage = detail
               ? `Streaming disabled: ${detail}`
               : "Streaming disabled.";
+            streamSummary.textContent = configSummary
+              ? `${baseMessage} ${configSummary}`
+              : baseMessage;
           }
           if (openStreamLink) {
             openStreamLink.classList.add("disabled");
@@ -2145,11 +2319,47 @@
           : "/stream/mjpeg";
         const absoluteUrl = new URL(endpoint, window.location.origin).toString();
         const streamType = stream.content_type ? String(stream.content_type) : "MJPEG";
+        const activeFps =
+          activeSettings && typeof activeSettings.fps === "number"
+            ? activeSettings.fps
+            : null;
+        const activeQuality =
+          activeSettings && typeof activeSettings.jpeg_quality === "number"
+            ? activeSettings.jpeg_quality
+            : null;
+        const configuredFps =
+          configuredSettings && typeof configuredSettings.fps === "number"
+            ? configuredSettings.fps
+            : null;
+        const configuredQuality =
+          configuredSettings && typeof configuredSettings.jpeg_quality === "number"
+            ? configuredSettings.jpeg_quality
+            : null;
+        const fpsDisplay =
+          activeFps !== null && Number.isFinite(activeFps)
+            ? Math.round(activeFps)
+            : configuredFps !== null && Number.isFinite(configuredFps)
+            ? Math.round(configuredFps)
+            : null;
+        const qualityDisplay =
+          activeQuality !== null && Number.isFinite(activeQuality)
+            ? Math.round(activeQuality)
+            : configuredQuality !== null && Number.isFinite(configuredQuality)
+            ? Math.round(configuredQuality)
+            : null;
         if (streamSummary) {
           if (stream.error) {
             streamSummary.textContent = `Streaming issue: ${stream.error}`;
           } else {
-            streamSummary.textContent = `Live stream ready (${streamType})`;
+            const detailParts = [];
+            if (fpsDisplay !== null) {
+              detailParts.push(`${fpsDisplay} fps`);
+            }
+            if (qualityDisplay !== null) {
+              detailParts.push(`quality ${qualityDisplay}`);
+            }
+            const detailText = detailParts.length ? ` – ${detailParts.join(" · ")}` : "";
+            streamSummary.textContent = `Live stream ready (${streamType})${detailText}`;
           }
         }
         if (openStreamLink) {
@@ -2324,6 +2534,117 @@
                 resetCopyFeedback();
               }
             }, 2500);
+          }
+        });
+      }
+
+      if (streamFpsInput) {
+        streamFpsInput.addEventListener("input", () => {
+          streamFpsInput.dataset.userEdited = "true";
+          clearStreamSettingsStatus();
+        });
+      }
+
+      if (streamQualityInput) {
+        const handleQualityChange = () => {
+          streamQualityInput.dataset.userEdited = "true";
+          setStreamQualityDisplay(Number.parseInt(streamQualityInput.value, 10));
+          clearStreamSettingsStatus();
+        };
+        streamQualityInput.addEventListener("input", handleQualityChange);
+        streamQualityInput.addEventListener("change", handleQualityChange);
+      }
+
+      if (streamSettingsForm) {
+        streamSettingsForm.addEventListener("submit", async (event) => {
+          event.preventDefault();
+          clearStreamSettingsStatus();
+          if (streamSettingsStatus) {
+            streamSettingsStatus.textContent = "Saving…";
+          }
+          const payload = {};
+          if (streamFpsInput) {
+            const parsedFps = Number.parseInt(streamFpsInput.value, 10);
+            if (!Number.isFinite(parsedFps) || parsedFps < 1 || parsedFps > 60) {
+              if (streamSettingsStatus) {
+                streamSettingsStatus.textContent = "Enter a valid FPS between 1 and 60.";
+              }
+              return;
+            }
+            payload.fps = parsedFps;
+          }
+          if (streamQualityInput) {
+            const parsedQuality = Number.parseInt(streamQualityInput.value, 10);
+            if (!Number.isFinite(parsedQuality) || parsedQuality < 1 || parsedQuality > 100) {
+              if (streamSettingsStatus) {
+                streamSettingsStatus.textContent = "Quality must be between 1 and 100.";
+              }
+              return;
+            }
+            payload.jpeg_quality = parsedQuality;
+          }
+
+          try {
+            const response = await fetch("/api/stream/settings", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(payload),
+            });
+            if (!response.ok) {
+              let errorDetail = "Unable to save streaming settings.";
+              try {
+                const error = await response.json();
+                if (error && typeof error.detail === "string" && error.detail.trim()) {
+                  errorDetail = error.detail.trim();
+                }
+              } catch (err) {
+                console.error(err);
+              }
+              if (streamSettingsStatus) {
+                streamSettingsStatus.textContent = `Error: ${errorDetail}`;
+              }
+              return;
+            }
+            const data = await response.json();
+            const updatedSettings = {
+              fps:
+                data && typeof data.fps === "number" && Number.isFinite(data.fps)
+                  ? data.fps
+                  : payload.fps,
+              jpeg_quality:
+                data &&
+                typeof data.jpeg_quality === "number" &&
+                Number.isFinite(data.jpeg_quality)
+                  ? data.jpeg_quality
+                  : payload.jpeg_quality,
+            };
+            updateStreamInputs(updatedSettings, { force: true });
+            if (streamSettingsStatus) {
+              streamSettingsStatus.textContent = "Streaming settings saved";
+            }
+            if (streamSettingsStatusTimer) {
+              clearTimeout(streamSettingsStatusTimer);
+            }
+            streamSettingsStatusTimer = window.setTimeout(() => {
+              if (streamSettingsStatus) {
+                streamSettingsStatus.textContent = "";
+              }
+              streamSettingsStatusTimer = null;
+            }, 3000);
+            try {
+              const cameraResponse = await fetch("/api/camera", { cache: "no-store" });
+              if (cameraResponse.ok) {
+                const cameraData = await cameraResponse.json();
+                updateStreamSection(cameraData);
+              }
+            } catch (err) {
+              console.error(err);
+            }
+          } catch (err) {
+            console.error(err);
+            if (streamSettingsStatus) {
+              streamSettingsStatus.textContent = "Error: Unable to save streaming settings.";
+            }
           }
         });
       }

--- a/src/rev_cam/streaming.py
+++ b/src/rev_cam/streaming.py
@@ -91,6 +91,34 @@ class MJPEGStreamer:
             ) from _SIMPLEJPEG_IMPORT_ERROR
         self._frame_interval = 1.0 / float(self.fps)
 
+    def apply_settings(
+        self,
+        *,
+        fps: int | None = None,
+        jpeg_quality: int | None = None,
+    ) -> None:
+        """Update streaming parameters at runtime."""
+
+        update_interval = False
+        if fps is not None:
+            new_fps = int(fps)
+            if new_fps <= 0:
+                raise ValueError("fps must be positive")
+            if new_fps != self.fps:
+                self.fps = new_fps
+                update_interval = True
+
+        if jpeg_quality is not None:
+            new_quality = int(jpeg_quality)
+            if new_quality < 1:
+                new_quality = 1
+            elif new_quality > 100:
+                new_quality = 100
+            self.jpeg_quality = new_quality
+
+        if update_interval:
+            self._frame_interval = 1.0 / float(self.fps)
+
     @property
     def media_type(self) -> str:
         """Return the MIME type advertised for MJPEG responses."""

--- a/tests/test_app_camera.py
+++ b/tests/test_app_camera.py
@@ -55,6 +55,48 @@ class _BrokenPicamera:
         raise CameraError("picamera backend unavailable")
 
 
+class _RecorderStreamer:
+    instances: list["_RecorderStreamer"] = []
+
+    def __init__(
+        self,
+        *,
+        camera: BaseCamera,
+        pipeline,
+        fps: int = 20,
+        jpeg_quality: int = 85,
+        boundary: str = "frame",
+    ) -> None:
+        self.camera = camera
+        self.pipeline = pipeline
+        self.fps = fps
+        self.jpeg_quality = jpeg_quality
+        self.boundary = boundary
+        self.apply_calls: list[dict[str, int | None]] = []
+        _RecorderStreamer.instances.append(self)
+
+    @property
+    def media_type(self) -> str:
+        return f"multipart/x-mixed-replace; boundary={self.boundary}"
+
+    async def stream(self):  # pragma: no cover - not exercised in tests
+        yield b""
+
+    async def aclose(self) -> None:  # pragma: no cover - not exercised in tests
+        return None
+
+    def apply_settings(
+        self,
+        *,
+        fps: int | None = None,
+        jpeg_quality: int | None = None,
+    ) -> None:
+        if fps is not None:
+            self.fps = fps
+        if jpeg_quality is not None:
+            self.jpeg_quality = jpeg_quality
+        self.apply_calls.append({"fps": fps, "jpeg_quality": jpeg_quality})
+
 @pytest.fixture
 def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
     _apply_common_stubs(monkeypatch)
@@ -78,6 +120,8 @@ def test_camera_endpoint_reports_picamera_error(client: TestClient) -> None:
     assert stream_info["enabled"] is True
     assert stream_info["endpoint"] == "/stream/mjpeg"
     assert "multipart/x-mixed-replace" in stream_info["content_type"]
+    assert stream_info["settings"] == {"fps": 20, "jpeg_quality": 85}
+    assert stream_info["active"] == {"fps": 20, "jpeg_quality": 85}
     resolution_info = payload["resolution"]
     assert resolution_info["selected"] == DEFAULT_RESOLUTION_KEY
     assert resolution_info["active"] == DEFAULT_RESOLUTION_KEY
@@ -97,6 +141,8 @@ def test_camera_update_surfaces_failure(client: TestClient) -> None:
     assert stream_info["enabled"] is True
     assert stream_info["endpoint"] == "/stream/mjpeg"
     assert "multipart/x-mixed-replace" in stream_info["content_type"]
+    assert stream_info["settings"] == {"fps": 20, "jpeg_quality": 85}
+    assert stream_info["active"] == {"fps": 20, "jpeg_quality": 85}
     resolution_info = refreshed["resolution"]
     assert resolution_info["selected"] == DEFAULT_RESOLUTION_KEY
     assert resolution_info["active"] == DEFAULT_RESOLUTION_KEY
@@ -182,8 +228,66 @@ def test_stream_error_surfaces_when_streamer_unavailable(
         assert stream_info["enabled"] is False
         assert stream_info["endpoint"] is None
         assert stream_info["error"] == "encoder offline"
+        assert stream_info["settings"] == {"fps": 20, "jpeg_quality": 85}
+        assert stream_info["active"] is None
 
         stream_response = test_client.get("/stream/mjpeg")
         assert stream_response.status_code == 503
         detail = stream_response.json()["detail"]
         assert "encoder offline" in detail
+
+
+def test_stream_settings_endpoint_updates_config_and_streamer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _apply_common_stubs(monkeypatch)
+    _RecorderStreamer.instances.clear()
+    monkeypatch.setattr("rev_cam.app.MJPEGStreamer", _RecorderStreamer)
+    config_path = tmp_path / "config.json"
+    app = create_app(config_path)
+    with TestClient(app) as test_client:
+        initial = test_client.get("/api/camera")
+        assert initial.status_code == 200
+        initial_payload = initial.json()
+        assert initial_payload["stream"]["settings"] == {"fps": 20, "jpeg_quality": 85}
+        assert initial_payload["stream"]["active"] == {"fps": 20, "jpeg_quality": 85}
+        assert _RecorderStreamer.instances
+        streamer = _RecorderStreamer.instances[-1]
+
+        response = test_client.post(
+            "/api/stream/settings",
+            json={"fps": 12, "jpeg_quality": 65},
+        )
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["fps"] == 12
+        assert payload["jpeg_quality"] == 65
+        assert payload["active"] == {"fps": 12, "jpeg_quality": 65}
+        assert streamer.apply_calls
+        assert streamer.apply_calls[-1] == {"fps": 12, "jpeg_quality": 65}
+        assert streamer.fps == 12
+        assert streamer.jpeg_quality == 65
+
+        config_data = json.loads(Path(config_path).read_text())
+        assert config_data["stream"] == {"fps": 12, "jpeg_quality": 65}
+
+        refreshed = test_client.get("/api/camera")
+        assert refreshed.status_code == 200
+        stream_info = refreshed.json()["stream"]
+        assert stream_info["settings"] == {"fps": 12, "jpeg_quality": 65}
+        assert stream_info["active"] == {"fps": 12, "jpeg_quality": 65}
+
+
+def test_stream_settings_endpoint_validates_input(client: TestClient) -> None:
+    response = client.post("/api/stream/settings", json={"fps": 0})
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert "fps" in detail.lower()
+
+    invalid_quality = client.post("/api/stream/settings", json={"jpeg_quality": 150})
+    assert invalid_quality.status_code == 400
+    quality_detail = invalid_quality.json()["detail"]
+    assert "quality" in quality_detail.lower()
+
+    camera = client.get("/api/camera").json()
+    assert camera["stream"]["settings"] == {"fps": 20, "jpeg_quality": 85}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+from pathlib import Path
+
 import pytest
 
 from rev_cam.battery import BatteryLimits
@@ -7,6 +9,7 @@ from rev_cam.config import (
     ConfigManager,
     DistanceZones,
     Orientation,
+    StreamSettings,
     DEFAULT_BATTERY_CAPACITY_MAH,
     DEFAULT_CAMERA_CHOICE,
 )
@@ -98,3 +101,30 @@ def test_battery_capacity_persistence(tmp_path: Path):
     assert updated == 2400
     reloaded = ConfigManager(config_file)
     assert reloaded.get_battery_capacity() == 2400
+
+
+def test_default_stream_settings(tmp_path: Path) -> None:
+    manager = ConfigManager(tmp_path / "config.json")
+    settings = manager.get_stream_settings()
+    assert isinstance(settings, StreamSettings)
+    assert settings.fps == 20
+    assert settings.jpeg_quality == 85
+
+
+def test_stream_settings_persistence(tmp_path: Path) -> None:
+    config_file = tmp_path / "config.json"
+    manager = ConfigManager(config_file)
+    updated = manager.set_stream_settings({"fps": 18, "jpeg_quality": 70})
+    assert isinstance(updated, StreamSettings)
+    assert updated.fps == 18
+    assert updated.jpeg_quality == 70
+    reloaded = ConfigManager(config_file)
+    assert reloaded.get_stream_settings() == updated
+
+
+def test_stream_settings_validation(tmp_path: Path) -> None:
+    manager = ConfigManager(tmp_path / "config.json")
+    with pytest.raises(ValueError):
+        manager.set_stream_settings({"fps": 0})
+    with pytest.raises(ValueError):
+        manager.set_stream_settings({"jpeg_quality": 120})


### PR DESCRIPTION
## Summary
- persist MJPEG stream fps and JPEG quality in the configuration manager with validation helpers
- apply configuration-driven runtime updates to MJPEGStreamer and expose stream settings through the API
- add settings UI controls and API tests covering persistence, validation, and streamer reconfiguration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf243df63c83328fcb0e88e9f01df0