### PR TITLE
Add diagnostics API endpoint and UI

### DIFF
--- a/src/rev_cam/diagnostics.py
+++ b/src/rev_cam/diagnostics.py
@@ -101,19 +101,25 @@ def diagnose_picamera_stack() -> dict[str, object]:
     return payload
 
 
+def collect_diagnostics() -> dict[str, object]:
+    """Collect diagnostics payload used by both the CLI and API."""
+
+    hints = diagnose_camera_conflicts()
+    picamera_stack = diagnose_picamera_stack()
+    return {
+        "version": APP_VERSION,
+        "camera_conflicts": hints,
+        "picamera": picamera_stack,
+    }
+
+
 def run(argv: Sequence[str] | None = None) -> int:
     """Execute the diagnostics CLI with *argv* arguments."""
 
     parser = build_parser()
     args = parser.parse_args(argv)
 
-    hints = diagnose_camera_conflicts()
-    picamera_stack = diagnose_picamera_stack()
-    payload = {
-        "version": APP_VERSION,
-        "camera_conflicts": hints,
-        "picamera": picamera_stack,
-    }
+    payload = collect_diagnostics()
 
     if args.json:
         json.dump(payload, sys.stdout)
@@ -154,7 +160,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     return run(argv)
 
 
-__all__ = ["build_parser", "diagnose_picamera_stack", "run", "main"]
+__all__ = [
+    "build_parser",
+    "diagnose_picamera_stack",
+    "collect_diagnostics",
+    "run",
+    "main",
+]
 
 
 if __name__ == "__main__":  # pragma: no cover - module behaviour

--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -481,6 +481,48 @@
         margin: 0.75rem 0 0;
         min-height: 1rem;
       }
+      .diagnostics-actions {
+        margin: 0.75rem 0 1rem;
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 0.75rem;
+      }
+      .diagnostics-status {
+        font-size: 0.9rem;
+        opacity: 0.85;
+      }
+      .diagnostics-error {
+        margin: 0.75rem 0 0;
+        font-size: 0.95rem;
+        color: #ff6b6b;
+      }
+      .diagnostics-results h3 {
+        margin: 1rem 0 0.5rem;
+        font-size: 1rem;
+      }
+      .diagnostics-results h4 {
+        margin: 0.75rem 0 0.35rem;
+        font-size: 0.95rem;
+      }
+      .diagnostics-list {
+        margin: 0.35rem 0 0.75rem 1.25rem;
+        padding: 0;
+      }
+      .diagnostics-list li {
+        margin: 0.3rem 0;
+      }
+      .diagnostics-empty {
+        margin: 0.35rem 0 0.75rem;
+        font-size: 0.95rem;
+        opacity: 0.8;
+      }
+      .diagnostics-picamera-status.ok {
+        color: #30d158;
+      }
+      .diagnostics-picamera-status.error {
+        color: #ff9f0a;
+      }
       #distance-zones-status {
         font-size: 0.9rem;
       }
@@ -656,6 +698,49 @@
               <div id="status">Loading…</div>
             </div>
           </form>
+
+          <section id="diagnostics-card" class="card">
+            <h2>Diagnostics</h2>
+            <p class="muted">
+              Check for conflicting camera services and validate the Picamera2 Python stack.
+            </p>
+            <div class="diagnostics-actions">
+              <button type="button" id="diagnostics-refresh" class="secondary-button">
+                Run diagnostics
+              </button>
+              <span
+                id="diagnostics-status"
+                class="diagnostics-status"
+                role="status"
+                aria-live="polite"
+              ></span>
+            </div>
+            <div id="diagnostics-results" class="diagnostics-results" hidden>
+              <p id="diagnostics-summary" class="muted"></p>
+              <div>
+                <h3>Camera conflicts</h3>
+                <p id="diagnostics-no-conflicts" class="diagnostics-empty">
+                  No conflicting services detected.
+                </p>
+                <ul id="diagnostics-conflicts" class="diagnostics-list" hidden></ul>
+              </div>
+              <div>
+                <h3>Picamera2 stack</h3>
+                <p id="diagnostics-picamera-status" class="diagnostics-picamera-status"></p>
+                <ul id="diagnostics-picamera-details" class="diagnostics-list" hidden></ul>
+                <div id="diagnostics-picamera-hints-block" hidden>
+                  <h4>Hints</h4>
+                  <ul id="diagnostics-picamera-hints" class="diagnostics-list"></ul>
+                </div>
+              </div>
+            </div>
+            <p
+              id="diagnostics-error"
+              class="diagnostics-error"
+              role="alert"
+              aria-live="assertive"
+            ></p>
+          </section>
         </section>
 
         <section
@@ -926,6 +1011,21 @@
           }
         }
       }
+      const diagnosticsButton = document.getElementById("diagnostics-refresh");
+      const diagnosticsStatus = document.getElementById("diagnostics-status");
+      const diagnosticsResults = document.getElementById("diagnostics-results");
+      const diagnosticsSummary = document.getElementById("diagnostics-summary");
+      const diagnosticsConflicts = document.getElementById("diagnostics-conflicts");
+      const diagnosticsNoConflicts = document.getElementById("diagnostics-no-conflicts");
+      const diagnosticsPicameraStatus = document.getElementById("diagnostics-picamera-status");
+      const diagnosticsPicameraDetails = document.getElementById("diagnostics-picamera-details");
+      const diagnosticsPicameraHintsBlock = document.getElementById(
+        "diagnostics-picamera-hints-block",
+      );
+      const diagnosticsPicameraHints = document.getElementById("diagnostics-picamera-hints");
+      const diagnosticsError = document.getElementById("diagnostics-error");
+      let diagnosticsLoading = false;
+      let diagnosticsStatusTimer = null;
       const batterySummary = document.getElementById("battery-summary");
       const batteryRefreshButton = document.getElementById("battery-refresh");
       const batteryIndicator = document.getElementById("battery-indicator");
@@ -1172,6 +1272,162 @@
         }
         if (data && data.zones) {
           updateDistanceInputs(data.zones, options.updateInputs === true);
+        }
+      }
+
+      function renderDiagnosticsList(element, items) {
+        if (!element) {
+          return 0;
+        }
+        const entries = Array.isArray(items)
+          ? items
+              .map((item) => (typeof item === "string" ? item.trim() : ""))
+              .filter((item) => item.length > 0)
+          : [];
+        if (entries.length === 0) {
+          element.hidden = true;
+          element.replaceChildren();
+          return 0;
+        }
+        const fragment = document.createDocumentFragment();
+        for (const entry of entries) {
+          const listItem = document.createElement("li");
+          listItem.textContent = entry;
+          fragment.appendChild(listItem);
+        }
+        element.replaceChildren(fragment);
+        element.hidden = false;
+        return entries.length;
+      }
+
+      function applyDiagnostics(data) {
+        if (!diagnosticsResults) {
+          return;
+        }
+        diagnosticsResults.hidden = false;
+        if (diagnosticsError) {
+          diagnosticsError.textContent = "";
+        }
+        if (diagnosticsSummary) {
+          const version =
+            data && typeof data.version === "string" ? data.version.trim() : "";
+          diagnosticsSummary.textContent = version ? `Application version ${version}` : "";
+          diagnosticsSummary.hidden = version.length === 0;
+        }
+        const conflicts = data && Array.isArray(data.camera_conflicts)
+          ? data.camera_conflicts
+          : [];
+        const conflictCount = renderDiagnosticsList(diagnosticsConflicts, conflicts);
+        if (diagnosticsNoConflicts) {
+          diagnosticsNoConflicts.hidden = conflictCount > 0;
+        }
+        const picamera =
+          data && typeof data.picamera === "object" && data.picamera !== null
+            ? data.picamera
+            : {};
+        if (diagnosticsPicameraStatus) {
+          const statusText =
+            typeof picamera.status === "string" ? picamera.status.trim() : "";
+          const classes = diagnosticsPicameraStatus.classList;
+          classes.remove("ok", "error");
+          let summary;
+          if (statusText.toLowerCase() === "ok") {
+            summary = "Picamera2 Python stack: OK";
+            classes.add("ok");
+          } else if (statusText) {
+            summary = `Picamera2 Python stack status: ${statusText}`;
+            classes.add("error");
+          } else {
+            summary = "Picamera2 Python stack status unknown.";
+          }
+          const numpyVersion =
+            typeof picamera.numpy_version === "string"
+              ? picamera.numpy_version.trim()
+              : "";
+          if (numpyVersion) {
+            summary = `${summary} • NumPy ${numpyVersion}`;
+          }
+          diagnosticsPicameraStatus.textContent = summary;
+        }
+        const detailsCount = renderDiagnosticsList(
+          diagnosticsPicameraDetails,
+          picamera && Array.isArray(picamera.details) ? picamera.details : [],
+        );
+        if (diagnosticsPicameraDetails) {
+          diagnosticsPicameraDetails.hidden = detailsCount === 0;
+        }
+        const hintsCount = renderDiagnosticsList(
+          diagnosticsPicameraHints,
+          picamera && Array.isArray(picamera.hints) ? picamera.hints : [],
+        );
+        if (diagnosticsPicameraHintsBlock) {
+          diagnosticsPicameraHintsBlock.hidden = hintsCount === 0;
+        }
+      }
+
+      async function refreshDiagnostics() {
+        if (diagnosticsLoading) {
+          return;
+        }
+        diagnosticsLoading = true;
+        if (diagnosticsStatusTimer) {
+          clearTimeout(diagnosticsStatusTimer);
+          diagnosticsStatusTimer = null;
+        }
+        if (diagnosticsStatus) {
+          diagnosticsStatus.textContent = "Running diagnostics…";
+        }
+        if (diagnosticsButton) {
+          diagnosticsButton.disabled = true;
+        }
+        if (diagnosticsError) {
+          diagnosticsError.textContent = "";
+        }
+        try {
+          const response = await fetch("/api/diagnostics", { cache: "no-store" });
+          if (!response.ok) {
+            let errorDetail = `Diagnostics request failed with status ${response.status}`;
+            try {
+              const errorPayload = await response.json();
+              if (errorPayload && typeof errorPayload.detail === "string") {
+                const detail = errorPayload.detail.trim();
+                if (detail) {
+                  errorDetail = detail;
+                }
+              }
+            } catch (err) {
+              console.error(err);
+            }
+            throw new Error(errorDetail);
+          }
+          const payload = await response.json();
+          applyDiagnostics(payload);
+          if (diagnosticsStatus) {
+            diagnosticsStatus.textContent = "Diagnostics updated";
+            diagnosticsStatusTimer = window.setTimeout(() => {
+              if (diagnosticsStatus) {
+                diagnosticsStatus.textContent = "";
+              }
+              diagnosticsStatusTimer = null;
+            }, 4000);
+          }
+        } catch (error) {
+          console.error("Diagnostics fetch failed", error);
+          const message =
+            error instanceof Error && error.message
+              ? error.message
+              : "Unable to collect diagnostics.";
+          if (diagnosticsError) {
+            diagnosticsError.textContent = message;
+          }
+          if (diagnosticsStatus) {
+            diagnosticsStatus.textContent = "Diagnostics failed";
+          }
+        } finally {
+          diagnosticsLoading = false;
+          if (diagnosticsButton) {
+            diagnosticsButton.disabled = false;
+          }
         }
       }
 
@@ -1578,6 +1834,12 @@
           }
         });
       });
+
+      if (diagnosticsButton) {
+        diagnosticsButton.addEventListener("click", () => {
+          refreshDiagnostics().catch((err) => console.error(err));
+        });
+      }
 
       if (distanceRefreshButton) {
         distanceRefreshButton.addEventListener("click", () => {

--- a/tests/test_app_diagnostics.py
+++ b/tests/test_app_diagnostics.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("numpy")
+pytest.importorskip("httpx")
+
+from fastapi.testclient import TestClient
+
+from rev_cam import app as app_module
+
+
+def _apply_app_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _StubBatteryMonitor:
+        def read(self):  # pragma: no cover - used indirectly
+            return SimpleNamespace(to_dict=lambda: {"available": False})
+
+    class _StubSupervisor:
+        def start(self) -> None:  # pragma: no cover - used indirectly
+            return None
+
+        async def aclose(self) -> None:  # pragma: no cover - used indirectly
+            return None
+
+    class _StubDistanceMonitor:
+        def read(self):  # pragma: no cover - used indirectly
+            return SimpleNamespace(available=False)
+
+    class _StubCamera(app_module.BaseCamera):
+        async def get_frame(self):  # pragma: no cover - not exercised
+            import numpy as np
+
+            return np.zeros((1, 1, 3), dtype=np.uint8)
+
+        async def close(self) -> None:  # pragma: no cover - not exercised
+            return None
+
+    class _StubStreamer:
+        def __init__(
+            self,
+            *,
+            camera,
+            pipeline,
+            fps: int = 20,
+            jpeg_quality: int = 85,
+            boundary: str = "frame",
+        ) -> None:
+            self.camera = camera
+            self.pipeline = pipeline
+            self.fps = fps
+            self.jpeg_quality = jpeg_quality
+            self.boundary = boundary
+
+        @property
+        def media_type(self) -> str:
+            return f"multipart/x-mixed-replace; boundary={self.boundary}"
+
+        async def stream(self):  # pragma: no cover - not exercised
+            yield b""
+
+        async def aclose(self) -> None:  # pragma: no cover - not exercised
+            return None
+
+        def apply_settings(
+            self,
+            *,
+            fps: int | None = None,
+            jpeg_quality: int | None = None,
+        ) -> None:
+            if fps is not None:
+                self.fps = fps
+            if jpeg_quality is not None:
+                self.jpeg_quality = jpeg_quality
+
+    class _StubWiFiManager:
+        def close(self) -> None:  # pragma: no cover - used indirectly
+            return None
+
+    def _create_camera(choice: str, *args, **kwargs):
+        return _StubCamera()
+
+    monkeypatch.setattr(app_module, "BatteryMonitor", lambda *args, **kwargs: _StubBatteryMonitor())
+    monkeypatch.setattr(app_module, "BatterySupervisor", lambda *args, **kwargs: _StubSupervisor())
+    monkeypatch.setattr(app_module, "create_battery_overlay", lambda *args, **kwargs: (lambda frame: frame))
+    monkeypatch.setattr(app_module, "create_distance_overlay", lambda *args, **kwargs: (lambda frame: frame))
+    monkeypatch.setattr(app_module, "DistanceMonitor", lambda *args, **kwargs: _StubDistanceMonitor())
+    monkeypatch.setattr(app_module, "create_camera", _create_camera)
+    monkeypatch.setattr(app_module, "identify_camera", lambda camera: "stub")
+    monkeypatch.setattr(app_module, "MJPEGStreamer", _StubStreamer)
+    monkeypatch.setattr(app_module, "WiFiManager", lambda *args, **kwargs: _StubWiFiManager())
+
+
+def test_diagnostics_endpoint_returns_payload(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _apply_app_stubs(monkeypatch)
+
+    payload = {
+        "version": "1.2.3",
+        "camera_conflicts": ["motion service", "legacy camera stack"],
+        "picamera": {
+            "status": "error",
+            "details": ["picamera2 module not found."],
+            "hints": ["Install Picamera2 packages"],
+            "numpy_version": "1.26.2",
+        },
+    }
+    monkeypatch.setattr(app_module, "collect_diagnostics", lambda: payload)
+
+    app = app_module.create_app(tmp_path / "config.json")
+    with TestClient(app) as client:
+        response = client.get("/api/diagnostics")
+
+    assert response.status_code == 200
+    assert response.json() == payload
+
+
+def test_diagnostics_endpoint_maps_errors(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _apply_app_stubs(monkeypatch)
+
+    def _raise_error() -> None:
+        raise RuntimeError("test failure")
+
+    monkeypatch.setattr(app_module, "collect_diagnostics", _raise_error)
+
+    app = app_module.create_app(tmp_path / "config.json")
+    with TestClient(app) as client:
+        response = client.get("/api/diagnostics")
+
+    assert response.status_code == 500
+    detail = response.json()["detail"]
+    assert "Unable to collect diagnostics" in detail
+    assert "test failure" in detail

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -11,6 +11,21 @@ pytest.importorskip("numpy")
 import rev_cam.diagnostics as diagnostics
 
 
+def test_collect_diagnostics(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(diagnostics, "diagnose_camera_conflicts", lambda: ["service"])
+    monkeypatch.setattr(
+        diagnostics,
+        "diagnose_picamera_stack",
+        lambda: {"status": "ok", "details": []},
+    )
+
+    payload = diagnostics.collect_diagnostics()
+
+    assert payload["version"] == diagnostics.APP_VERSION
+    assert payload["camera_conflicts"] == ["service"]
+    assert payload["picamera"] == {"status": "ok", "details": []}
+
+
 def test_run_outputs_conflicts(capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(diagnostics, "diagnose_camera_conflicts", lambda: ["service running"])
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- refactor the diagnostics module to expose a collect_diagnostics helper used by the CLI and API
- add a /api/diagnostics endpoint plus a settings page card that fetches and renders camera and Picamera status
- cover the new endpoint with regression tests and extend diagnostics unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf286242688332803b4609cdc07e85