### PR TITLE
Fix MJPEG encoding for rotated frames

### DIFF
--- a/src/rev_cam/streaming.py
+++ b/src/rev_cam/streaming.py
@@ -54,6 +54,9 @@ def encode_frame_to_jpeg(
     if array.dtype != np.uint8:
         array = np.clip(array, 0, 255).astype(np.uint8)
 
+    if not array.flags["C_CONTIGUOUS"]:
+        array = np.ascontiguousarray(array)
+
     encode_kwargs: dict[str, object] = {
         "quality": int(quality),
         "colorspace": "RGB",


### PR DESCRIPTION
## Summary
- ensure MJPEG encoding copies non-contiguous frame data before passing it to simplejpeg so rotated frames encode successfully
- extend streaming unit tests to capture encoder inputs and verify non-contiguous frames are re-packed

## Testing
- pytest tests/test_streaming.py


------
https://chatgpt.com/codex/tasks/task_e_68cf1692cb948332a26cf223a97cdb20