### PR TITLE
Add distance calibration controls and persistence

### DIFF
--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -481,6 +481,25 @@
         margin: 0.75rem 0 0;
         min-height: 1rem;
       }
+      .distance-calibration-grid {
+        margin-top: 1rem;
+        display: grid;
+        gap: 1rem;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      }
+      .distance-calibration-grid label {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        margin-bottom: 0;
+      }
+      .distance-calibration-note {
+        font-size: 0.9rem;
+        margin-top: 0.75rem;
+      }
+      #distance-calibration-status {
+        font-size: 0.9rem;
+      }
       .diagnostics-actions {
         margin: 0.75rem 0 1rem;
         display: flex;
@@ -766,6 +785,46 @@
             </div>
           </section>
 
+          <form id="distance-calibration-form" class="card">
+            <h2>Calibration</h2>
+            <p class="muted">
+              Adjust the offset and scale applied to the sensor to match real-world distances.
+            </p>
+            <div class="distance-calibration-grid">
+              <label>
+                Offset adjustment (m)
+                <input
+                  type="number"
+                  name="offset_m"
+                  min="-5"
+                  max="5"
+                  step="0.01"
+                  inputmode="decimal"
+                />
+              </label>
+              <label>
+                Scale factor
+                <input
+                  type="number"
+                  name="scale"
+                  min="0.5"
+                  max="2"
+                  step="0.01"
+                  inputmode="decimal"
+                />
+              </label>
+            </div>
+            <div class="form-actions">
+              <button type="submit">Save calibration</button>
+              <button type="button" id="distance-zero" class="secondary-button">Zero sensor</button>
+              <span id="distance-calibration-status" class="muted"></span>
+            </div>
+            <p class="distance-calibration-note muted">
+              Place the target at the zero point, refresh the reading, then choose “Zero sensor” to
+              automatically adjust the offset.
+            </p>
+          </form>
+
           <form id="distance-zones-form" class="card">
             <h2>Warning zones</h2>
             <p class="muted">
@@ -984,6 +1043,9 @@
         clear: "Clear",
         unavailable: "Unavailable",
       };
+      const CALIBRATION_OFFSET_LIMIT = 5.0;
+      const CALIBRATION_SCALE_MIN = 0.5;
+      const CALIBRATION_SCALE_MAX = 2.0;
       const distanceSummary = document.getElementById("distance-summary");
       const distanceValue = document.getElementById("distance-value");
       const distanceZone = document.getElementById("distance-zone");
@@ -998,7 +1060,17 @@
             danger: distanceZonesForm.querySelector('input[name="danger"]'),
           }
         : null;
+      const distanceCalibrationForm = document.getElementById("distance-calibration-form");
+      const distanceCalibrationStatus = document.getElementById("distance-calibration-status");
+      const distanceZeroButton = document.getElementById("distance-zero");
+      const distanceCalibrationInputs = distanceCalibrationForm
+        ? {
+            offset: distanceCalibrationForm.querySelector('input[name="offset_m"]'),
+            scale: distanceCalibrationForm.querySelector('input[name="scale"]'),
+          }
+        : null;
       let distanceLoading = false;
+      let distanceCalibrationStatusTimer = null;
       if (distanceInputs) {
         for (const input of Object.values(distanceInputs)) {
           if (input instanceof HTMLInputElement) {
@@ -1006,6 +1078,18 @@
               input.dataset.userEdited = "true";
               if (distanceZonesStatus) {
                 distanceZonesStatus.textContent = "";
+              }
+            });
+          }
+        }
+      }
+      if (distanceCalibrationInputs) {
+        for (const input of Object.values(distanceCalibrationInputs)) {
+          if (input instanceof HTMLInputElement) {
+            input.addEventListener("input", () => {
+              input.dataset.userEdited = "true";
+              if (distanceCalibrationStatus) {
+                distanceCalibrationStatus.textContent = "";
               }
             });
           }
@@ -1203,6 +1287,58 @@
         distanceZone.textContent = label.toUpperCase();
       }
 
+      function setDistanceCalibrationStatus(message, options = {}) {
+        if (!distanceCalibrationStatus) {
+          return;
+        }
+        if (distanceCalibrationStatusTimer) {
+          window.clearTimeout(distanceCalibrationStatusTimer);
+          distanceCalibrationStatusTimer = null;
+        }
+        distanceCalibrationStatus.textContent = message || "";
+        if (message && options.persistent !== true) {
+          distanceCalibrationStatusTimer = window.setTimeout(() => {
+            if (
+              distanceCalibrationStatus &&
+              distanceCalibrationStatus.textContent === message
+            ) {
+              distanceCalibrationStatus.textContent = "";
+            }
+            distanceCalibrationStatusTimer = null;
+          }, 4000);
+        }
+      }
+
+      function formatCalibrationValue(value, fractionDigits) {
+        if (typeof value !== "number" || !Number.isFinite(value)) {
+          return "";
+        }
+        const text = value.toFixed(fractionDigits);
+        return text.replace(/(\.\d*?)0+$/, "$1").replace(/\.$/, "");
+      }
+
+      function updateDistanceCalibrationInputs(calibration, forceUpdate = false) {
+        if (!distanceCalibrationInputs || typeof calibration !== "object" || calibration === null) {
+          return;
+        }
+        const offsetInput = distanceCalibrationInputs.offset;
+        const scaleInput = distanceCalibrationInputs.scale;
+        if (
+          offsetInput instanceof HTMLInputElement &&
+          (forceUpdate || offsetInput.dataset.userEdited !== "true")
+        ) {
+          offsetInput.value = formatCalibrationValue(calibration.offset_m, 2);
+          delete offsetInput.dataset.userEdited;
+        }
+        if (
+          scaleInput instanceof HTMLInputElement &&
+          (forceUpdate || scaleInput.dataset.userEdited !== "true")
+        ) {
+          scaleInput.value = formatCalibrationValue(calibration.scale, 3);
+          delete scaleInput.dataset.userEdited;
+        }
+      }
+
       function updateDistanceInputs(zones, forceUpdate = false) {
         if (!zones || !distanceInputs) {
           return;
@@ -1272,6 +1408,10 @@
         }
         if (data && data.zones) {
           updateDistanceInputs(data.zones, options.updateInputs === true);
+        }
+        if (data && data.calibration) {
+          const forceUpdate = options.updateCalibration === true || options.updateInputs === true;
+          updateDistanceCalibrationInputs(data.calibration, forceUpdate);
         }
       }
 
@@ -1847,6 +1987,108 @@
         });
       }
 
+      if (distanceCalibrationForm) {
+        distanceCalibrationForm.addEventListener("submit", async (event) => {
+          event.preventDefault();
+          if (!distanceCalibrationInputs) {
+            return;
+          }
+          const offsetInput = distanceCalibrationInputs.offset;
+          const scaleInput = distanceCalibrationInputs.scale;
+          if (!(offsetInput instanceof HTMLInputElement) || !(scaleInput instanceof HTMLInputElement)) {
+            return;
+          }
+          const offset = Number.parseFloat(offsetInput.value);
+          const scale = Number.parseFloat(scaleInput.value);
+          if (!Number.isFinite(offset) || !Number.isFinite(scale)) {
+            setDistanceCalibrationStatus("Enter numeric values for offset and scale.");
+            return;
+          }
+          if (Math.abs(offset) > CALIBRATION_OFFSET_LIMIT) {
+            setDistanceCalibrationStatus(
+              `Offset must be between -${CALIBRATION_OFFSET_LIMIT} and ${CALIBRATION_OFFSET_LIMIT}.`,
+              { persistent: true },
+            );
+            return;
+          }
+          if (scale < CALIBRATION_SCALE_MIN || scale > CALIBRATION_SCALE_MAX) {
+            setDistanceCalibrationStatus(
+              `Scale must be between ${CALIBRATION_SCALE_MIN} and ${CALIBRATION_SCALE_MAX}.`,
+              { persistent: true },
+            );
+            return;
+          }
+          setDistanceCalibrationStatus("Saving…", { persistent: true });
+          try {
+            const response = await fetch("/api/distance/calibration", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ offset_m: offset, scale }),
+            });
+            if (!response.ok) {
+              let detail = "Unable to save calibration.";
+              try {
+                const payload = await response.json();
+                if (payload && typeof payload.detail === "string") {
+                  detail = payload.detail;
+                }
+              } catch (err) {
+                console.error(err);
+              }
+              setDistanceCalibrationStatus(detail, { persistent: true });
+              return;
+            }
+            const payload = await response.json();
+            applyDistanceData(payload, { updateInputs: true, updateCalibration: true });
+            setDistanceCalibrationStatus("Calibration saved");
+          } catch (error) {
+            console.error(error);
+            setDistanceCalibrationStatus("Unable to save calibration.", { persistent: true });
+          }
+        });
+      }
+
+      if (distanceZeroButton) {
+        distanceZeroButton.addEventListener("click", async () => {
+          if (distanceSummary) {
+            distanceSummary.textContent = "Zeroing sensor…";
+          }
+          setDistanceCalibrationStatus("Zeroing…", { persistent: true });
+          distanceZeroButton.disabled = true;
+          try {
+            const response = await fetch("/api/distance/calibration/zero", { method: "POST" });
+            if (!response.ok) {
+              let detail = "Unable to zero sensor.";
+              try {
+                const payload = await response.json();
+                if (payload && typeof payload.detail === "string") {
+                  detail = payload.detail;
+                }
+              } catch (err) {
+                console.error(err);
+              }
+              if (distanceSummary) {
+                distanceSummary.textContent = detail;
+              }
+              setDistanceCalibrationStatus(detail, { persistent: true });
+              return;
+            }
+            const payload = await response.json();
+            applyDistanceData(payload, { updateInputs: true, updateCalibration: true });
+            setDistanceCalibrationStatus("Sensor zeroed");
+          } catch (error) {
+            console.error(error);
+            const message = "Unable to zero sensor.";
+            if (distanceSummary) {
+              distanceSummary.textContent = message;
+            }
+            setDistanceCalibrationStatus(message, { persistent: true });
+          } finally {
+            distanceZeroButton.disabled = false;
+          }
+        });
+      }
+
       if (distanceZonesForm) {
         distanceZonesForm.addEventListener("submit", async (event) => {
           event.preventDefault();
@@ -1905,7 +2147,7 @@
               return;
             }
             const payload = await response.json();
-            applyDistanceData(payload, { updateInputs: true });
+            applyDistanceData(payload, { updateInputs: true, updateCalibration: true });
             if (distanceZonesStatus) {
               distanceZonesStatus.textContent = "Warning zones saved";
               setTimeout(() => {
@@ -2980,7 +3222,7 @@
       async function loadSettings() {
         const data = await fetchSettings();
         applySettings(data.orientation, data.camera);
-        applyDistanceData(data.distance, { updateInputs: true });
+        applyDistanceData(data.distance, { updateInputs: true, updateCalibration: true });
       }
 
       form.addEventListener("submit", async (event) => {
@@ -3037,7 +3279,7 @@
           try {
             const data = await fetchSettings();
             applySettings(data.orientation, data.camera, statusLabel.textContent);
-            applyDistanceData(data.distance, { updateInputs: true });
+            applyDistanceData(data.distance, { updateInputs: true, updateCalibration: true });
           } catch (err) {
             console.error(err);
           }
@@ -3046,7 +3288,7 @@
         try {
           const data = await fetchSettings();
           applySettings(data.orientation, data.camera, "Settings saved");
-          applyDistanceData(data.distance, { updateInputs: true });
+          applyDistanceData(data.distance, { updateInputs: true, updateCalibration: true });
         } catch (err) {
           console.error(err);
           statusLabel.textContent = "Settings saved";

--- a/tests/test_app_distance.py
+++ b/tests/test_app_distance.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import types
+import json
 from pathlib import Path
 
 import pytest
@@ -13,20 +14,58 @@ pytest.importorskip("httpx")
 from fastapi.testclient import TestClient
 
 from rev_cam import app as app_module
-from rev_cam.distance import DistanceReading
+from rev_cam.distance import DistanceCalibration, DistanceReading
 
 
 @pytest.fixture
 def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
     class _StubMonitor:
+        def __init__(
+            self,
+            *args,
+            calibration: DistanceCalibration | None = None,
+            **kwargs,
+        ) -> None:
+            self.raw_value = 1.25
+            if calibration is None:
+                self._calibration = DistanceCalibration()
+            else:
+                self._calibration = DistanceCalibration(
+                    calibration.offset_m,
+                    calibration.scale,
+                )
+            self._timestamp = 0.0
+
         def read(self) -> DistanceReading:
+            self._timestamp += 0.1
+            calibrated = self.raw_value * self._calibration.scale + self._calibration.offset_m
             return DistanceReading(
                 available=True,
-                distance_m=1.25,
-                raw_distance_m=1.25,
-                timestamp=0.0,
+                distance_m=calibrated,
+                raw_distance_m=self.raw_value,
+                timestamp=self._timestamp,
                 error=None,
             )
+
+        def set_calibration(
+            self,
+            calibration: DistanceCalibration | None = None,
+            *,
+            offset_m: float | None = None,
+            scale: float | None = None,
+        ) -> DistanceCalibration:
+            if calibration is not None:
+                self._calibration = DistanceCalibration(calibration.offset_m, calibration.scale)
+            else:
+                current = self._calibration
+                self._calibration = DistanceCalibration(
+                    offset_m=current.offset_m if offset_m is None else offset_m,
+                    scale=current.scale if scale is None else scale,
+                )
+            return self._calibration
+
+        def get_calibration(self) -> DistanceCalibration:
+            return self._calibration
 
     class _StubBatteryMonitor:
         def read(self):  # pragma: no cover - used indirectly
@@ -39,12 +78,22 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
         async def aclose(self) -> None:  # pragma: no cover - used indirectly
             return None
 
-    monkeypatch.setattr(app_module, "DistanceMonitor", lambda *args, **kwargs: _StubMonitor())
+    monitor_holder: dict[str, _StubMonitor] = {}
+
+    def _make_monitor(*args, **kwargs) -> _StubMonitor:
+        monitor = _StubMonitor(*args, **kwargs)
+        monitor_holder["instance"] = monitor
+        return monitor
+
+    monkeypatch.setattr(app_module, "DistanceMonitor", _make_monitor)
     monkeypatch.setattr(app_module, "BatteryMonitor", lambda *args, **kwargs: _StubBatteryMonitor())
     monkeypatch.setattr(app_module, "BatterySupervisor", lambda *args, **kwargs: _StubSupervisor())
     monkeypatch.setattr(app_module, "create_battery_overlay", lambda *args, **kwargs: (lambda frame: frame))
-    app = app_module.create_app(tmp_path / "config.json")
+    config_file = tmp_path / "config.json"
+    app = app_module.create_app(config_file)
     with TestClient(app) as test_client:
+        test_client.monitor = monitor_holder.get("instance")
+        test_client.config_path = config_file
         yield test_client
 
 
@@ -57,6 +106,8 @@ def test_distance_endpoint_returns_reading(client: TestClient) -> None:
     assert payload["raw_distance_m"] == pytest.approx(1.25)
     assert payload["zone"] == "warning"
     assert payload["zones"]["danger"] > 0
+    assert payload["calibration"]["offset_m"] == pytest.approx(0.0)
+    assert payload["calibration"]["scale"] == pytest.approx(1.0)
 
 
 def test_distance_zone_update_returns_updated_values(client: TestClient) -> None:
@@ -70,6 +121,7 @@ def test_distance_zone_update_returns_updated_values(client: TestClient) -> None
     assert payload["zones"]["warning"] == pytest.approx(2.5)
     assert payload["zones"]["danger"] == pytest.approx(1.0)
     assert payload["zone"] == "danger"
+    assert payload["calibration"]["scale"] == pytest.approx(1.0)
 
 
 def test_distance_zone_update_validates_order(client: TestClient) -> None:
@@ -80,3 +132,54 @@ def test_distance_zone_update_validates_order(client: TestClient) -> None:
     assert response.status_code == 400
     payload = response.json()
     assert "distance" in payload.get("detail", "").lower()
+
+
+def test_distance_calibration_update_persists(client: TestClient) -> None:
+    monitor = getattr(client, "monitor", None)
+    assert monitor is not None
+    response = client.post(
+        "/api/distance/calibration",
+        json={"offset_m": 0.4, "scale": 1.2},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["calibration"]["offset_m"] == pytest.approx(0.4)
+    assert payload["calibration"]["scale"] == pytest.approx(1.2)
+    expected_distance = monitor.raw_value * 1.2 + 0.4
+    assert payload["distance_m"] == pytest.approx(expected_distance)
+    current_calibration = monitor.get_calibration()
+    assert current_calibration.offset_m == pytest.approx(0.4)
+    assert current_calibration.scale == pytest.approx(1.2)
+    calibration_response = client.get("/api/distance/calibration")
+    assert calibration_response.status_code == 200
+    calibration_payload = calibration_response.json()
+    assert calibration_payload["calibration"]["offset_m"] == pytest.approx(0.4)
+    assert calibration_payload["calibration"]["scale"] == pytest.approx(1.2)
+    config_data = json.loads(Path(client.config_path).read_text())
+    calibration = config_data["distance"]["calibration"]
+    assert calibration["offset_m"] == pytest.approx(0.4)
+    assert calibration["scale"] == pytest.approx(1.2)
+
+
+def test_distance_calibration_rejects_invalid_input(client: TestClient) -> None:
+    response = client.post(
+        "/api/distance/calibration",
+        json={"offset_m": 6.0, "scale": 1.0},
+    )
+    assert response.status_code == 400
+
+
+def test_distance_calibration_zero_endpoint(client: TestClient) -> None:
+    monitor = getattr(client, "monitor", None)
+    assert monitor is not None
+    monitor.raw_value = 0.35
+    response = client.post("/api/distance/calibration/zero")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["calibration"]["offset_m"] == pytest.approx(-0.35, rel=1e-6)
+    assert payload["calibration"]["scale"] == pytest.approx(1.0)
+    assert payload["distance_m"] == pytest.approx(0.0, abs=1e-6)
+    config_data = json.loads(Path(client.config_path).read_text())
+    calibration = config_data["distance"]["calibration"]
+    assert calibration["offset_m"] == pytest.approx(-0.35, rel=1e-6)
+    assert calibration["scale"] == pytest.approx(1.0)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,6 +13,7 @@ from rev_cam.config import (
     DEFAULT_BATTERY_CAPACITY_MAH,
     DEFAULT_CAMERA_CHOICE,
 )
+from rev_cam.distance import DistanceCalibration
 
 
 def test_default_orientation(tmp_path: Path):
@@ -71,6 +72,29 @@ def test_distance_zones_persistence(tmp_path: Path):
     assert isinstance(updated, DistanceZones)
     reloaded = ConfigManager(config_file)
     assert reloaded.get_distance_zones() == updated
+
+
+def test_default_distance_calibration(tmp_path: Path) -> None:
+    manager = ConfigManager(tmp_path / "config.json")
+    calibration = manager.get_distance_calibration()
+    assert isinstance(calibration, DistanceCalibration)
+    assert calibration.offset_m == pytest.approx(0.0)
+    assert calibration.scale == pytest.approx(1.0)
+
+
+def test_distance_calibration_persistence(tmp_path: Path) -> None:
+    config_file = tmp_path / "config.json"
+    manager = ConfigManager(config_file)
+    updated = manager.set_distance_calibration(DistanceCalibration(offset_m=0.3, scale=1.1))
+    assert isinstance(updated, DistanceCalibration)
+    reloaded = ConfigManager(config_file)
+    assert reloaded.get_distance_calibration() == updated
+
+
+def test_distance_calibration_validation(tmp_path: Path) -> None:
+    manager = ConfigManager(tmp_path / "config.json")
+    with pytest.raises(ValueError):
+        manager.set_distance_calibration({"offset_m": "invalid", "scale": 1.0})
 
 
 def test_default_battery_limits(tmp_path: Path):


### PR DESCRIPTION
## Summary
- add a `DistanceCalibration` model, apply calibration inside `DistanceMonitor`, and expose runtime setters
- persist calibration in the config manager and extend the FastAPI distance endpoints with validation and zeroing support
- surface calibration controls and guided zeroing workflow in the settings page and cover the new flows with tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf2e0a493c8332b2d2c76dd3abcd39