### PR TITLE
Add configurable reversing aids overlay and settings

### DIFF
--- a/src/rev_cam/reversing_aids.py
+++ b/src/rev_cam/reversing_aids.py
@@ -1,0 +1,124 @@
+"""Overlay helpers for rendering configurable reversing aids."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+try:  # pragma: no cover - optional dependency on numpy for overlays
+    import numpy as _np
+except ImportError:  # pragma: no cover - optional dependency
+    _np = None
+
+from .config import ReversingAidsConfig, ReversingAidSegment
+
+OverlayFn = Callable[[object], object]
+
+_SEGMENT_COLOURS: tuple[tuple[int, int, int], ...] = (
+    (102, 187, 106),  # green
+    (255, 193, 7),  # amber
+    (239, 83, 80),  # red
+)
+
+
+def create_reversing_aids_overlay(
+    config_provider: Callable[[], ReversingAidsConfig]
+) -> OverlayFn:
+    """Return an overlay function that renders reversing aid guides."""
+
+    def _overlay(frame: object) -> object:
+        if _np is None or not isinstance(frame, _np.ndarray):  # pragma: no cover - optional path
+            return frame
+
+        config = config_provider()
+        if not config.enabled:
+            return frame
+        return _render_reversing_aids(frame, config)
+
+    return _overlay
+
+
+def _render_reversing_aids(frame: _np.ndarray, config: ReversingAidsConfig) -> _np.ndarray:
+    height, width = frame.shape[:2]
+    if height < 10 or width < 10:
+        return frame
+
+    thickness = max(1, int(round(min(width, height) * 0.01)))
+    colours = list(_SEGMENT_COLOURS)
+
+    for index, segment in enumerate(config.left):
+        colour = colours[min(index, len(colours) - 1)]
+        _draw_segment(frame, segment, width, height, thickness, colour)
+
+    for index, segment in enumerate(config.right):
+        colour = colours[min(index, len(colours) - 1)]
+        _draw_segment(frame, segment, width, height, thickness, colour)
+
+    return frame
+
+
+def _draw_segment(
+    frame: _np.ndarray,
+    segment: ReversingAidSegment,
+    width: int,
+    height: int,
+    thickness: int,
+    colour: tuple[int, int, int],
+) -> None:
+    start_x = int(round(segment.start.x * (width - 1)))
+    start_y = int(round(segment.start.y * (height - 1)))
+    end_x = int(round(segment.end.x * (width - 1)))
+    end_y = int(round(segment.end.y * (height - 1)))
+
+    _draw_line(frame, start_x, start_y, end_x, end_y, thickness, colour)
+
+
+def _draw_line(
+    frame: _np.ndarray,
+    x0: int,
+    y0: int,
+    x1: int,
+    y1: int,
+    thickness: int,
+    colour: tuple[int, int, int],
+) -> None:
+    dx = abs(x1 - x0)
+    sx = 1 if x0 < x1 else -1
+    dy = -abs(y1 - y0)
+    sy = 1 if y0 < y1 else -1
+    err = dx + dy
+
+    radius = max(0, thickness // 2)
+
+    while True:
+        _stamp_disc(frame, x0, y0, radius, colour)
+        if x0 == x1 and y0 == y1:
+            break
+        e2 = 2 * err
+        if e2 >= dy:
+            err += dy
+            x0 += sx
+        if e2 <= dx:
+            err += dx
+            y0 += sy
+
+
+def _stamp_disc(
+    frame: _np.ndarray,
+    cx: int,
+    cy: int,
+    radius: int,
+    colour: tuple[int, int, int],
+) -> None:
+    height, width = frame.shape[:2]
+    for y in range(cy - radius, cy + radius + 1):
+        if y < 0 or y >= height:
+            continue
+        for x in range(cx - radius, cx + radius + 1):
+            if x < 0 or x >= width:
+                continue
+            if radius == 0 or (x - cx) ** 2 + (y - cy) ** 2 <= radius**2:
+                frame[y, x] = colour
+
+
+__all__ = ["create_reversing_aids_overlay"]
+

--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -236,6 +236,86 @@
         gap: 0.75rem;
         flex-wrap: wrap;
       }
+      #reversing-aids-form {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+      }
+      #reversing-aids-status {
+        min-height: 1.2rem;
+      }
+      .reversing-grid {
+        display: grid;
+        gap: 1rem;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      }
+      fieldset.reversing-side {
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        border-radius: 12px;
+        padding: 1rem;
+        background: rgba(255, 255, 255, 0.03);
+      }
+      fieldset.reversing-side legend {
+        padding: 0 0.35rem;
+        font-weight: 600;
+      }
+      fieldset.reversing-side p {
+        margin: 0.25rem 0 0.85rem;
+        font-size: 0.9rem;
+        opacity: 0.8;
+      }
+      fieldset.reversing-side:disabled {
+        opacity: 0.6;
+      }
+      .reversing-nudge-group {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+        margin-bottom: 1rem;
+      }
+      .reversing-nudge-buttons {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 0.25rem;
+      }
+      .reversing-nudge-buttons button {
+        padding: 0.35rem 0.65rem;
+        font-size: 0.9rem;
+      }
+      .reversing-segment {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        margin-bottom: 1.25rem;
+      }
+      .reversing-segment:last-of-type {
+        margin-bottom: 0;
+      }
+      .reversing-segment-header {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        font-weight: 600;
+      }
+      .reversing-colour {
+        width: 0.9rem;
+        height: 0.9rem;
+        border-radius: 50%;
+        display: inline-block;
+      }
+      .reversing-segment-fields {
+        display: grid;
+        gap: 0.75rem;
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      }
+      .reversing-segment-fields label {
+        display: flex;
+        flex-direction: column;
+        gap: 0.4rem;
+        font-size: 0.9rem;
+        margin: 0;
+      }
       #status {
         font-size: 0.95rem;
         opacity: 0.85;
@@ -601,6 +681,18 @@
             type="button"
             class="tab-button"
             role="tab"
+            id="tab-reversing"
+            aria-controls="panel-reversing"
+            aria-selected="false"
+            data-tab="reversing"
+            tabindex="-1"
+          >
+            Reversing aids
+          </button>
+          <button
+            type="button"
+            class="tab-button"
+            role="tab"
             id="tab-network"
             aria-controls="panel-network"
             aria-selected="false"
@@ -871,6 +963,505 @@
         </section>
 
         <section
+          id="panel-reversing"
+          class="tab-panel"
+          role="tabpanel"
+          aria-labelledby="tab-reversing"
+          data-tab="reversing"
+          hidden
+        >
+          <form id="reversing-aids-form" class="card">
+            <h2>Reversing aids</h2>
+            <p class="muted">
+              Configure the on-screen guides to match your vehicle width, camera position and
+              preferred viewing angle.
+            </p>
+            <label style="display: inline-flex; align-items: center; gap: 0.5rem;">
+              <input type="checkbox" id="reversing-aids-enabled" />
+              Show reversing aids on the live view
+            </label>
+            <p class="muted" style="margin: 0;">
+              Coordinates are expressed as percentages of the frame. Adjust the nudge controls to
+              shift each side without changing individual values.
+            </p>
+            <div class="reversing-grid">
+              <fieldset class="reversing-side" data-side="left">
+                <legend>Left guide</legend>
+                <p>Adjust the driver’s-side guide segments. Use nudge buttons for quick alignment.</p>
+                <div class="reversing-nudge-group">
+                  <span class="muted">Nudge:</span>
+                  <div class="reversing-nudge-buttons">
+                    <button
+                      type="button"
+                      data-reversing-nudge="up"
+                      data-side="left"
+                      aria-label="Nudge left guide up"
+                    >
+                      ↑
+                    </button>
+                    <button
+                      type="button"
+                      data-reversing-nudge="down"
+                      data-side="left"
+                      aria-label="Nudge left guide down"
+                    >
+                      ↓
+                    </button>
+                    <button
+                      type="button"
+                      data-reversing-nudge="left"
+                      data-side="left"
+                      aria-label="Nudge left guide left"
+                    >
+                      ←
+                    </button>
+                    <button
+                      type="button"
+                      data-reversing-nudge="right"
+                      data-side="left"
+                      aria-label="Nudge left guide right"
+                    >
+                      →
+                    </button>
+                  </div>
+                </div>
+                <div class="reversing-segment" data-side="left" data-segment="0">
+                  <div class="reversing-segment-header">
+                    <span class="reversing-colour" style="background: #66bb6a;"></span>
+                    <span>Far segment</span>
+                  </div>
+                  <div class="reversing-segment-fields">
+                    <label>
+                      Start horizontal (%)
+                      <input
+                        type="number"
+                        min="0"
+                        max="100"
+                        step="0.5"
+                        inputmode="decimal"
+                        data-reversing-field="start-x"
+                        data-segment="0"
+                        data-side="left"
+                        data-axis="x"
+                      />
+                    </label>
+                    <label>
+                      Start vertical (%)
+                      <input
+                        type="number"
+                        min="0"
+                        max="100"
+                        step="0.5"
+                        inputmode="decimal"
+                        data-reversing-field="start-y"
+                        data-segment="0"
+                        data-side="left"
+                        data-axis="y"
+                      />
+                    </label>
+                    <label>
+                      End horizontal (%)
+                      <input
+                        type="number"
+                        min="0"
+                        max="100"
+                        step="0.5"
+                        inputmode="decimal"
+                        data-reversing-field="end-x"
+                        data-segment="0"
+                        data-side="left"
+                        data-axis="x"
+                      />
+                    </label>
+                    <label>
+                      End vertical (%)
+                      <input
+                        type="number"
+                        min="0"
+                        max="100"
+                        step="0.5"
+                        inputmode="decimal"
+                        data-reversing-field="end-y"
+                        data-segment="0"
+                        data-side="left"
+                        data-axis="y"
+                      />
+                    </label>
+                  </div>
+                </div>
+                <div class="reversing-segment" data-side="left" data-segment="1">
+                  <div class="reversing-segment-header">
+                    <span class="reversing-colour" style="background: #ffc107;"></span>
+                    <span>Mid segment</span>
+                  </div>
+                  <div class="reversing-segment-fields">
+                    <label>
+                      Start horizontal (%)
+                      <input
+                        type="number"
+                        min="0"
+                        max="100"
+                        step="0.5"
+                        inputmode="decimal"
+                        data-reversing-field="start-x"
+                        data-segment="1"
+                        data-side="left"
+                        data-axis="x"
+                      />
+                    </label>
+                    <label>
+                      Start vertical (%)
+                      <input
+                        type="number"
+                        min="0"
+                        max="100"
+                        step="0.5"
+                        inputmode="decimal"
+                        data-reversing-field="start-y"
+                        data-segment="1"
+                        data-side="left"
+                        data-axis="y"
+                      />
+                    </label>
+                    <label>
+                      End horizontal (%)
+                      <input
+                        type="number"
+                        min="0"
+                        max="100"
+                        step="0.5"
+                        inputmode="decimal"
+                        data-reversing-field="end-x"
+                        data-segment="1"
+                        data-side="left"
+                        data-axis="x"
+                      />
+                    </label>
+                    <label>
+                      End vertical (%)
+                      <input
+                        type="number"
+                        min="0"
+                        max="100"
+                        step="0.5"
+                        inputmode="decimal"
+                        data-reversing-field="end-y"
+                        data-segment="1"
+                        data-side="left"
+                        data-axis="y"
+                      />
+                    </label>
+                  </div>
+                </div>
+                <div class="reversing-segment" data-side="left" data-segment="2">
+                  <div class="reversing-segment-header">
+                    <span class="reversing-colour" style="background: #ef5350;"></span>
+                    <span>Near segment</span>
+                  </div>
+                  <div class="reversing-segment-fields">
+                    <label>
+                      Start horizontal (%)
+                      <input
+                        type="number"
+                        min="0"
+                        max="100"
+                        step="0.5"
+                        inputmode="decimal"
+                        data-reversing-field="start-x"
+                        data-segment="2"
+                        data-side="left"
+                        data-axis="x"
+                      />
+                    </label>
+                    <label>
+                      Start vertical (%)
+                      <input
+                        type="number"
+                        min="0"
+                        max="100"
+                        step="0.5"
+                        inputmode="decimal"
+                        data-reversing-field="start-y"
+                        data-segment="2"
+                        data-side="left"
+                        data-axis="y"
+                      />
+                    </label>
+                    <label>
+                      End horizontal (%)
+                      <input
+                        type="number"
+                        min="0"
+                        max="100"
+                        step="0.5"
+                        inputmode="decimal"
+                        data-reversing-field="end-x"
+                        data-segment="2"
+                        data-side="left"
+                        data-axis="x"
+                      />
+                    </label>
+                    <label>
+                      End vertical (%)
+                      <input
+                        type="number"
+                        min="0"
+                        max="100"
+                        step="0.5"
+                        inputmode="decimal"
+                        data-reversing-field="end-y"
+                        data-segment="2"
+                        data-side="left"
+                        data-axis="y"
+                      />
+                    </label>
+                  </div>
+                </div>
+              </fieldset>
+              <fieldset class="reversing-side" data-side="right">
+                <legend>Right guide</legend>
+                <p>
+                  Adjust the passenger-side guide segments. Nudge controls apply to the whole side.
+                </p>
+                <div class="reversing-nudge-group">
+                  <span class="muted">Nudge:</span>
+                  <div class="reversing-nudge-buttons">
+                    <button
+                      type="button"
+                      data-reversing-nudge="up"
+                      data-side="right"
+                      aria-label="Nudge right guide up"
+                    >
+                      ↑
+                    </button>
+                    <button
+                      type="button"
+                      data-reversing-nudge="down"
+                      data-side="right"
+                      aria-label="Nudge right guide down"
+                    >
+                      ↓
+                    </button>
+                    <button
+                      type="button"
+                      data-reversing-nudge="left"
+                      data-side="right"
+                      aria-label="Nudge right guide left"
+                    >
+                      ←
+                    </button>
+                    <button
+                      type="button"
+                      data-reversing-nudge="right"
+                      data-side="right"
+                      aria-label="Nudge right guide right"
+                    >
+                      →
+                    </button>
+                  </div>
+                </div>
+                <div class="reversing-segment" data-side="right" data-segment="0">
+                  <div class="reversing-segment-header">
+                    <span class="reversing-colour" style="background: #66bb6a;"></span>
+                    <span>Far segment</span>
+                  </div>
+                  <div class="reversing-segment-fields">
+                    <label>
+                      Start horizontal (%)
+                      <input
+                        type="number"
+                        min="0"
+                        max="100"
+                        step="0.5"
+                        inputmode="decimal"
+                        data-reversing-field="start-x"
+                        data-segment="0"
+                        data-side="right"
+                        data-axis="x"
+                      />
+                    </label>
+                    <label>
+                      Start vertical (%)
+                      <input
+                        type="number"
+                        min="0"
+                        max="100"
+                        step="0.5"
+                        inputmode="decimal"
+                        data-reversing-field="start-y"
+                        data-segment="0"
+                        data-side="right"
+                        data-axis="y"
+                      />
+                    </label>
+                    <label>
+                      End horizontal (%)
+                      <input
+                        type="number"
+                        min="0"
+                        max="100"
+                        step="0.5"
+                        inputmode="decimal"
+                        data-reversing-field="end-x"
+                        data-segment="0"
+                        data-side="right"
+                        data-axis="x"
+                      />
+                    </label>
+                    <label>
+                      End vertical (%)
+                      <input
+                        type="number"
+                        min="0"
+                        max="100"
+                        step="0.5"
+                        inputmode="decimal"
+                        data-reversing-field="end-y"
+                        data-segment="0"
+                        data-side="right"
+                        data-axis="y"
+                      />
+                    </label>
+                  </div>
+                </div>
+                <div class="reversing-segment" data-side="right" data-segment="1">
+                  <div class="reversing-segment-header">
+                    <span class="reversing-colour" style="background: #ffc107;"></span>
+                    <span>Mid segment</span>
+                  </div>
+                  <div class="reversing-segment-fields">
+                    <label>
+                      Start horizontal (%)
+                      <input
+                        type="number"
+                        min="0"
+                        max="100"
+                        step="0.5"
+                        inputmode="decimal"
+                        data-reversing-field="start-x"
+                        data-segment="1"
+                        data-side="right"
+                        data-axis="x"
+                      />
+                    </label>
+                    <label>
+                      Start vertical (%)
+                      <input
+                        type="number"
+                        min="0"
+                        max="100"
+                        step="0.5"
+                        inputmode="decimal"
+                        data-reversing-field="start-y"
+                        data-segment="1"
+                        data-side="right"
+                        data-axis="y"
+                      />
+                    </label>
+                    <label>
+                      End horizontal (%)
+                      <input
+                        type="number"
+                        min="0"
+                        max="100"
+                        step="0.5"
+                        inputmode="decimal"
+                        data-reversing-field="end-x"
+                        data-segment="1"
+                        data-side="right"
+                        data-axis="x"
+                      />
+                    </label>
+                    <label>
+                      End vertical (%)
+                      <input
+                        type="number"
+                        min="0"
+                        max="100"
+                        step="0.5"
+                        inputmode="decimal"
+                        data-reversing-field="end-y"
+                        data-segment="1"
+                        data-side="right"
+                        data-axis="y"
+                      />
+                    </label>
+                  </div>
+                </div>
+                <div class="reversing-segment" data-side="right" data-segment="2">
+                  <div class="reversing-segment-header">
+                    <span class="reversing-colour" style="background: #ef5350;"></span>
+                    <span>Near segment</span>
+                  </div>
+                  <div class="reversing-segment-fields">
+                    <label>
+                      Start horizontal (%)
+                      <input
+                        type="number"
+                        min="0"
+                        max="100"
+                        step="0.5"
+                        inputmode="decimal"
+                        data-reversing-field="start-x"
+                        data-segment="2"
+                        data-side="right"
+                        data-axis="x"
+                      />
+                    </label>
+                    <label>
+                      Start vertical (%)
+                      <input
+                        type="number"
+                        min="0"
+                        max="100"
+                        step="0.5"
+                        inputmode="decimal"
+                        data-reversing-field="start-y"
+                        data-segment="2"
+                        data-side="right"
+                        data-axis="y"
+                      />
+                    </label>
+                    <label>
+                      End horizontal (%)
+                      <input
+                        type="number"
+                        min="0"
+                        max="100"
+                        step="0.5"
+                        inputmode="decimal"
+                        data-reversing-field="end-x"
+                        data-segment="2"
+                        data-side="right"
+                        data-axis="x"
+                      />
+                    </label>
+                    <label>
+                      End vertical (%)
+                      <input
+                        type="number"
+                        min="0"
+                        max="100"
+                        step="0.5"
+                        inputmode="decimal"
+                        data-reversing-field="end-y"
+                        data-segment="2"
+                        data-side="right"
+                        data-axis="y"
+                      />
+                    </label>
+                  </div>
+                </div>
+              </fieldset>
+            </div>
+            <div class="form-actions">
+              <button type="submit">Save reversing aids</button>
+              <span id="reversing-aids-status" class="muted"></span>
+            </div>
+          </form>
+        </section>
+
+        <section
           id="panel-network"
           class="tab-panel"
           role="tabpanel"
@@ -1095,6 +1686,41 @@
           }
         }
       }
+      const reversingAidsForm = document.getElementById("reversing-aids-form");
+      const reversingAidsStatus = document.getElementById("reversing-aids-status");
+      const reversingAidsEnabledInput = document.getElementById("reversing-aids-enabled");
+      const reversingSideFieldsets = reversingAidsForm
+        ? Array.from(reversingAidsForm.querySelectorAll("fieldset.reversing-side")).filter(
+            (element) => element instanceof HTMLFieldSetElement,
+          )
+        : [];
+      const reversingInputs = reversingAidsForm
+        ? Array.from(
+            reversingAidsForm.querySelectorAll('input[data-reversing-field]'),
+          ).filter((element) => element instanceof HTMLInputElement)
+        : [];
+      const reversingInputMap = new Map();
+      if (reversingInputs.length) {
+        for (const input of reversingInputs) {
+          if (!input.dataset.side || !input.dataset.segment || !input.dataset.reversingField) {
+            continue;
+          }
+          const key = `${input.dataset.side}|${input.dataset.segment}|${input.dataset.reversingField}`;
+          reversingInputMap.set(key, input);
+          input.addEventListener("input", () => {
+            input.dataset.userEdited = "true";
+            if (reversingAidsStatus) {
+              reversingAidsStatus.textContent = "";
+            }
+          });
+        }
+      }
+      const reversingNudgeButtons = reversingAidsForm
+        ? Array.from(
+            reversingAidsForm.querySelectorAll('button[data-reversing-nudge]'),
+          ).filter((element) => element instanceof HTMLButtonElement)
+        : [];
+      const REVERSING_NUDGE_STEP = 1;
       const diagnosticsButton = document.getElementById("diagnostics-refresh");
       const diagnosticsStatus = document.getElementById("diagnostics-status");
       const diagnosticsResults = document.getElementById("diagnostics-results");
@@ -1265,6 +1891,179 @@
       }
 
       setStreamQualityDisplay(null);
+
+      function formatPercentageValue(value) {
+        if (typeof value !== "number" || !Number.isFinite(value)) {
+          return "";
+        }
+        const rounded = Math.round(value * 10) / 10;
+        let text = rounded.toFixed(1);
+        if (text.endsWith(".0")) {
+          text = text.slice(0, -2);
+        }
+        return text;
+      }
+
+      function normalisedToPercent(value) {
+        if (typeof value !== "number" || !Number.isFinite(value)) {
+          return null;
+        }
+        const clamped = Math.min(1, Math.max(0, value));
+        return Math.round(clamped * 1000) / 10;
+      }
+
+      function setReversingInputsDisabled(disabled) {
+        if (!reversingSideFieldsets.length) {
+          return;
+        }
+        for (const fieldset of reversingSideFieldsets) {
+          fieldset.disabled = Boolean(disabled);
+        }
+      }
+
+      function setReversingInputValue(input, normalised) {
+        if (!(input instanceof HTMLInputElement)) {
+          return;
+        }
+        const percent = normalisedToPercent(normalised);
+        if (percent === null) {
+          input.value = "";
+        } else {
+          input.value = formatPercentageValue(percent);
+        }
+        delete input.dataset.userEdited;
+      }
+
+      function updateReversingAidsStatus(config) {
+        if (!reversingAidsStatus) {
+          return;
+        }
+        if (!config) {
+          reversingAidsStatus.textContent = "Unable to load reversing aids.";
+          return;
+        }
+        reversingAidsStatus.textContent = config.enabled
+          ? "Reversing aids are enabled."
+          : "Reversing aids are disabled.";
+      }
+
+      function updateReversingAidsInputs(config, forceUpdate = false) {
+        if (!reversingInputMap.size) {
+          return;
+        }
+        const sides = ["left", "right"];
+        for (const side of sides) {
+          const segments = Array.isArray(config?.[side]) ? config[side] : [];
+          for (let index = 0; index < 3; index += 1) {
+            const segment = segments[index] || null;
+            const start = segment && segment.start ? segment.start : null;
+            const end = segment && segment.end ? segment.end : null;
+            const mappings = {
+              "start-x": start && typeof start.x === "number" ? start.x : null,
+              "start-y": start && typeof start.y === "number" ? start.y : null,
+              "end-x": end && typeof end.x === "number" ? end.x : null,
+              "end-y": end && typeof end.y === "number" ? end.y : null,
+            };
+            for (const [field, value] of Object.entries(mappings)) {
+              const key = `${side}|${index}|${field}`;
+              const input = reversingInputMap.get(key);
+              if (!(input instanceof HTMLInputElement)) {
+                continue;
+              }
+              if (!forceUpdate && input.dataset.userEdited === "true") {
+                continue;
+              }
+              setReversingInputValue(input, value);
+            }
+          }
+        }
+      }
+
+      function applyReversingAids(config, options = {}) {
+        if (!reversingAidsEnabledInput) {
+          return;
+        }
+        const forceUpdate = options.forceUpdate === true || options.updateInputs === true;
+        const enabled = config && typeof config.enabled === "boolean" ? config.enabled : false;
+        reversingAidsEnabledInput.checked = enabled;
+        setReversingInputsDisabled(!enabled);
+        updateReversingAidsStatus(config);
+        updateReversingAidsInputs(config, forceUpdate);
+      }
+
+      function readReversingInput(input) {
+        if (!(input instanceof HTMLInputElement)) {
+          throw new Error("Reversing aids input missing.");
+        }
+        const raw = parseFloat(input.value);
+        if (!Number.isFinite(raw)) {
+          throw new Error("Enter numeric values between 0 and 100.");
+        }
+        if (raw < 0 || raw > 100) {
+          throw new Error("Values must be between 0 and 100.");
+        }
+        return raw / 100;
+      }
+
+      function collectReversingAidsPayload() {
+        if (!reversingAidsEnabledInput) {
+          throw new Error("Reversing aids form unavailable.");
+        }
+        const payload = {
+          enabled: reversingAidsEnabledInput.checked,
+          left: [],
+          right: [],
+        };
+        const sides = ["left", "right"];
+        const segmentsPerSide = 3;
+        for (const side of sides) {
+          for (let index = 0; index < segmentsPerSide; index += 1) {
+            const startX = reversingInputMap.get(`${side}|${index}|start-x`);
+            const startY = reversingInputMap.get(`${side}|${index}|start-y`);
+            const endX = reversingInputMap.get(`${side}|${index}|end-x`);
+            const endY = reversingInputMap.get(`${side}|${index}|end-y`);
+            if (!startX || !startY || !endX || !endY) {
+              throw new Error("Reversing aids inputs are missing.");
+            }
+            payload[side].push({
+              start: {
+                x: readReversingInput(startX),
+                y: readReversingInput(startY),
+              },
+              end: {
+                x: readReversingInput(endX),
+                y: readReversingInput(endY),
+              },
+            });
+          }
+        }
+        return payload;
+      }
+
+      function adjustReversingSide(side, deltaX, deltaY) {
+        if (!reversingInputs.length) {
+          return;
+        }
+        for (const input of reversingInputs) {
+          if (!(input instanceof HTMLInputElement) || input.dataset.side !== side) {
+            continue;
+          }
+          const axis = input.dataset.axis;
+          const current = parseFloat(input.value);
+          if (!Number.isFinite(current)) {
+            continue;
+          }
+          if (axis === "x" && deltaX !== 0) {
+            const updated = Math.min(100, Math.max(0, current + deltaX));
+            input.value = formatPercentageValue(updated);
+            input.dataset.userEdited = "true";
+          } else if (axis === "y" && deltaY !== 0) {
+            const updated = Math.min(100, Math.max(0, current + deltaY));
+            input.value = formatPercentageValue(updated);
+            input.dataset.userEdited = "true";
+          }
+        }
+      }
 
       function formatDistance(value) {
         if (typeof value !== "number" || Number.isNaN(value)) {
@@ -2161,6 +2960,95 @@
             if (distanceZonesStatus) {
               distanceZonesStatus.textContent = "Unable to save warning zones.";
             }
+          }
+        });
+      }
+
+      if (reversingAidsEnabledInput) {
+        setReversingInputsDisabled(!reversingAidsEnabledInput.checked);
+        reversingAidsEnabledInput.addEventListener("change", () => {
+          setReversingInputsDisabled(!reversingAidsEnabledInput.checked);
+        });
+      }
+
+      if (reversingNudgeButtons.length) {
+        for (const button of reversingNudgeButtons) {
+          button.addEventListener("click", () => {
+            const side = button.dataset.side;
+            const direction = button.dataset.reversingNudge;
+            if (!side || !direction) {
+              return;
+            }
+            let deltaX = 0;
+            let deltaY = 0;
+            if (direction === "left") {
+              deltaX = -REVERSING_NUDGE_STEP;
+            } else if (direction === "right") {
+              deltaX = REVERSING_NUDGE_STEP;
+            } else if (direction === "up") {
+              deltaY = -REVERSING_NUDGE_STEP;
+            } else if (direction === "down") {
+              deltaY = REVERSING_NUDGE_STEP;
+            }
+            if (deltaX === 0 && deltaY === 0) {
+              return;
+            }
+            adjustReversingSide(side, deltaX, deltaY);
+            if (reversingAidsStatus) {
+              reversingAidsStatus.textContent = "";
+            }
+          });
+        }
+      }
+
+      if (reversingAidsForm) {
+        reversingAidsForm.addEventListener("submit", async (event) => {
+          event.preventDefault();
+          if (!reversingAidsStatus) {
+            return;
+          }
+          let payload;
+          try {
+            payload = collectReversingAidsPayload();
+          } catch (err) {
+            const message = err instanceof Error ? err.message : "Unable to save reversing aids.";
+            reversingAidsStatus.textContent = message;
+            return;
+          }
+          reversingAidsStatus.textContent = "Saving…";
+          try {
+            const response = await fetch("/api/reversing-aids", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(payload),
+            });
+            if (!response.ok) {
+              let detail = "Unable to save reversing aids.";
+              try {
+                const problem = await response.json();
+                if (problem && typeof problem.detail === "string") {
+                  detail = problem.detail;
+                }
+              } catch (err2) {
+                console.error(err2);
+              }
+              reversingAidsStatus.textContent = detail;
+              return;
+            }
+            const data = await response.json();
+            applyReversingAids(data, { forceUpdate: true });
+            reversingAidsStatus.textContent = "Reversing aids saved.";
+            setTimeout(() => {
+              if (
+                reversingAidsStatus &&
+                reversingAidsStatus.textContent === "Reversing aids saved."
+              ) {
+                reversingAidsStatus.textContent = "";
+              }
+            }, 3000);
+          } catch (err) {
+            console.error("Reversing aids update error", err);
+            reversingAidsStatus.textContent = "Unable to save reversing aids.";
           }
         });
       }
@@ -3197,10 +4085,16 @@
       }
 
       async function fetchSettings() {
-        const [orientationResponse, cameraResponse, distanceResponse] = await Promise.all([
+        const [
+          orientationResponse,
+          cameraResponse,
+          distanceResponse,
+          reversingResponse,
+        ] = await Promise.all([
           fetch("/api/orientation"),
           fetch("/api/camera"),
           fetch("/api/distance"),
+          fetch("/api/reversing-aids"),
         ]);
         if (!orientationResponse.ok) {
           throw new Error("Unable to fetch current orientation");
@@ -3211,18 +4105,28 @@
         if (!distanceResponse.ok) {
           throw new Error("Unable to fetch distance configuration");
         }
-        const [orientationData, cameraData, distanceData] = await Promise.all([
+        if (!reversingResponse.ok) {
+          throw new Error("Unable to fetch reversing aid configuration");
+        }
+        const [orientationData, cameraData, distanceData, reversingData] = await Promise.all([
           orientationResponse.json(),
           cameraResponse.json(),
           distanceResponse.json(),
+          reversingResponse.json(),
         ]);
-        return { orientation: orientationData, camera: cameraData, distance: distanceData };
+        return {
+          orientation: orientationData,
+          camera: cameraData,
+          distance: distanceData,
+          reversing: reversingData,
+        };
       }
 
       async function loadSettings() {
         const data = await fetchSettings();
         applySettings(data.orientation, data.camera);
         applyDistanceData(data.distance, { updateInputs: true, updateCalibration: true });
+        applyReversingAids(data.reversing, { forceUpdate: true });
       }
 
       form.addEventListener("submit", async (event) => {
@@ -3280,6 +4184,7 @@
             const data = await fetchSettings();
             applySettings(data.orientation, data.camera, statusLabel.textContent);
             applyDistanceData(data.distance, { updateInputs: true, updateCalibration: true });
+            applyReversingAids(data.reversing, { forceUpdate: true });
           } catch (err) {
             console.error(err);
           }
@@ -3289,6 +4194,7 @@
           const data = await fetchSettings();
           applySettings(data.orientation, data.camera, "Settings saved");
           applyDistanceData(data.distance, { updateInputs: true, updateCalibration: true });
+          applyReversingAids(data.reversing, { forceUpdate: true });
         } catch (err) {
           console.error(err);
           statusLabel.textContent = "Settings saved";

--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -1119,49 +1119,6 @@
             <fieldset class="reversing-side" data-side="left">
                 <legend>Left guide</legend>
                 <p>Adjust the driver’s-side guide segments. Click the preview or edit the values.</p>
-                <div class="reversing-line-point" data-side="left" data-point="near">
-                  <div class="reversing-line-header">
-                    <span class="reversing-colour" style="background: #ef5350;"></span>
-                    <span>Near point</span>
-                    <button
-                      type="button"
-                      class="reversing-point-button"
-                      data-side="left"
-                      data-reversing-pick="near"
-                      aria-pressed="false"
-                    >
-                      Select on preview
-                    </button>
-                  </div>
-                  <div class="reversing-line-fields">
-                    <label>
-                      Horizontal (%)
-                      <input
-                        type="number"
-                        min="0"
-                        max="100"
-                        step="0.1"
-                        inputmode="decimal"
-                        data-reversing-field="near-x"
-                        data-side="left"
-                        data-axis="x"
-                      />
-                    </label>
-                    <label>
-                      Vertical (%)
-                      <input
-                        type="number"
-                        min="0"
-                        max="100"
-                        step="0.1"
-                        inputmode="decimal"
-                        data-reversing-field="near-y"
-                        data-side="left"
-                        data-axis="y"
-                      />
-                    </label>
-                  </div>
-                </div>
                 <div class="reversing-line-point" data-side="left" data-point="far">
                   <div class="reversing-line-header">
                     <span class="reversing-colour" style="background: #66bb6a;"></span>
@@ -1205,18 +1162,14 @@
                     </label>
                   </div>
                 </div>
-              </fieldset>
-              <fieldset class="reversing-side" data-side="right">
-                <legend>Right guide</legend>
-                <p>Adjust the passenger-side guide segments from the preview or the inputs.</p>
-                <div class="reversing-line-point" data-side="right" data-point="near">
+                <div class="reversing-line-point" data-side="left" data-point="near">
                   <div class="reversing-line-header">
                     <span class="reversing-colour" style="background: #ef5350;"></span>
                     <span>Near point</span>
                     <button
                       type="button"
                       class="reversing-point-button"
-                      data-side="right"
+                      data-side="left"
                       data-reversing-pick="near"
                       aria-pressed="false"
                     >
@@ -1233,7 +1186,7 @@
                         step="0.1"
                         inputmode="decimal"
                         data-reversing-field="near-x"
-                        data-side="right"
+                        data-side="left"
                         data-axis="x"
                       />
                     </label>
@@ -1246,12 +1199,16 @@
                         step="0.1"
                         inputmode="decimal"
                         data-reversing-field="near-y"
-                        data-side="right"
+                        data-side="left"
                         data-axis="y"
                       />
                     </label>
                   </div>
                 </div>
+              </fieldset>
+              <fieldset class="reversing-side" data-side="right">
+                <legend>Right guide</legend>
+                <p>Adjust the passenger-side guide segments from the preview or the inputs.</p>
                 <div class="reversing-line-point" data-side="right" data-point="far">
                   <div class="reversing-line-header">
                     <span class="reversing-colour" style="background: #66bb6a;"></span>
@@ -1289,6 +1246,49 @@
                         step="0.1"
                         inputmode="decimal"
                         data-reversing-field="far-y"
+                        data-side="right"
+                        data-axis="y"
+                      />
+                    </label>
+                  </div>
+                </div>
+                <div class="reversing-line-point" data-side="right" data-point="near">
+                  <div class="reversing-line-header">
+                    <span class="reversing-colour" style="background: #ef5350;"></span>
+                    <span>Near point</span>
+                    <button
+                      type="button"
+                      class="reversing-point-button"
+                      data-side="right"
+                      data-reversing-pick="near"
+                      aria-pressed="false"
+                    >
+                      Select on preview
+                    </button>
+                  </div>
+                  <div class="reversing-line-fields">
+                    <label>
+                      Horizontal (%)
+                      <input
+                        type="number"
+                        min="0"
+                        max="100"
+                        step="0.1"
+                        inputmode="decimal"
+                        data-reversing-field="near-x"
+                        data-side="right"
+                        data-axis="x"
+                      />
+                    </label>
+                    <label>
+                      Vertical (%)
+                      <input
+                        type="number"
+                        min="0"
+                        max="100"
+                        step="0.1"
+                        inputmode="decimal"
+                        data-reversing-field="near-y"
                         data-side="right"
                         data-axis="y"
                       />

--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -283,6 +283,31 @@
         padding: 0.35rem 0.65rem;
         font-size: 0.9rem;
       }
+      .reversing-angle-group {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+        margin-bottom: 1rem;
+      }
+      .reversing-angle-buttons {
+        display: inline-flex;
+        gap: 0.25rem;
+      }
+      .reversing-angle-buttons button {
+        padding: 0.35rem 0.65rem;
+        font-size: 0.9rem;
+      }
+      .reversing-angle-value {
+        font-weight: 600;
+        font-variant-numeric: tabular-nums;
+        min-width: 3rem;
+      }
+      .reversing-angle-hint {
+        margin: -0.25rem 0 0.75rem;
+        font-size: 0.85rem;
+        opacity: 0.75;
+      }
       .reversing-segment {
         display: flex;
         flex-direction: column;
@@ -1093,10 +1118,14 @@
                 <div class="reversing-preview-placeholder" id="reversing-preview-placeholder">
                   Capture a snapshot or upload an image to preview the reversing aids.
                 </div>
-              </div>
             </div>
-            <div class="reversing-grid">
-              <fieldset class="reversing-side" data-side="left">
+          </div>
+          <p class="muted reversing-angle-hint">
+            Angle controls rotate each side together so the guide segments stay parallel. Values
+            are reported in degrees from the horizontal.
+          </p>
+          <div class="reversing-grid">
+            <fieldset class="reversing-side" data-side="left">
                 <legend>Left guide</legend>
                 <p>Adjust the driver’s-side guide segments. Use nudge buttons for quick alignment.</p>
                 <div class="reversing-nudge-group">
@@ -1135,6 +1164,36 @@
                       →
                     </button>
                   </div>
+                </div>
+                <div class="reversing-angle-group" data-side="left">
+                  <span class="muted">Angle:</span>
+                  <div class="reversing-angle-buttons">
+                    <button
+                      type="button"
+                      data-reversing-angle="narrow"
+                      data-side="left"
+                      aria-label="Make left guide more vertical"
+                      title="Make left guide more vertical"
+                    >
+                      –
+                    </button>
+                    <button
+                      type="button"
+                      data-reversing-angle="wide"
+                      data-side="left"
+                      aria-label="Make left guide more horizontal"
+                      title="Make left guide more horizontal"
+                    >
+                      +
+                    </button>
+                  </div>
+                  <output
+                    class="reversing-angle-value"
+                    data-reversing-angle-value="left"
+                    aria-live="polite"
+                  >
+                    —
+                  </output>
                 </div>
                 <div class="reversing-segment" data-side="left" data-segment="0">
                   <div class="reversing-segment-header">
@@ -1370,6 +1429,36 @@
                       →
                     </button>
                   </div>
+                </div>
+                <div class="reversing-angle-group" data-side="right">
+                  <span class="muted">Angle:</span>
+                  <div class="reversing-angle-buttons">
+                    <button
+                      type="button"
+                      data-reversing-angle="narrow"
+                      data-side="right"
+                      aria-label="Make right guide more vertical"
+                      title="Make right guide more vertical"
+                    >
+                      –
+                    </button>
+                    <button
+                      type="button"
+                      data-reversing-angle="wide"
+                      data-side="right"
+                      aria-label="Make right guide more horizontal"
+                      title="Make right guide more horizontal"
+                    >
+                      +
+                    </button>
+                  </div>
+                  <output
+                    class="reversing-angle-value"
+                    data-reversing-angle-value="right"
+                    aria-live="polite"
+                  >
+                    —
+                  </output>
                 </div>
                 <div class="reversing-segment" data-side="right" data-segment="0">
                   <div class="reversing-segment-header">
@@ -1823,10 +1912,31 @@
             if (reversingAidsStatus) {
               reversingAidsStatus.textContent = "";
             }
+            handleReversingInputEdit(input);
             drawReversingPreviewOverlay();
           });
         }
       }
+      const reversingAngleValueElements = reversingAidsForm
+        ? Array.from(
+            reversingAidsForm.querySelectorAll('[data-reversing-angle-value]'),
+          ).filter((element) => element instanceof HTMLElement)
+        : [];
+      const reversingAngleValueMap = new Map();
+      if (reversingAngleValueElements.length) {
+        for (const element of reversingAngleValueElements) {
+          const side = element.dataset.reversingAngleValue;
+          if (typeof side !== "string" || !side) {
+            continue;
+          }
+          reversingAngleValueMap.set(side, element);
+        }
+      }
+      const reversingAngleButtons = reversingAidsForm
+        ? Array.from(
+            reversingAidsForm.querySelectorAll('button[data-reversing-angle]'),
+          ).filter((element) => element instanceof HTMLButtonElement)
+        : [];
       const reversingNudgeButtons = reversingAidsForm
         ? Array.from(
             reversingAidsForm.querySelectorAll('button[data-reversing-nudge]'),
@@ -1847,6 +1957,15 @@
       const REVERSING_SEGMENTS_PER_SIDE = 3;
       const REVERSING_SEGMENT_COLOURS = ["#66bb6a", "#ffc107", "#ef5350"];
       const REVERSING_PREVIEW_DEFAULT_RATIO = "16 / 9";
+      const REVERSING_ANGLE_STEP_DEGREES = 1.5;
+      const DEFAULT_REVERSING_SIDE_VECTORS = {
+        left: { dx: -0.2, dy: 0.16 },
+        right: { dx: 0.2, dy: 0.16 },
+      };
+      const reversingSideVectors = {
+        left: null,
+        right: null,
+      };
       const diagnosticsButton = document.getElementById("diagnostics-refresh");
       const diagnosticsStatus = document.getElementById("diagnostics-status");
       const diagnosticsResults = document.getElementById("diagnostics-results");
@@ -2345,6 +2464,7 @@
             }
           }
         }
+        refreshReversingSideVectors();
       }
 
       function applyReversingAids(config, options = {}) {
@@ -2357,6 +2477,7 @@
         setReversingInputsDisabled(!enabled);
         updateReversingAidsStatus(config);
         updateReversingAidsInputs(config, forceUpdate);
+        refreshReversingSideVectors();
         drawReversingPreviewOverlay();
       }
 
@@ -2408,6 +2529,323 @@
         return payload;
       }
 
+      function getReversingSegmentInputs(side, index) {
+        if (!reversingInputMap.size) {
+          return null;
+        }
+        return {
+          startX: reversingInputMap.get(`${side}|${index}|start-x`) || null,
+          startY: reversingInputMap.get(`${side}|${index}|start-y`) || null,
+          endX: reversingInputMap.get(`${side}|${index}|end-x`) || null,
+          endY: reversingInputMap.get(`${side}|${index}|end-y`) || null,
+        };
+      }
+
+      function readReversingSegmentStart(side, index) {
+        const inputs = getReversingSegmentInputs(side, index);
+        if (!inputs) {
+          return null;
+        }
+        const startX = parseReversingPreviewValue(inputs.startX);
+        const startY = parseReversingPreviewValue(inputs.startY);
+        if (startX === null || startY === null) {
+          return null;
+        }
+        return { x: startX, y: startY };
+      }
+
+      function readReversingSegmentVector(side, index) {
+        const inputs = getReversingSegmentInputs(side, index);
+        if (!inputs) {
+          return null;
+        }
+        const startX = parseReversingPreviewValue(inputs.startX);
+        const startY = parseReversingPreviewValue(inputs.startY);
+        const endX = parseReversingPreviewValue(inputs.endX);
+        const endY = parseReversingPreviewValue(inputs.endY);
+        if (
+          startX === null ||
+          startY === null ||
+          endX === null ||
+          endY === null
+        ) {
+          return null;
+        }
+        return { dx: endX - startX, dy: endY - startY };
+      }
+
+      function computeSideVector(side) {
+        for (let index = 0; index < REVERSING_SEGMENTS_PER_SIDE; index += 1) {
+          const vector = readReversingSegmentVector(side, index);
+          if (vector) {
+            return vector;
+          }
+        }
+        return null;
+      }
+
+      function updateReversingSideVectorFromInputs(side) {
+        const vector = computeSideVector(side);
+        if (!vector) {
+          return false;
+        }
+        reversingSideVectors[side] = { dx: vector.dx, dy: vector.dy };
+        updateReversingAngleValue(side);
+        return true;
+      }
+
+      function ensureReversingSideVector(side) {
+        if (!reversingSideVectors[side]) {
+          if (!updateReversingSideVectorFromInputs(side)) {
+            const fallback = DEFAULT_REVERSING_SIDE_VECTORS[side] || {
+              dx: 0,
+              dy: 0,
+            };
+            reversingSideVectors[side] = { dx: fallback.dx, dy: fallback.dy };
+            updateReversingAngleValue(side);
+          }
+        }
+        return reversingSideVectors[side];
+      }
+
+      function clampVectorForSide(side, vector) {
+        if (
+          !vector ||
+          typeof vector.dx !== "number" ||
+          typeof vector.dy !== "number"
+        ) {
+          return { dx: 0, dy: 0 };
+        }
+        const baseDx = Number.isFinite(vector.dx) ? vector.dx : 0;
+        const baseDy = Number.isFinite(vector.dy) ? vector.dy : 0;
+        let limit = 1;
+        let constrained = false;
+        for (let index = 0; index < REVERSING_SEGMENTS_PER_SIDE; index += 1) {
+          const start = readReversingSegmentStart(side, index);
+          if (!start) {
+            continue;
+          }
+          if (baseDx > 0) {
+            const ratio = (1 - start.x) / baseDx;
+            if (Number.isFinite(ratio)) {
+              limit = Math.min(limit, ratio);
+              constrained = true;
+            }
+          } else if (baseDx < 0) {
+            const ratio = start.x / -baseDx;
+            if (Number.isFinite(ratio)) {
+              limit = Math.min(limit, ratio);
+              constrained = true;
+            }
+          }
+          if (baseDy > 0) {
+            const ratio = (1 - start.y) / baseDy;
+            if (Number.isFinite(ratio)) {
+              limit = Math.min(limit, ratio);
+              constrained = true;
+            }
+          } else if (baseDy < 0) {
+            const ratio = start.y / -baseDy;
+            if (Number.isFinite(ratio)) {
+              limit = Math.min(limit, ratio);
+              constrained = true;
+            }
+          }
+        }
+        if (!constrained || !Number.isFinite(limit) || limit > 1) {
+          limit = 1;
+        }
+        if (limit < 0) {
+          limit = 0;
+        }
+        return { dx: baseDx * limit, dy: baseDy * limit };
+      }
+
+      function applyVectorToSide(side, vector, options = {}) {
+        if (
+          !vector ||
+          typeof vector.dx !== "number" ||
+          typeof vector.dy !== "number"
+        ) {
+          return false;
+        }
+        let skipSegment = null;
+        let skipFields = null;
+        if (options.skip && typeof options.skip.segment === "number") {
+          const numeric = Number(options.skip.segment);
+          if (Number.isFinite(numeric)) {
+            skipSegment = numeric;
+          }
+          const fields = options.skip.fields;
+          if (fields instanceof Set) {
+            skipFields = fields;
+          } else if (Array.isArray(fields)) {
+            skipFields = new Set(fields);
+          }
+        }
+        let changed = false;
+        for (let index = 0; index < REVERSING_SEGMENTS_PER_SIDE; index += 1) {
+          const inputs = getReversingSegmentInputs(side, index);
+          if (!inputs) {
+            continue;
+          }
+          const startX = parseReversingPreviewValue(inputs.startX);
+          const startY = parseReversingPreviewValue(inputs.startY);
+          if (startX === null || startY === null) {
+            continue;
+          }
+          const endXInput = inputs.endX;
+          const endYInput = inputs.endY;
+          if (
+            !(endXInput instanceof HTMLInputElement) ||
+            !(endYInput instanceof HTMLInputElement)
+          ) {
+            continue;
+          }
+          const endX = Math.min(1, Math.max(0, startX + vector.dx));
+          const endY = Math.min(1, Math.max(0, startY + vector.dy));
+          const endXPercent = endX * 100;
+          const endYPercent = endY * 100;
+          const formattedX = formatPercentageValue(endXPercent);
+          const formattedY = formatPercentageValue(endYPercent);
+          if (!(skipSegment === index && skipFields?.has("end-x"))) {
+            if (endXInput.value !== formattedX) {
+              endXInput.value = formattedX;
+              changed = true;
+            }
+            endXInput.dataset.userEdited = "true";
+          }
+          if (!(skipSegment === index && skipFields?.has("end-y"))) {
+            if (endYInput.value !== formattedY) {
+              endYInput.value = formattedY;
+              changed = true;
+            }
+            endYInput.dataset.userEdited = "true";
+          }
+        }
+        return changed;
+      }
+
+      function setReversingSideVector(side, vector, options = {}) {
+        const clamped = clampVectorForSide(side, vector);
+        reversingSideVectors[side] = { dx: clamped.dx, dy: clamped.dy };
+        updateReversingAngleValue(side);
+        return applyVectorToSide(side, clamped, options);
+      }
+
+      function refreshReversingSideVectors() {
+        for (const side of ["left", "right"]) {
+          if (!updateReversingSideVectorFromInputs(side)) {
+            const fallback = DEFAULT_REVERSING_SIDE_VECTORS[side] || {
+              dx: 0,
+              dy: 0,
+            };
+            reversingSideVectors[side] = { dx: fallback.dx, dy: fallback.dy };
+            updateReversingAngleValue(side);
+          }
+        }
+      }
+
+      function computeAngleFromVector(vector) {
+        if (
+          !vector ||
+          typeof vector.dx !== "number" ||
+          typeof vector.dy !== "number"
+        ) {
+          return null;
+        }
+        const dx = Math.abs(vector.dx);
+        const dy = Math.abs(vector.dy);
+        if (!(dx > 0) && !(dy > 0)) {
+          return null;
+        }
+        const radians = Math.atan2(dy, dx);
+        if (!Number.isFinite(radians)) {
+          return null;
+        }
+        const degrees = (radians * 180) / Math.PI;
+        return Math.max(0, Math.min(90, degrees));
+      }
+
+      function updateReversingAngleValue(side) {
+        const output = reversingAngleValueMap.get(side);
+        if (!output) {
+          return;
+        }
+        const angle = computeAngleFromVector(reversingSideVectors[side]);
+        if (angle === null) {
+          output.textContent = "—";
+        } else {
+          output.textContent = `${formatPercentageValue(angle)}°`;
+        }
+      }
+
+      function handleReversingInputEdit(input) {
+        if (!(input instanceof HTMLInputElement)) {
+          return;
+        }
+        const side = input.dataset.side;
+        const field = input.dataset.reversingField;
+        const segment = Number.parseInt(input.dataset.segment || "", 10);
+        if (!side || !field || !Number.isFinite(segment)) {
+          return;
+        }
+        if (field.startsWith("start-")) {
+          const vector = ensureReversingSideVector(side);
+          if (vector) {
+            applyVectorToSide(side, vector);
+            updateReversingAngleValue(side);
+          }
+        } else if (field.startsWith("end-")) {
+          const vector = readReversingSegmentVector(side, segment);
+          if (!vector) {
+            return;
+          }
+          const skipFields = new Set([field]);
+          setReversingSideVector(side, vector, {
+            skip: { segment, fields: skipFields },
+          });
+        }
+      }
+
+      function getAngleLimitsForSide(side) {
+        const epsilon = Math.PI / 180;
+        if (side === "left") {
+          return { min: Math.PI / 2 + epsilon, max: Math.PI - epsilon };
+        }
+        return { min: epsilon, max: Math.PI / 2 - epsilon };
+      }
+
+      function adjustReversingSideAngle(side, direction) {
+        if (typeof side !== "string" || !direction) {
+          return false;
+        }
+        const vector = ensureReversingSideVector(side);
+        if (!vector) {
+          return false;
+        }
+        const magnitude = Math.hypot(vector.dx, vector.dy);
+        if (!(magnitude > 0)) {
+          return false;
+        }
+        const delta = (REVERSING_ANGLE_STEP_DEGREES * Math.PI) / 180;
+        let angle = Math.atan2(vector.dy, vector.dx);
+        if (direction === "narrow") {
+          angle += side === "left" ? -delta : delta;
+        } else if (direction === "wide") {
+          angle += side === "left" ? delta : -delta;
+        } else {
+          return false;
+        }
+        const limits = getAngleLimitsForSide(side);
+        angle = Math.min(limits.max, Math.max(limits.min, angle));
+        const rotated = {
+          dx: Math.cos(angle) * magnitude,
+          dy: Math.sin(angle) * magnitude,
+        };
+        return setReversingSideVector(side, rotated);
+      }
+
       function adjustReversingSide(side, deltaX, deltaY) {
         if (!reversingInputs.length) {
           return;
@@ -2430,6 +2868,11 @@
             input.value = formatPercentageValue(updated);
             input.dataset.userEdited = "true";
           }
+        }
+        const vector = ensureReversingSideVector(side);
+        if (vector) {
+          applyVectorToSide(side, vector);
+          updateReversingAngleValue(side);
         }
         drawReversingPreviewOverlay();
       }
@@ -3340,6 +3783,23 @@
           drawReversingPreviewOverlay();
         });
         drawReversingPreviewOverlay();
+      }
+
+      if (reversingAngleButtons.length) {
+        for (const button of reversingAngleButtons) {
+          button.addEventListener("click", () => {
+            const side = button.dataset.side;
+            const direction = button.dataset.reversingAngle;
+            if (!side || !direction) {
+              return;
+            }
+            adjustReversingSideAngle(side, direction);
+            if (reversingAidsStatus) {
+              reversingAidsStatus.textContent = "";
+            }
+            drawReversingPreviewOverlay();
+          });
+        }
       }
 
       if (reversingNudgeButtons.length) {

--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -316,6 +316,84 @@
         font-size: 0.9rem;
         margin: 0;
       }
+      .reversing-preview {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        margin: 0.5rem 0 1.25rem;
+      }
+      .reversing-preview h3 {
+        margin: 0;
+      }
+      .reversing-preview-controls {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        align-items: center;
+      }
+      .reversing-preview-status {
+        min-height: 1.2rem;
+        display: block;
+      }
+      .reversing-upload-label {
+        position: relative;
+        overflow: hidden;
+        border: 1px solid #0a84ff;
+        border-radius: 999px;
+        padding: 0.6rem 1.2rem;
+        color: #0a84ff;
+        font-weight: 600;
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.35rem;
+        background: transparent;
+      }
+      .reversing-upload-label:hover,
+      .reversing-upload-label:focus-within {
+        color: #fff;
+        background: rgba(10, 132, 255, 0.15);
+      }
+      .reversing-upload-label input[type="file"] {
+        position: absolute;
+        inset: 0;
+        opacity: 0;
+        cursor: pointer;
+      }
+      .reversing-preview-stage {
+        position: relative;
+        width: 100%;
+        border-radius: 12px;
+        overflow: hidden;
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        background: rgba(255, 255, 255, 0.05);
+        aspect-ratio: 16 / 9;
+      }
+      .reversing-preview-stage img,
+      .reversing-preview-stage canvas {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        object-fit: contain;
+        display: block;
+      }
+      .reversing-preview-stage canvas {
+        pointer-events: none;
+      }
+      .reversing-preview-placeholder {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+        padding: 1rem;
+        color: rgba(255, 255, 255, 0.65);
+        font-size: 0.95rem;
+        letter-spacing: 0.01em;
+      }
       #status {
         font-size: 0.95rem;
         opacity: 0.85;
@@ -984,6 +1062,39 @@
               Coordinates are expressed as percentages of the frame. Adjust the nudge controls to
               shift each side without changing individual values.
             </p>
+            <div class="reversing-preview">
+              <h3>Alignment preview</h3>
+              <p class="muted" style="margin: 0;">
+                Capture the current camera view or upload a reference image to preview how the guides
+                will line up as you make adjustments.
+              </p>
+              <div class="reversing-preview-controls">
+                <button type="button" id="reversing-preview-capture">Capture snapshot</button>
+                <label class="reversing-upload-label">
+                  Upload image
+                  <input type="file" id="reversing-preview-upload" accept="image/*" />
+                </label>
+                <button
+                  type="button"
+                  id="reversing-preview-clear"
+                  class="secondary-button"
+                >
+                  Clear image
+                </button>
+              </div>
+              <span id="reversing-preview-status" class="muted reversing-preview-status"></span>
+              <div class="reversing-preview-stage" id="reversing-preview-stage">
+                <img
+                  id="reversing-preview-image"
+                  alt="Reference image for aligning reversing aids"
+                  hidden
+                />
+                <canvas id="reversing-preview-canvas" aria-hidden="true"></canvas>
+                <div class="reversing-preview-placeholder" id="reversing-preview-placeholder">
+                  Capture a snapshot or upload an image to preview the reversing aids.
+                </div>
+              </div>
+            </div>
             <div class="reversing-grid">
               <fieldset class="reversing-side" data-side="left">
                 <legend>Left guide</legend>
@@ -1712,6 +1823,7 @@
             if (reversingAidsStatus) {
               reversingAidsStatus.textContent = "";
             }
+            drawReversingPreviewOverlay();
           });
         }
       }
@@ -1720,7 +1832,21 @@
             reversingAidsForm.querySelectorAll('button[data-reversing-nudge]'),
           ).filter((element) => element instanceof HTMLButtonElement)
         : [];
+      const reversingPreviewStage = document.getElementById("reversing-preview-stage");
+      const reversingPreviewImage = document.getElementById("reversing-preview-image");
+      const reversingPreviewCanvas = document.getElementById("reversing-preview-canvas");
+      const reversingPreviewPlaceholder = document.getElementById("reversing-preview-placeholder");
+      const reversingPreviewStatus = document.getElementById("reversing-preview-status");
+      const reversingPreviewCaptureButton = document.getElementById("reversing-preview-capture");
+      const reversingPreviewUploadInput = document.getElementById("reversing-preview-upload");
+      const reversingPreviewClearButton = document.getElementById("reversing-preview-clear");
+      let reversingPreviewObjectUrl = null;
+      let reversingPreviewStatusTimer = null;
+      let reversingPreviewLoading = false;
       const REVERSING_NUDGE_STEP = 1;
+      const REVERSING_SEGMENTS_PER_SIDE = 3;
+      const REVERSING_SEGMENT_COLOURS = ["#66bb6a", "#ffc107", "#ef5350"];
+      const REVERSING_PREVIEW_DEFAULT_RATIO = "16 / 9";
       const diagnosticsButton = document.getElementById("diagnostics-refresh");
       const diagnosticsStatus = document.getElementById("diagnostics-status");
       const diagnosticsResults = document.getElementById("diagnostics-results");
@@ -1934,6 +2060,248 @@
         delete input.dataset.userEdited;
       }
 
+      function setReversingPreviewStatus(message, options = {}) {
+        if (!reversingPreviewStatus) {
+          return;
+        }
+        if (reversingPreviewStatusTimer) {
+          window.clearTimeout(reversingPreviewStatusTimer);
+          reversingPreviewStatusTimer = null;
+        }
+        reversingPreviewStatus.textContent = message || "";
+        if (message && options.persistent !== true) {
+          reversingPreviewStatusTimer = window.setTimeout(() => {
+            if (reversingPreviewStatus && reversingPreviewStatus.textContent === message) {
+              reversingPreviewStatus.textContent = "";
+            }
+            reversingPreviewStatusTimer = null;
+          }, 4000);
+        }
+      }
+
+      function hasReversingPreviewImage() {
+        return (
+          reversingPreviewImage instanceof HTMLImageElement &&
+          !reversingPreviewImage.hidden &&
+          reversingPreviewImage.naturalWidth > 0 &&
+          reversingPreviewImage.naturalHeight > 0
+        );
+      }
+
+      function updateReversingPreviewControlsState() {
+        if (reversingPreviewClearButton) {
+          reversingPreviewClearButton.disabled = !hasReversingPreviewImage();
+        }
+      }
+
+      function setReversingPreviewPlaceholderVisible(visible) {
+        if (reversingPreviewPlaceholder) {
+          reversingPreviewPlaceholder.hidden = !visible;
+        }
+      }
+
+      function setReversingPreviewAspect(width, height) {
+        if (!reversingPreviewStage) {
+          return;
+        }
+        if (
+          typeof width === "number" &&
+          width > 0 &&
+          typeof height === "number" &&
+          height > 0
+        ) {
+          reversingPreviewStage.style.aspectRatio = `${width} / ${height}`;
+        } else {
+          reversingPreviewStage.style.aspectRatio = REVERSING_PREVIEW_DEFAULT_RATIO;
+        }
+      }
+
+      function revokeReversingPreviewObjectUrl() {
+        if (reversingPreviewObjectUrl) {
+          URL.revokeObjectURL(reversingPreviewObjectUrl);
+          reversingPreviewObjectUrl = null;
+        }
+      }
+
+      function clearReversingPreviewImage() {
+        revokeReversingPreviewObjectUrl();
+        if (reversingPreviewImage instanceof HTMLImageElement) {
+          reversingPreviewImage.src = "";
+          reversingPreviewImage.hidden = true;
+        }
+        setReversingPreviewAspect();
+        setReversingPreviewPlaceholderVisible(true);
+        updateReversingPreviewControlsState();
+        drawReversingPreviewOverlay();
+      }
+
+      async function loadReversingPreviewFromBlob(blob) {
+        if (!(blob instanceof Blob)) {
+          throw new Error("Invalid image data");
+        }
+        const objectUrl = URL.createObjectURL(blob);
+        revokeReversingPreviewObjectUrl();
+        reversingPreviewObjectUrl = objectUrl;
+        if (reversingPreviewImage instanceof HTMLImageElement) {
+          reversingPreviewImage.hidden = true;
+          reversingPreviewImage.onload = null;
+          reversingPreviewImage.onerror = null;
+        }
+        const loaded = await new Promise((resolve) => {
+          if (!(reversingPreviewImage instanceof HTMLImageElement)) {
+            resolve(false);
+            return;
+          }
+          reversingPreviewImage.onload = () => {
+            reversingPreviewImage.onload = null;
+            reversingPreviewImage.onerror = null;
+            reversingPreviewImage.hidden = false;
+            setReversingPreviewAspect(
+              reversingPreviewImage.naturalWidth,
+              reversingPreviewImage.naturalHeight,
+            );
+            setReversingPreviewPlaceholderVisible(false);
+            updateReversingPreviewControlsState();
+            drawReversingPreviewOverlay();
+            resolve(true);
+          };
+          reversingPreviewImage.onerror = () => {
+            reversingPreviewImage.onload = null;
+            reversingPreviewImage.onerror = null;
+            resolve(false);
+          };
+          reversingPreviewImage.src = objectUrl;
+        });
+        if (!loaded) {
+          if (reversingPreviewObjectUrl === objectUrl) {
+            revokeReversingPreviewObjectUrl();
+          } else {
+            URL.revokeObjectURL(objectUrl);
+          }
+          setReversingPreviewAspect();
+          setReversingPreviewPlaceholderVisible(true);
+          updateReversingPreviewControlsState();
+          throw new Error("Unable to load reference image");
+        }
+        return true;
+      }
+
+      function parseReversingPreviewValue(input) {
+        if (!(input instanceof HTMLInputElement)) {
+          return null;
+        }
+        const raw = parseFloat(input.value);
+        if (!Number.isFinite(raw)) {
+          return null;
+        }
+        const normalised = raw / 100;
+        if (Number.isNaN(normalised)) {
+          return null;
+        }
+        return Math.min(1, Math.max(0, normalised));
+      }
+
+      function getReversingPreviewSegments() {
+        const geometry = {
+          left: Array.from({ length: REVERSING_SEGMENTS_PER_SIDE }, () => null),
+          right: Array.from({ length: REVERSING_SEGMENTS_PER_SIDE }, () => null),
+        };
+        if (!reversingInputMap.size) {
+          return geometry;
+        }
+        const sides = ["left", "right"];
+        for (const side of sides) {
+          for (let index = 0; index < REVERSING_SEGMENTS_PER_SIDE; index += 1) {
+            const startXInput = reversingInputMap.get(`${side}|${index}|start-x`);
+            const startYInput = reversingInputMap.get(`${side}|${index}|start-y`);
+            const endXInput = reversingInputMap.get(`${side}|${index}|end-x`);
+            const endYInput = reversingInputMap.get(`${side}|${index}|end-y`);
+            const startX = parseReversingPreviewValue(startXInput);
+            const startY = parseReversingPreviewValue(startYInput);
+            const endX = parseReversingPreviewValue(endXInput);
+            const endY = parseReversingPreviewValue(endYInput);
+            if (
+              startX === null ||
+              startY === null ||
+              endX === null ||
+              endY === null
+            ) {
+              geometry[side][index] = null;
+            } else {
+              geometry[side][index] = {
+                start: { x: startX, y: startY },
+                end: { x: endX, y: endY },
+              };
+            }
+          }
+        }
+        return geometry;
+      }
+
+      function drawReversingPreviewOverlay() {
+        if (!(reversingPreviewStage instanceof HTMLElement)) {
+          return;
+        }
+        if (!(reversingPreviewCanvas instanceof HTMLCanvasElement)) {
+          return;
+        }
+        const width = Math.round(reversingPreviewStage.clientWidth);
+        const height = Math.round(reversingPreviewStage.clientHeight);
+        if (!(width > 0 && height > 0)) {
+          return;
+        }
+        const context = reversingPreviewCanvas.getContext("2d");
+        if (!context) {
+          return;
+        }
+        if (reversingPreviewCanvas.width !== width || reversingPreviewCanvas.height !== height) {
+          reversingPreviewCanvas.width = width;
+          reversingPreviewCanvas.height = height;
+        }
+        context.clearRect(0, 0, width, height);
+        const geometry = getReversingPreviewSegments();
+        const widthScale = Math.max(1, width - 1);
+        const heightScale = Math.max(1, height - 1);
+        const thickness = Math.max(2, Math.round(Math.min(width, height) * 0.01));
+        const enabled = reversingAidsEnabledInput ? reversingAidsEnabledInput.checked : true;
+        context.save();
+        context.lineCap = "round";
+        context.lineJoin = "round";
+        context.globalAlpha = enabled ? 1 : 0.5;
+        for (const side of ["left", "right"]) {
+          const segments = geometry[side];
+          for (let index = 0; index < segments.length; index += 1) {
+            const segment = segments[index];
+            if (!segment) {
+              continue;
+            }
+            const colour =
+              REVERSING_SEGMENT_COLOURS[
+                Math.min(index, REVERSING_SEGMENT_COLOURS.length - 1)
+              ];
+            const startX = segment.start.x * widthScale;
+            const startY = segment.start.y * heightScale;
+            const endX = segment.end.x * widthScale;
+            const endY = segment.end.y * heightScale;
+            context.strokeStyle = colour;
+            context.lineWidth = thickness;
+            context.beginPath();
+            context.moveTo(startX, startY);
+            context.lineTo(endX, endY);
+            context.stroke();
+            const pointRadius = Math.max(3, Math.round(thickness * 0.6));
+            context.fillStyle = colour;
+            context.beginPath();
+            context.arc(startX, startY, pointRadius, 0, Math.PI * 2);
+            context.fill();
+            context.beginPath();
+            context.arc(endX, endY, pointRadius, 0, Math.PI * 2);
+            context.fill();
+          }
+        }
+        context.restore();
+      }
+
       function updateReversingAidsStatus(config) {
         if (!reversingAidsStatus) {
           return;
@@ -1954,7 +2322,7 @@
         const sides = ["left", "right"];
         for (const side of sides) {
           const segments = Array.isArray(config?.[side]) ? config[side] : [];
-          for (let index = 0; index < 3; index += 1) {
+          for (let index = 0; index < REVERSING_SEGMENTS_PER_SIDE; index += 1) {
             const segment = segments[index] || null;
             const start = segment && segment.start ? segment.start : null;
             const end = segment && segment.end ? segment.end : null;
@@ -1989,6 +2357,7 @@
         setReversingInputsDisabled(!enabled);
         updateReversingAidsStatus(config);
         updateReversingAidsInputs(config, forceUpdate);
+        drawReversingPreviewOverlay();
       }
 
       function readReversingInput(input) {
@@ -2015,9 +2384,8 @@
           right: [],
         };
         const sides = ["left", "right"];
-        const segmentsPerSide = 3;
         for (const side of sides) {
-          for (let index = 0; index < segmentsPerSide; index += 1) {
+          for (let index = 0; index < REVERSING_SEGMENTS_PER_SIDE; index += 1) {
             const startX = reversingInputMap.get(`${side}|${index}|start-x`);
             const startY = reversingInputMap.get(`${side}|${index}|start-y`);
             const endX = reversingInputMap.get(`${side}|${index}|end-x`);
@@ -2063,6 +2431,7 @@
             input.dataset.userEdited = "true";
           }
         }
+        drawReversingPreviewOverlay();
       }
 
       function formatDistance(value) {
@@ -2968,7 +3337,9 @@
         setReversingInputsDisabled(!reversingAidsEnabledInput.checked);
         reversingAidsEnabledInput.addEventListener("change", () => {
           setReversingInputsDisabled(!reversingAidsEnabledInput.checked);
+          drawReversingPreviewOverlay();
         });
+        drawReversingPreviewOverlay();
       }
 
       if (reversingNudgeButtons.length) {
@@ -3000,6 +3371,69 @@
           });
         }
       }
+
+      updateReversingPreviewControlsState();
+
+      if (reversingPreviewClearButton) {
+        reversingPreviewClearButton.addEventListener("click", () => {
+          clearReversingPreviewImage();
+          setReversingPreviewStatus("Reference image cleared.");
+        });
+      }
+
+      if (reversingPreviewUploadInput) {
+        reversingPreviewUploadInput.addEventListener("change", async () => {
+          const files = reversingPreviewUploadInput.files;
+          if (!files || files.length === 0) {
+            return;
+          }
+          const file = files[0];
+          setReversingPreviewStatus(`Loading ${file.name}…`);
+          try {
+            await loadReversingPreviewFromBlob(file);
+            setReversingPreviewStatus(`Loaded ${file.name}`);
+          } catch (err) {
+            console.error("Reversing preview upload error", err);
+            clearReversingPreviewImage();
+            setReversingPreviewStatus("Unable to load image.", { persistent: true });
+          } finally {
+            reversingPreviewUploadInput.value = "";
+          }
+        });
+      }
+
+      if (reversingPreviewCaptureButton) {
+        const captureDefaultText = reversingPreviewCaptureButton.textContent || "Capture snapshot";
+        reversingPreviewCaptureButton.addEventListener("click", async () => {
+          if (reversingPreviewLoading) {
+            return;
+          }
+          reversingPreviewLoading = true;
+          reversingPreviewCaptureButton.disabled = true;
+          reversingPreviewCaptureButton.textContent = "Capturing…";
+          setReversingPreviewStatus("Capturing snapshot…", { persistent: true });
+          try {
+            const response = await fetch("/api/camera/snapshot", { cache: "no-store" });
+            if (!response.ok) {
+              throw new Error(`Snapshot request failed: ${response.status}`);
+            }
+            const blob = await response.blob();
+            await loadReversingPreviewFromBlob(blob);
+            setReversingPreviewStatus("Snapshot captured.");
+          } catch (err) {
+            console.error("Reversing preview capture error", err);
+            setReversingPreviewStatus("Unable to capture snapshot.", { persistent: true });
+          } finally {
+            reversingPreviewLoading = false;
+            reversingPreviewCaptureButton.disabled = false;
+            reversingPreviewCaptureButton.textContent = captureDefaultText;
+          }
+        });
+      }
+
+      window.addEventListener("resize", () => {
+        window.requestAnimationFrame(drawReversingPreviewOverlay);
+      });
 
       if (reversingAidsForm) {
         reversingAidsForm.addEventListener("submit", async (event) => {

--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -336,14 +336,6 @@
         font-size: 0.9rem;
         margin: 0;
       }
-      .reversing-line-note {
-        margin: -0.3rem 0 1.25rem;
-        font-size: 0.85rem;
-        opacity: 0.75;
-        display: inline-flex;
-        align-items: center;
-        gap: 0.4rem;
-      }
       .reversing-preview {
         display: flex;
         flex-direction: column;
@@ -357,37 +349,26 @@
         display: flex;
         flex-wrap: wrap;
         gap: 0.75rem;
-        align-items: center;
+        align-items: stretch;
+      }
+      .reversing-preview-controls button {
+        min-height: 2.5rem;
+        white-space: nowrap;
+      }
+      .reversing-preview-file-input {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        clip-path: inset(50%);
+        border: 0;
       }
       .reversing-preview-status {
         min-height: 1.2rem;
         display: block;
-      }
-      .reversing-upload-label {
-        position: relative;
-        overflow: hidden;
-        border: 1px solid #0a84ff;
-        border-radius: 999px;
-        padding: 0.6rem 1.2rem;
-        color: #0a84ff;
-        font-weight: 600;
-        cursor: pointer;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        gap: 0.35rem;
-        background: transparent;
-      }
-      .reversing-upload-label:hover,
-      .reversing-upload-label:focus-within {
-        color: #fff;
-        background: rgba(10, 132, 255, 0.15);
-      }
-      .reversing-upload-label input[type="file"] {
-        position: absolute;
-        inset: 0;
-        opacity: 0;
-        cursor: pointer;
       }
       .reversing-preview-stage {
         position: relative;
@@ -1102,10 +1083,13 @@
               </p>
               <div class="reversing-preview-controls">
                 <button type="button" id="reversing-preview-capture">Capture snapshot</button>
-                <label class="reversing-upload-label">
-                  Upload image
-                  <input type="file" id="reversing-preview-upload" accept="image/*" />
-                </label>
+                <button type="button" id="reversing-preview-upload-button">Upload image</button>
+                <input
+                  type="file"
+                  id="reversing-preview-upload"
+                  accept="image/*"
+                  class="reversing-preview-file-input"
+                />
                 <button
                   type="button"
                   id="reversing-preview-clear"
@@ -1135,49 +1119,6 @@
             <fieldset class="reversing-side" data-side="left">
                 <legend>Left guide</legend>
                 <p>Adjust the driver’s-side guide segments. Click the preview or edit the values.</p>
-                <div class="reversing-line-point" data-side="left" data-point="far">
-                  <div class="reversing-line-header">
-                    <span class="reversing-colour" style="background: #66bb6a;"></span>
-                    <span>Far point</span>
-                    <button
-                      type="button"
-                      class="reversing-point-button"
-                      data-side="left"
-                      data-reversing-pick="far"
-                      aria-pressed="false"
-                    >
-                      Select on preview
-                    </button>
-                  </div>
-                  <div class="reversing-line-fields">
-                    <label>
-                      Horizontal (%)
-                      <input
-                        type="number"
-                        min="0"
-                        max="100"
-                        step="0.1"
-                        inputmode="decimal"
-                        data-reversing-field="far-x"
-                        data-side="left"
-                        data-axis="x"
-                      />
-                    </label>
-                    <label>
-                      Vertical (%)
-                      <input
-                        type="number"
-                        min="0"
-                        max="100"
-                        step="0.1"
-                        inputmode="decimal"
-                        data-reversing-field="far-y"
-                        data-side="left"
-                        data-axis="y"
-                      />
-                    </label>
-                  </div>
-                </div>
                 <div class="reversing-line-point" data-side="left" data-point="near">
                   <div class="reversing-line-header">
                     <span class="reversing-colour" style="background: #ef5350;"></span>
@@ -1221,22 +1162,14 @@
                     </label>
                   </div>
                 </div>
-                <p class="reversing-line-note muted">
-                  <span class="reversing-colour" style="background: #ffc107;"></span>
-                  Mid segment spacing updates automatically between the far and near points.
-                </p>
-              </fieldset>
-              <fieldset class="reversing-side" data-side="right">
-                <legend>Right guide</legend>
-                <p>Adjust the passenger-side guide segments from the preview or the inputs.</p>
-                <div class="reversing-line-point" data-side="right" data-point="far">
+                <div class="reversing-line-point" data-side="left" data-point="far">
                   <div class="reversing-line-header">
                     <span class="reversing-colour" style="background: #66bb6a;"></span>
                     <span>Far point</span>
                     <button
                       type="button"
                       class="reversing-point-button"
-                      data-side="right"
+                      data-side="left"
                       data-reversing-pick="far"
                       aria-pressed="false"
                     >
@@ -1253,7 +1186,7 @@
                         step="0.1"
                         inputmode="decimal"
                         data-reversing-field="far-x"
-                        data-side="right"
+                        data-side="left"
                         data-axis="x"
                       />
                     </label>
@@ -1266,12 +1199,16 @@
                         step="0.1"
                         inputmode="decimal"
                         data-reversing-field="far-y"
-                        data-side="right"
+                        data-side="left"
                         data-axis="y"
                       />
                     </label>
                   </div>
                 </div>
+              </fieldset>
+              <fieldset class="reversing-side" data-side="right">
+                <legend>Right guide</legend>
+                <p>Adjust the passenger-side guide segments from the preview or the inputs.</p>
                 <div class="reversing-line-point" data-side="right" data-point="near">
                   <div class="reversing-line-header">
                     <span class="reversing-colour" style="background: #ef5350;"></span>
@@ -1315,10 +1252,49 @@
                     </label>
                   </div>
                 </div>
-                <p class="reversing-line-note muted">
-                  <span class="reversing-colour" style="background: #ffc107;"></span>
-                  Mid segment spacing updates automatically between the far and near points.
-                </p>
+                <div class="reversing-line-point" data-side="right" data-point="far">
+                  <div class="reversing-line-header">
+                    <span class="reversing-colour" style="background: #66bb6a;"></span>
+                    <span>Far point</span>
+                    <button
+                      type="button"
+                      class="reversing-point-button"
+                      data-side="right"
+                      data-reversing-pick="far"
+                      aria-pressed="false"
+                    >
+                      Select on preview
+                    </button>
+                  </div>
+                  <div class="reversing-line-fields">
+                    <label>
+                      Horizontal (%)
+                      <input
+                        type="number"
+                        min="0"
+                        max="100"
+                        step="0.1"
+                        inputmode="decimal"
+                        data-reversing-field="far-x"
+                        data-side="right"
+                        data-axis="x"
+                      />
+                    </label>
+                    <label>
+                      Vertical (%)
+                      <input
+                        type="number"
+                        min="0"
+                        max="100"
+                        step="0.1"
+                        inputmode="decimal"
+                        data-reversing-field="far-y"
+                        data-side="right"
+                        data-axis="y"
+                      />
+                    </label>
+                  </div>
+                </div>
               </fieldset>
             </div>
             <div class="form-actions">
@@ -1595,6 +1571,9 @@
       const reversingPreviewPlaceholder = document.getElementById("reversing-preview-placeholder");
       const reversingPreviewStatus = document.getElementById("reversing-preview-status");
       const reversingPreviewCaptureButton = document.getElementById("reversing-preview-capture");
+      const reversingPreviewUploadButton = document.getElementById(
+        "reversing-preview-upload-button",
+      );
       const reversingPreviewUploadInput = document.getElementById("reversing-preview-upload");
       const reversingPreviewClearButton = document.getElementById("reversing-preview-clear");
       const reversingPreviewCaptureDefaultText =
@@ -3393,6 +3372,15 @@
         reversingPreviewClearButton.addEventListener("click", () => {
           clearReversingPreviewImage();
           setReversingPreviewStatus("Reference image cleared.");
+        });
+      }
+
+      if (reversingPreviewUploadButton && reversingPreviewUploadInput) {
+        reversingPreviewUploadButton.addEventListener("click", () => {
+          if (reversingPreviewUploadInput.disabled) {
+            return;
+          }
+          reversingPreviewUploadInput.click();
         });
       }
 

--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -1173,7 +1173,7 @@
                       data-reversing-pick="near"
                       aria-pressed="false"
                     >
-                      Select on preview
+                      Select on Preview
                     </button>
                   </div>
                   <div class="reversing-line-fields">
@@ -1263,7 +1263,7 @@
                       data-reversing-pick="near"
                       aria-pressed="false"
                     >
-                      Select on preview
+                      Select on Preview
                     </button>
                   </div>
                   <div class="reversing-line-fields">

--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -267,22 +267,6 @@
       fieldset.reversing-side:disabled {
         opacity: 0.6;
       }
-      .reversing-nudge-group {
-        display: flex;
-        align-items: center;
-        gap: 0.75rem;
-        flex-wrap: wrap;
-        margin-bottom: 1rem;
-      }
-      .reversing-nudge-buttons {
-        display: grid;
-        grid-template-columns: repeat(3, minmax(0, 1fr));
-        gap: 0.25rem;
-      }
-      .reversing-nudge-buttons button {
-        padding: 0.35rem 0.65rem;
-        font-size: 0.9rem;
-      }
       .reversing-point-button {
         margin-left: auto;
         border: 1px solid rgba(10, 132, 255, 0.35);
@@ -1107,8 +1091,8 @@
               Show reversing aids on the live view
             </label>
             <p class="muted" style="margin: 0;">
-              Coordinates are expressed as percentages of the frame. Adjust the nudge controls to
-              shift each side without changing individual values.
+              Coordinates are expressed as percentages of the frame. Click the preview or edit the
+              values below to fine-tune each side.
             </p>
             <div class="reversing-preview">
               <h3>Alignment preview</h3>
@@ -1150,44 +1134,7 @@
           <div class="reversing-grid">
             <fieldset class="reversing-side" data-side="left">
                 <legend>Left guide</legend>
-                <p>Adjust the driver’s-side guide segments. Use nudge buttons for quick alignment.</p>
-                <div class="reversing-nudge-group">
-                  <span class="muted">Nudge:</span>
-                  <div class="reversing-nudge-buttons">
-                    <button
-                      type="button"
-                      data-reversing-nudge="up"
-                      data-side="left"
-                      aria-label="Nudge left guide up"
-                    >
-                      ↑
-                    </button>
-                    <button
-                      type="button"
-                      data-reversing-nudge="down"
-                      data-side="left"
-                      aria-label="Nudge left guide down"
-                    >
-                      ↓
-                    </button>
-                    <button
-                      type="button"
-                      data-reversing-nudge="left"
-                      data-side="left"
-                      aria-label="Nudge left guide left"
-                    >
-                      ←
-                    </button>
-                    <button
-                      type="button"
-                      data-reversing-nudge="right"
-                      data-side="left"
-                      aria-label="Nudge left guide right"
-                    >
-                      →
-                    </button>
-                  </div>
-                </div>
+                <p>Adjust the driver’s-side guide segments. Click the preview or edit the values.</p>
                 <div class="reversing-line-point" data-side="left" data-point="far">
                   <div class="reversing-line-header">
                     <span class="reversing-colour" style="background: #66bb6a;"></span>
@@ -1209,7 +1156,7 @@
                         type="number"
                         min="0"
                         max="100"
-                        step="0.5"
+                        step="0.1"
                         inputmode="decimal"
                         data-reversing-field="far-x"
                         data-side="left"
@@ -1222,7 +1169,7 @@
                         type="number"
                         min="0"
                         max="100"
-                        step="0.5"
+                        step="0.1"
                         inputmode="decimal"
                         data-reversing-field="far-y"
                         data-side="left"
@@ -1252,7 +1199,7 @@
                         type="number"
                         min="0"
                         max="100"
-                        step="0.5"
+                        step="0.1"
                         inputmode="decimal"
                         data-reversing-field="near-x"
                         data-side="left"
@@ -1265,7 +1212,7 @@
                         type="number"
                         min="0"
                         max="100"
-                        step="0.5"
+                        step="0.1"
                         inputmode="decimal"
                         data-reversing-field="near-y"
                         data-side="left"
@@ -1281,46 +1228,7 @@
               </fieldset>
               <fieldset class="reversing-side" data-side="right">
                 <legend>Right guide</legend>
-                <p>
-                  Adjust the passenger-side guide segments. Nudge controls apply to the whole side.
-                </p>
-                <div class="reversing-nudge-group">
-                  <span class="muted">Nudge:</span>
-                  <div class="reversing-nudge-buttons">
-                    <button
-                      type="button"
-                      data-reversing-nudge="up"
-                      data-side="right"
-                      aria-label="Nudge right guide up"
-                    >
-                      ↑
-                    </button>
-                    <button
-                      type="button"
-                      data-reversing-nudge="down"
-                      data-side="right"
-                      aria-label="Nudge right guide down"
-                    >
-                      ↓
-                    </button>
-                    <button
-                      type="button"
-                      data-reversing-nudge="left"
-                      data-side="right"
-                      aria-label="Nudge right guide left"
-                    >
-                      ←
-                    </button>
-                    <button
-                      type="button"
-                      data-reversing-nudge="right"
-                      data-side="right"
-                      aria-label="Nudge right guide right"
-                    >
-                      →
-                    </button>
-                  </div>
-                </div>
+                <p>Adjust the passenger-side guide segments from the preview or the inputs.</p>
                 <div class="reversing-line-point" data-side="right" data-point="far">
                   <div class="reversing-line-header">
                     <span class="reversing-colour" style="background: #66bb6a;"></span>
@@ -1342,7 +1250,7 @@
                         type="number"
                         min="0"
                         max="100"
-                        step="0.5"
+                        step="0.1"
                         inputmode="decimal"
                         data-reversing-field="far-x"
                         data-side="right"
@@ -1355,7 +1263,7 @@
                         type="number"
                         min="0"
                         max="100"
-                        step="0.5"
+                        step="0.1"
                         inputmode="decimal"
                         data-reversing-field="far-y"
                         data-side="right"
@@ -1385,7 +1293,7 @@
                         type="number"
                         min="0"
                         max="100"
-                        step="0.5"
+                        step="0.1"
                         inputmode="decimal"
                         data-reversing-field="near-x"
                         data-side="right"
@@ -1398,7 +1306,7 @@
                         type="number"
                         min="0"
                         max="100"
-                        step="0.5"
+                        step="0.1"
                         inputmode="decimal"
                         data-reversing-field="near-y"
                         data-side="right"
@@ -1681,11 +1589,6 @@
             reversingAidsForm.querySelectorAll('button[data-reversing-pick]'),
           ).filter((element) => element instanceof HTMLButtonElement)
         : [];
-      const reversingNudgeButtons = reversingAidsForm
-        ? Array.from(
-            reversingAidsForm.querySelectorAll('button[data-reversing-nudge]'),
-          ).filter((element) => element instanceof HTMLButtonElement)
-        : [];
       const reversingPreviewStage = document.getElementById("reversing-preview-stage");
       const reversingPreviewImage = document.getElementById("reversing-preview-image");
       const reversingPreviewCanvas = document.getElementById("reversing-preview-canvas");
@@ -1694,11 +1597,15 @@
       const reversingPreviewCaptureButton = document.getElementById("reversing-preview-capture");
       const reversingPreviewUploadInput = document.getElementById("reversing-preview-upload");
       const reversingPreviewClearButton = document.getElementById("reversing-preview-clear");
+      const reversingPreviewCaptureDefaultText =
+        reversingPreviewCaptureButton && typeof reversingPreviewCaptureButton.textContent === "string"
+          ? reversingPreviewCaptureButton.textContent
+          : "Capture snapshot";
       let reversingPreviewObjectUrl = null;
       let reversingPreviewStatusTimer = null;
       let reversingPreviewLoading = false;
       let reversingPreviewActivePoint = null;
-      const REVERSING_NUDGE_STEP = 1;
+      let reversingPreviewSource = null;
       const REVERSING_SEGMENT_RATIOS = [
         { start: 0.0, end: 0.25 },
         { start: 0.375, end: 0.625 },
@@ -1996,6 +1903,7 @@
           reversingPreviewImage.src = "";
           reversingPreviewImage.hidden = true;
         }
+        reversingPreviewSource = null;
         setReversingPreviewAspect();
         setReversingPreviewPlaceholderVisible(true);
         updateReversingPreviewControlsState();
@@ -2051,6 +1959,45 @@
           throw new Error("Unable to load reference image");
         }
         return true;
+      }
+
+      async function captureReversingPreviewSnapshot(options = {}) {
+        if (reversingPreviewLoading) {
+          return false;
+        }
+        const silent = options.silent === true;
+        reversingPreviewLoading = true;
+        if (!silent && reversingPreviewCaptureButton instanceof HTMLButtonElement) {
+          reversingPreviewCaptureButton.disabled = true;
+          reversingPreviewCaptureButton.textContent = "Capturing…";
+        }
+        setReversingPreviewStatus(silent ? "Refreshing snapshot…" : "Capturing snapshot…", {
+          persistent: true,
+        });
+        try {
+          const response = await fetch("/api/camera/snapshot", { cache: "no-store" });
+          if (!response.ok) {
+            throw new Error(`Snapshot request failed: ${response.status}`);
+          }
+          const blob = await response.blob();
+          await loadReversingPreviewFromBlob(blob);
+          reversingPreviewSource = "snapshot";
+          setReversingPreviewStatus(silent ? "Snapshot refreshed." : "Snapshot captured.");
+          return true;
+        } catch (err) {
+          console.error("Reversing preview capture error", err);
+          setReversingPreviewStatus(
+            silent ? "Unable to refresh snapshot." : "Unable to capture snapshot.",
+            { persistent: true },
+          );
+          return false;
+        } finally {
+          reversingPreviewLoading = false;
+          if (!silent && reversingPreviewCaptureButton instanceof HTMLButtonElement) {
+            reversingPreviewCaptureButton.disabled = false;
+            reversingPreviewCaptureButton.textContent = reversingPreviewCaptureDefaultText;
+          }
+        }
       }
 
       function parseReversingPreviewValue(input) {
@@ -2477,32 +2424,6 @@
           `${description} point updated. Click the preview to refine or choose another point.`,
           { persistent: true },
         );
-      }
-
-      function adjustReversingSide(side, deltaX, deltaY) {
-        if (!reversingInputs.length) {
-          return;
-        }
-        for (const input of reversingInputs) {
-          if (!(input instanceof HTMLInputElement) || input.dataset.side !== side) {
-            continue;
-          }
-          const axis = input.dataset.axis;
-          const current = parseFloat(input.value);
-          if (!Number.isFinite(current)) {
-            continue;
-          }
-          if (axis === "x" && deltaX !== 0) {
-            const updated = Math.min(100, Math.max(0, current + deltaX));
-            input.value = formatPercentageValue(updated);
-            input.dataset.userEdited = "true";
-          } else if (axis === "y" && deltaY !== 0) {
-            const updated = Math.min(100, Math.max(0, current + deltaY));
-            input.value = formatPercentageValue(updated);
-            input.dataset.userEdited = "true";
-          }
-        }
-        drawReversingPreviewOverlay();
       }
 
       function formatDistance(value) {
@@ -3466,36 +3387,6 @@
         });
       }
 
-      if (reversingNudgeButtons.length) {
-        for (const button of reversingNudgeButtons) {
-          button.addEventListener("click", () => {
-            const side = button.dataset.side;
-            const direction = button.dataset.reversingNudge;
-            if (!side || !direction) {
-              return;
-            }
-            let deltaX = 0;
-            let deltaY = 0;
-            if (direction === "left") {
-              deltaX = -REVERSING_NUDGE_STEP;
-            } else if (direction === "right") {
-              deltaX = REVERSING_NUDGE_STEP;
-            } else if (direction === "up") {
-              deltaY = -REVERSING_NUDGE_STEP;
-            } else if (direction === "down") {
-              deltaY = REVERSING_NUDGE_STEP;
-            }
-            if (deltaX === 0 && deltaY === 0) {
-              return;
-            }
-            adjustReversingSide(side, deltaX, deltaY);
-            if (reversingAidsStatus) {
-              reversingAidsStatus.textContent = "";
-            }
-          });
-        }
-      }
-
       updateReversingPreviewControlsState();
 
       if (reversingPreviewClearButton) {
@@ -3515,6 +3406,7 @@
           setReversingPreviewStatus(`Loading ${file.name}…`);
           try {
             await loadReversingPreviewFromBlob(file);
+            reversingPreviewSource = "upload";
             setReversingPreviewStatus(`Loaded ${file.name}`);
           } catch (err) {
             console.error("Reversing preview upload error", err);
@@ -3527,31 +3419,8 @@
       }
 
       if (reversingPreviewCaptureButton) {
-        const captureDefaultText = reversingPreviewCaptureButton.textContent || "Capture snapshot";
-        reversingPreviewCaptureButton.addEventListener("click", async () => {
-          if (reversingPreviewLoading) {
-            return;
-          }
-          reversingPreviewLoading = true;
-          reversingPreviewCaptureButton.disabled = true;
-          reversingPreviewCaptureButton.textContent = "Capturing…";
-          setReversingPreviewStatus("Capturing snapshot…", { persistent: true });
-          try {
-            const response = await fetch("/api/camera/snapshot", { cache: "no-store" });
-            if (!response.ok) {
-              throw new Error(`Snapshot request failed: ${response.status}`);
-            }
-            const blob = await response.blob();
-            await loadReversingPreviewFromBlob(blob);
-            setReversingPreviewStatus("Snapshot captured.");
-          } catch (err) {
-            console.error("Reversing preview capture error", err);
-            setReversingPreviewStatus("Unable to capture snapshot.", { persistent: true });
-          } finally {
-            reversingPreviewLoading = false;
-            reversingPreviewCaptureButton.disabled = false;
-            reversingPreviewCaptureButton.textContent = captureDefaultText;
-          }
+        reversingPreviewCaptureButton.addEventListener("click", () => {
+          captureReversingPreviewSnapshot().catch((err) => console.error(err));
         });
       }
 
@@ -3595,6 +3464,12 @@
             }
             const data = await response.json();
             applyReversingAids(data, { forceUpdate: true });
+            setReversingPreviewActivePoint(null);
+            if (reversingPreviewSource === "snapshot") {
+              captureReversingPreviewSnapshot({ silent: true }).catch((err) =>
+                console.error("Reversing preview refresh error", err),
+              );
+            }
             reversingAidsStatus.textContent = "Reversing aids saved.";
             setTimeout(() => {
               if (

--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -1119,49 +1119,6 @@
             <fieldset class="reversing-side" data-side="left">
                 <legend>Left guide</legend>
                 <p>Adjust the driver’s-side guide segments. Click the preview or edit the values.</p>
-                <div class="reversing-line-point" data-side="left" data-point="far">
-                  <div class="reversing-line-header">
-                    <span class="reversing-colour" style="background: #66bb6a;"></span>
-                    <span>Far point</span>
-                    <button
-                      type="button"
-                      class="reversing-point-button"
-                      data-side="left"
-                      data-reversing-pick="far"
-                      aria-pressed="false"
-                    >
-                      Select on preview
-                    </button>
-                  </div>
-                  <div class="reversing-line-fields">
-                    <label>
-                      Horizontal (%)
-                      <input
-                        type="number"
-                        min="0"
-                        max="100"
-                        step="0.1"
-                        inputmode="decimal"
-                        data-reversing-field="far-x"
-                        data-side="left"
-                        data-axis="x"
-                      />
-                    </label>
-                    <label>
-                      Vertical (%)
-                      <input
-                        type="number"
-                        min="0"
-                        max="100"
-                        step="0.1"
-                        inputmode="decimal"
-                        data-reversing-field="far-y"
-                        data-side="left"
-                        data-axis="y"
-                      />
-                    </label>
-                  </div>
-                </div>
                 <div class="reversing-line-point" data-side="left" data-point="near">
                   <div class="reversing-line-header">
                     <span class="reversing-colour" style="background: #ef5350;"></span>
@@ -1205,18 +1162,14 @@
                     </label>
                   </div>
                 </div>
-              </fieldset>
-              <fieldset class="reversing-side" data-side="right">
-                <legend>Right guide</legend>
-                <p>Adjust the passenger-side guide segments from the preview or the inputs.</p>
-                <div class="reversing-line-point" data-side="right" data-point="far">
+                <div class="reversing-line-point" data-side="left" data-point="far">
                   <div class="reversing-line-header">
                     <span class="reversing-colour" style="background: #66bb6a;"></span>
                     <span>Far point</span>
                     <button
                       type="button"
                       class="reversing-point-button"
-                      data-side="right"
+                      data-side="left"
                       data-reversing-pick="far"
                       aria-pressed="false"
                     >
@@ -1233,7 +1186,7 @@
                         step="0.1"
                         inputmode="decimal"
                         data-reversing-field="far-x"
-                        data-side="right"
+                        data-side="left"
                         data-axis="x"
                       />
                     </label>
@@ -1246,12 +1199,16 @@
                         step="0.1"
                         inputmode="decimal"
                         data-reversing-field="far-y"
-                        data-side="right"
+                        data-side="left"
                         data-axis="y"
                       />
                     </label>
                   </div>
                 </div>
+              </fieldset>
+              <fieldset class="reversing-side" data-side="right">
+                <legend>Right guide</legend>
+                <p>Adjust the passenger-side guide segments from the preview or the inputs.</p>
                 <div class="reversing-line-point" data-side="right" data-point="near">
                   <div class="reversing-line-header">
                     <span class="reversing-colour" style="background: #ef5350;"></span>
@@ -1289,6 +1246,49 @@
                         step="0.1"
                         inputmode="decimal"
                         data-reversing-field="near-y"
+                        data-side="right"
+                        data-axis="y"
+                      />
+                    </label>
+                  </div>
+                </div>
+                <div class="reversing-line-point" data-side="right" data-point="far">
+                  <div class="reversing-line-header">
+                    <span class="reversing-colour" style="background: #66bb6a;"></span>
+                    <span>Far point</span>
+                    <button
+                      type="button"
+                      class="reversing-point-button"
+                      data-side="right"
+                      data-reversing-pick="far"
+                      aria-pressed="false"
+                    >
+                      Select on preview
+                    </button>
+                  </div>
+                  <div class="reversing-line-fields">
+                    <label>
+                      Horizontal (%)
+                      <input
+                        type="number"
+                        min="0"
+                        max="100"
+                        step="0.1"
+                        inputmode="decimal"
+                        data-reversing-field="far-x"
+                        data-side="right"
+                        data-axis="x"
+                      />
+                    </label>
+                    <label>
+                      Vertical (%)
+                      <input
+                        type="number"
+                        min="0"
+                        max="100"
+                        step="0.1"
+                        inputmode="decimal"
+                        data-reversing-field="far-y"
                         data-side="right"
                         data-axis="y"
                       />

--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -283,27 +283,37 @@
         padding: 0.35rem 0.65rem;
         font-size: 0.9rem;
       }
-      .reversing-angle-group {
-        display: flex;
-        align-items: center;
-        gap: 0.75rem;
-        flex-wrap: wrap;
-        margin-bottom: 1rem;
-      }
-      .reversing-angle-buttons {
-        display: inline-flex;
-        gap: 0.25rem;
-      }
-      .reversing-angle-buttons button {
-        padding: 0.35rem 0.65rem;
-        font-size: 0.9rem;
-      }
-      .reversing-angle-value {
+      .reversing-point-button {
+        margin-left: auto;
+        border: 1px solid rgba(10, 132, 255, 0.35);
+        border-radius: 999px;
+        background: rgba(10, 132, 255, 0.08);
+        color: #0a84ff;
+        font-size: 0.8rem;
         font-weight: 600;
-        font-variant-numeric: tabular-nums;
-        min-width: 3rem;
+        padding: 0.2rem 0.9rem;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        cursor: pointer;
+        transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
       }
-      .reversing-angle-hint {
+      .reversing-point-button:hover,
+      .reversing-point-button:focus {
+        background: rgba(10, 132, 255, 0.15);
+        color: #0a84ff;
+        border-color: rgba(10, 132, 255, 0.5);
+      }
+      .reversing-point-button[aria-pressed="true"] {
+        background: #0a84ff;
+        color: #fff;
+        border-color: #0a84ff;
+      }
+      .reversing-point-button:disabled {
+        opacity: 0.55;
+        cursor: not-allowed;
+      }
+      .reversing-point-hint {
         margin: -0.25rem 0 0.75rem;
         font-size: 0.85rem;
         opacity: 0.75;
@@ -322,6 +332,7 @@
         align-items: center;
         gap: 0.5rem;
         font-weight: 600;
+        flex-wrap: wrap;
       }
       .reversing-colour {
         width: 0.9rem;
@@ -414,6 +425,11 @@
       }
       .reversing-preview-stage canvas {
         pointer-events: none;
+      }
+      .reversing-preview-stage.is-picking,
+      .reversing-preview-stage.is-picking img,
+      .reversing-preview-stage.is-picking .reversing-preview-placeholder {
+        cursor: crosshair;
       }
       .reversing-preview-placeholder {
         position: absolute;
@@ -1084,8 +1100,7 @@
           <form id="reversing-aids-form" class="card">
             <h2>Reversing aids</h2>
             <p class="muted">
-              Configure the on-screen guides to match your vehicle width, camera position and
-              preferred viewing angle.
+              Configure the on-screen guides to match your vehicle width and camera position.
             </p>
             <label style="display: inline-flex; align-items: center; gap: 0.5rem;">
               <input type="checkbox" id="reversing-aids-enabled" />
@@ -1128,9 +1143,9 @@
                 </div>
             </div>
           </div>
-          <p class="muted reversing-angle-hint">
-            Angle controls rotate each side together so the guide segments stay parallel. Values
-            are reported in degrees from the horizontal.
+          <p class="muted reversing-point-hint">
+            Select a point below, then click the preview to position it. Active points stay
+            highlighted so you can fine-tune the guides visually.
           </p>
           <div class="reversing-grid">
             <fieldset class="reversing-side" data-side="left">
@@ -1173,40 +1188,19 @@
                     </button>
                   </div>
                 </div>
-                <div class="reversing-angle-group" data-side="left">
-                  <span class="muted">Angle:</span>
-                  <div class="reversing-angle-buttons">
-                    <button
-                      type="button"
-                      data-reversing-angle="narrow"
-                      data-side="left"
-                      aria-label="Make left guide more vertical"
-                      title="Make left guide more vertical"
-                    >
-                      –
-                    </button>
-                    <button
-                      type="button"
-                      data-reversing-angle="wide"
-                      data-side="left"
-                      aria-label="Make left guide more horizontal"
-                      title="Make left guide more horizontal"
-                    >
-                      +
-                    </button>
-                  </div>
-                  <output
-                    class="reversing-angle-value"
-                    data-reversing-angle-value="left"
-                    aria-live="polite"
-                  >
-                    —
-                  </output>
-                </div>
                 <div class="reversing-line-point" data-side="left" data-point="far">
                   <div class="reversing-line-header">
                     <span class="reversing-colour" style="background: #66bb6a;"></span>
                     <span>Far point</span>
+                    <button
+                      type="button"
+                      class="reversing-point-button"
+                      data-side="left"
+                      data-reversing-pick="far"
+                      aria-pressed="false"
+                    >
+                      Select on preview
+                    </button>
                   </div>
                   <div class="reversing-line-fields">
                     <label>
@@ -1241,6 +1235,15 @@
                   <div class="reversing-line-header">
                     <span class="reversing-colour" style="background: #ef5350;"></span>
                     <span>Near point</span>
+                    <button
+                      type="button"
+                      class="reversing-point-button"
+                      data-side="left"
+                      data-reversing-pick="near"
+                      aria-pressed="false"
+                    >
+                      Select on preview
+                    </button>
                   </div>
                   <div class="reversing-line-fields">
                     <label>
@@ -1318,40 +1321,19 @@
                     </button>
                   </div>
                 </div>
-                <div class="reversing-angle-group" data-side="right">
-                  <span class="muted">Angle:</span>
-                  <div class="reversing-angle-buttons">
-                    <button
-                      type="button"
-                      data-reversing-angle="narrow"
-                      data-side="right"
-                      aria-label="Make right guide more vertical"
-                      title="Make right guide more vertical"
-                    >
-                      –
-                    </button>
-                    <button
-                      type="button"
-                      data-reversing-angle="wide"
-                      data-side="right"
-                      aria-label="Make right guide more horizontal"
-                      title="Make right guide more horizontal"
-                    >
-                      +
-                    </button>
-                  </div>
-                  <output
-                    class="reversing-angle-value"
-                    data-reversing-angle-value="right"
-                    aria-live="polite"
-                  >
-                    —
-                  </output>
-                </div>
                 <div class="reversing-line-point" data-side="right" data-point="far">
                   <div class="reversing-line-header">
                     <span class="reversing-colour" style="background: #66bb6a;"></span>
                     <span>Far point</span>
+                    <button
+                      type="button"
+                      class="reversing-point-button"
+                      data-side="right"
+                      data-reversing-pick="far"
+                      aria-pressed="false"
+                    >
+                      Select on preview
+                    </button>
                   </div>
                   <div class="reversing-line-fields">
                     <label>
@@ -1386,6 +1368,15 @@
                   <div class="reversing-line-header">
                     <span class="reversing-colour" style="background: #ef5350;"></span>
                     <span>Near point</span>
+                    <button
+                      type="button"
+                      class="reversing-point-button"
+                      data-side="right"
+                      data-reversing-pick="near"
+                      aria-pressed="false"
+                    >
+                      Select on preview
+                    </button>
                   </div>
                   <div class="reversing-line-fields">
                     <label>
@@ -1685,24 +1676,9 @@
           });
         }
       }
-      const reversingAngleValueElements = reversingAidsForm
+      const reversingPointButtons = reversingAidsForm
         ? Array.from(
-            reversingAidsForm.querySelectorAll('[data-reversing-angle-value]'),
-          ).filter((element) => element instanceof HTMLElement)
-        : [];
-      const reversingAngleValueMap = new Map();
-      if (reversingAngleValueElements.length) {
-        for (const element of reversingAngleValueElements) {
-          const side = element.dataset.reversingAngleValue;
-          if (typeof side !== "string" || !side) {
-            continue;
-          }
-          reversingAngleValueMap.set(side, element);
-        }
-      }
-      const reversingAngleButtons = reversingAidsForm
-        ? Array.from(
-            reversingAidsForm.querySelectorAll('button[data-reversing-angle]'),
+            reversingAidsForm.querySelectorAll('button[data-reversing-pick]'),
           ).filter((element) => element instanceof HTMLButtonElement)
         : [];
       const reversingNudgeButtons = reversingAidsForm
@@ -1721,6 +1697,7 @@
       let reversingPreviewObjectUrl = null;
       let reversingPreviewStatusTimer = null;
       let reversingPreviewLoading = false;
+      let reversingPreviewActivePoint = null;
       const REVERSING_NUDGE_STEP = 1;
       const REVERSING_SEGMENT_RATIOS = [
         { start: 0.0, end: 0.25 },
@@ -1730,21 +1707,6 @@
       const REVERSING_SEGMENTS_PER_SIDE = REVERSING_SEGMENT_RATIOS.length;
       const REVERSING_SEGMENT_COLOURS = ["#66bb6a", "#ffc107", "#ef5350"];
       const REVERSING_PREVIEW_DEFAULT_RATIO = "16 / 9";
-      const REVERSING_ANGLE_STEP_DEGREES = 1.5;
-      const DEFAULT_REVERSING_LINES = {
-        left: {
-          near: { x: 0.14, y: 0.86 },
-          far: { x: 0.52, y: 0.18 },
-        },
-        right: {
-          near: { x: 0.86, y: 0.86 },
-          far: { x: 0.48, y: 0.18 },
-        },
-      };
-      const reversingSideVectors = {
-        left: null,
-        right: null,
-      };
       const diagnosticsButton = document.getElementById("diagnostics-refresh");
       const diagnosticsStatus = document.getElementById("diagnostics-status");
       const diagnosticsResults = document.getElementById("diagnostics-results");
@@ -1939,6 +1901,9 @@
       function setReversingInputsDisabled(disabled) {
         if (!reversingSideFieldsets.length) {
           return;
+        }
+        if (disabled) {
+          setReversingPreviewActivePoint(null);
         }
         for (const fieldset of reversingSideFieldsets) {
           fieldset.disabled = Boolean(disabled);
@@ -2182,6 +2147,23 @@
             context.fill();
           }
         }
+        if (reversingPreviewActivePoint) {
+          const line = readReversingLine(reversingPreviewActivePoint.side);
+          const activePoint =
+            reversingPreviewActivePoint.point === "near"
+              ? line?.near ?? null
+              : line?.far ?? null;
+          if (activePoint) {
+            const highlightX = activePoint.x * widthScale;
+            const highlightY = activePoint.y * heightScale;
+            const ringRadius = Math.max(thickness * 1.5, 6);
+            context.strokeStyle = "rgba(255, 255, 255, 0.85)";
+            context.lineWidth = Math.max(2, Math.round(thickness * 0.6));
+            context.beginPath();
+            context.arc(highlightX, highlightY, ringRadius, 0, Math.PI * 2);
+            context.stroke();
+          }
+        }
         context.restore();
       }
 
@@ -2223,7 +2205,6 @@
             updateReversingInputValue(input, value);
           }
         }
-        refreshReversingSideVectors();
       }
 
       function applyReversingAids(config, options = {}) {
@@ -2390,134 +2371,90 @@
         }));
       }
 
-      function clampVectorForSide(side, vector, nearOverride = null) {
-        const baseDx =
-          typeof vector?.dx === "number" && Number.isFinite(vector.dx) ? vector.dx : 0;
-        const baseDy =
-          typeof vector?.dy === "number" && Number.isFinite(vector.dy) ? vector.dy : 0;
-        let near = nearOverride;
-        if (!near) {
-          const line = readReversingLine(side);
-          if (line) {
-            near = line.near;
-          } else if (DEFAULT_REVERSING_LINES[side]) {
-            near = DEFAULT_REVERSING_LINES[side].near;
-          } else {
-            return { dx: 0, dy: 0 };
-          }
-        }
-        const minDx = near.x - 1;
-        const maxDx = near.x;
-        const minDy = near.y - 1;
-        const maxDy = near.y;
-        return {
-          dx: Math.min(maxDx, Math.max(minDx, baseDx)),
-          dy: Math.min(maxDy, Math.max(minDy, baseDy)),
-        };
+      function getReversingPointLabel(side, point) {
+        const sideLabel = side === "left" ? "left" : "right";
+        const pointLabel = point === "near" ? "near" : "far";
+        return `${sideLabel} ${pointLabel}`;
       }
 
-      function setReversingSideVector(side, vector, options = {}) {
+      function setReversingPreviewActivePoint(target) {
+        if (target && (typeof target.side !== "string" || typeof target.point !== "string")) {
+          target = null;
+        }
+        reversingPreviewActivePoint = target
+          ? { side: target.side, point: target.point }
+          : null;
+        if (reversingPreviewStage instanceof HTMLElement) {
+          reversingPreviewStage.classList.toggle(
+            "is-picking",
+            Boolean(reversingPreviewActivePoint),
+          );
+        }
+        if (reversingPointButtons.length) {
+          for (const button of reversingPointButtons) {
+            if (!(button instanceof HTMLButtonElement)) {
+              continue;
+            }
+            const side = button.dataset.side;
+            const point = button.dataset.reversingPick;
+            const isActive =
+              !!reversingPreviewActivePoint &&
+              reversingPreviewActivePoint.side === side &&
+              reversingPreviewActivePoint.point === point;
+            button.setAttribute("aria-pressed", isActive ? "true" : "false");
+          }
+        }
+        if (reversingPreviewActivePoint) {
+          const description = getReversingPointLabel(
+            reversingPreviewActivePoint.side,
+            reversingPreviewActivePoint.point,
+          );
+          setReversingPreviewStatus(`Click the preview to position the ${description} point.`, {
+            persistent: true,
+          });
+        } else {
+          setReversingPreviewStatus("");
+        }
+        drawReversingPreviewOverlay();
+      }
+
+      function setReversingPointFromPreview(side, point, x, y) {
+        if (!side || !point) {
+          return false;
+        }
         const inputs = getReversingLineInputs(side);
         if (!inputs) {
           return false;
         }
-        let nearX = parseReversingPreviewValue(inputs.nearX);
-        let nearY = parseReversingPreviewValue(inputs.nearY);
-        if (nearX === null || nearY === null) {
-          const fallback = DEFAULT_REVERSING_LINES[side];
-          if (!fallback) {
-            return false;
+        const clampedX = clamp01(x);
+        const clampedY = clamp01(y);
+        let changed = false;
+        const targetX = point === "near" ? inputs.nearX : inputs.farX;
+        const targetY = point === "near" ? inputs.nearY : inputs.farY;
+        if (targetX instanceof HTMLInputElement) {
+          updateReversingInputValue(targetX, clampedX, { markEdited: true });
+          handleReversingInputEdit(targetX);
+          changed = true;
+        }
+        if (targetY instanceof HTMLInputElement) {
+          updateReversingInputValue(targetY, clampedY, { markEdited: true });
+          handleReversingInputEdit(targetY);
+          changed = true;
+        }
+        if (changed) {
+          if (reversingAidsStatus) {
+            reversingAidsStatus.textContent = "";
           }
-          nearX = fallback.near.x;
-          nearY = fallback.near.y;
-          if (inputs.nearX instanceof HTMLInputElement) {
-            updateReversingInputValue(inputs.nearX, nearX, {
-              clearEdited: options.clearEdited !== false,
-              markEdited: options.markEdited === true,
-            });
-          }
-          if (inputs.nearY instanceof HTMLInputElement) {
-            updateReversingInputValue(inputs.nearY, nearY, {
-              clearEdited: options.clearEdited !== false,
-              markEdited: options.markEdited === true,
-            });
-          }
+          drawReversingPreviewOverlay();
         }
-        const clamped = clampVectorForSide(side, vector, { x: nearX, y: nearY });
-        const farX = clamp01(nearX - clamped.dx);
-        const farY = clamp01(nearY - clamped.dy);
-        if (inputs.farX instanceof HTMLInputElement) {
-          updateReversingInputValue(inputs.farX, farX, {
-            clearEdited: options.clearEdited !== false,
-            markEdited: options.markEdited === true,
-          });
-        }
-        if (inputs.farY instanceof HTMLInputElement) {
-          updateReversingInputValue(inputs.farY, farY, {
-            clearEdited: options.clearEdited !== false,
-            markEdited: options.markEdited === true,
-          });
-        }
-        reversingSideVectors[side] = {
-          dx: nearX - farX,
-          dy: nearY - farY,
-        };
-        updateReversingAngleValue(side);
-        return true;
-      }
-
-      function updateReversingSideVectorFromInputs(side) {
-        const line = readReversingLine(side);
-        if (!line) {
-          return false;
-        }
-        reversingSideVectors[side] = {
-          dx: line.near.x - line.far.x,
-          dy: line.near.y - line.far.y,
-        };
-        updateReversingAngleValue(side);
-        return true;
-      }
-
-      function ensureReversingSideVector(side) {
-        if (!reversingSideVectors[side]) {
-          if (!updateReversingSideVectorFromInputs(side)) {
-            const fallback = DEFAULT_REVERSING_LINES[side];
-            if (fallback) {
-              writeReversingLine(side, fallback, { force: true });
-              reversingSideVectors[side] = {
-                dx: fallback.near.x - fallback.far.x,
-                dy: fallback.near.y - fallback.far.y,
-              };
-            } else {
-              reversingSideVectors[side] = { dx: 0, dy: 0 };
-            }
-            updateReversingAngleValue(side);
-          }
-        }
-        return reversingSideVectors[side];
-      }
-
-      function refreshReversingSideVectors() {
-        for (const side of ["left", "right"]) {
-          if (!updateReversingSideVectorFromInputs(side)) {
-            const fallback = DEFAULT_REVERSING_LINES[side];
-            if (fallback) {
-              writeReversingLine(side, fallback, { force: true });
-              reversingSideVectors[side] = {
-                dx: fallback.near.x - fallback.far.x,
-                dy: fallback.near.y - fallback.far.y,
-              };
-            } else {
-              reversingSideVectors[side] = { dx: 0, dy: 0 };
-            }
-            updateReversingAngleValue(side);
-          }
-        }
+        return changed;
       }
 
       function handleReversingInputEdit(input) {
         if (!(input instanceof HTMLInputElement)) {
+          return;
+        }
+        if (!reversingPreviewActivePoint) {
           return;
         }
         const side = input.dataset.side;
@@ -2525,81 +2462,21 @@
         if (!side || !field) {
           return;
         }
-        if (field === "near-x" || field === "near-y" || field === "far-x" || field === "far-y") {
-          updateReversingSideVectorFromInputs(side);
-        }
-      }
-
-      function computeAngleFromVector(vector) {
-        if (
-          !vector ||
-          typeof vector.dx !== "number" ||
-          typeof vector.dy !== "number"
-        ) {
-          return null;
-        }
-        const dx = Math.abs(vector.dx);
-        const dy = Math.abs(vector.dy);
-        if (!(dx > 0) && !(dy > 0)) {
-          return null;
-        }
-        const radians = Math.atan2(dy, dx);
-        if (!Number.isFinite(radians)) {
-          return null;
-        }
-        const degrees = (radians * 180) / Math.PI;
-        return Math.max(0, Math.min(90, degrees));
-      }
-
-      function updateReversingAngleValue(side) {
-        const output = reversingAngleValueMap.get(side);
-        if (!output) {
+        if (side !== reversingPreviewActivePoint.side) {
           return;
         }
-        const angle = computeAngleFromVector(reversingSideVectors[side]);
-        if (angle === null) {
-          output.textContent = "—";
-        } else {
-          output.textContent = `${formatPercentageValue(angle)}°`;
+        const point = reversingPreviewActivePoint.point;
+        if (
+          (point === "near" && field !== "near-x" && field !== "near-y") ||
+          (point === "far" && field !== "far-x" && field !== "far-y")
+        ) {
+          return;
         }
-      }
-
-      function getAngleLimitsForSide(side) {
-        const epsilon = Math.PI / 180;
-        if (side === "left") {
-          return { min: Math.PI / 2 + epsilon, max: Math.PI - epsilon };
-        }
-        return { min: epsilon, max: Math.PI / 2 - epsilon };
-      }
-
-      function adjustReversingSideAngle(side, direction) {
-        if (typeof side !== "string" || !direction) {
-          return false;
-        }
-        const vector = ensureReversingSideVector(side);
-        if (!vector) {
-          return false;
-        }
-        const magnitude = Math.hypot(vector.dx, vector.dy);
-        if (!(magnitude > 0)) {
-          return false;
-        }
-        const delta = (REVERSING_ANGLE_STEP_DEGREES * Math.PI) / 180;
-        let angle = Math.atan2(vector.dy, vector.dx);
-        if (direction === "narrow") {
-          angle += side === "left" ? -delta : delta;
-        } else if (direction === "wide") {
-          angle += side === "left" ? delta : -delta;
-        } else {
-          return false;
-        }
-        const limits = getAngleLimitsForSide(side);
-        angle = Math.min(limits.max, Math.max(limits.min, angle));
-        const rotated = {
-          dx: Math.cos(angle) * magnitude,
-          dy: Math.sin(angle) * magnitude,
-        };
-        return setReversingSideVector(side, rotated, { markEdited: true });
+        const description = getReversingPointLabel(side, point);
+        setReversingPreviewStatus(
+          `${description} point updated. Click the preview to refine or choose another point.`,
+          { persistent: true },
+        );
       }
 
       function adjustReversingSide(side, deltaX, deltaY) {
@@ -2625,7 +2502,6 @@
             input.dataset.userEdited = "true";
           }
         }
-        updateReversingSideVectorFromInputs(side);
         drawReversingPreviewOverlay();
       }
 
@@ -3531,27 +3407,63 @@
       if (reversingAidsEnabledInput) {
         setReversingInputsDisabled(!reversingAidsEnabledInput.checked);
         reversingAidsEnabledInput.addEventListener("change", () => {
+          if (!reversingAidsEnabledInput.checked) {
+            setReversingPreviewActivePoint(null);
+          }
           setReversingInputsDisabled(!reversingAidsEnabledInput.checked);
           drawReversingPreviewOverlay();
         });
         drawReversingPreviewOverlay();
       }
 
-      if (reversingAngleButtons.length) {
-        for (const button of reversingAngleButtons) {
+      if (reversingPointButtons.length) {
+        for (const button of reversingPointButtons) {
           button.addEventListener("click", () => {
             const side = button.dataset.side;
-            const direction = button.dataset.reversingAngle;
-            if (!side || !direction) {
+            const point = button.dataset.reversingPick;
+            if (!side || !point) {
               return;
             }
-            adjustReversingSideAngle(side, direction);
-            if (reversingAidsStatus) {
-              reversingAidsStatus.textContent = "";
+            const isActive =
+              !!reversingPreviewActivePoint &&
+              reversingPreviewActivePoint.side === side &&
+              reversingPreviewActivePoint.point === point;
+            if (isActive) {
+              setReversingPreviewActivePoint(null);
+            } else {
+              setReversingPreviewActivePoint({ side, point });
             }
-            drawReversingPreviewOverlay();
           });
         }
+      }
+
+      if (reversingPreviewStage instanceof HTMLElement) {
+        reversingPreviewStage.addEventListener("click", (event) => {
+          if (reversingAidsEnabledInput && !reversingAidsEnabledInput.checked) {
+            return;
+          }
+          if (!reversingPreviewActivePoint) {
+            setReversingPreviewStatus("Select a point below to adjust it on the preview.", {
+              persistent: true,
+            });
+            return;
+          }
+          const rect = reversingPreviewStage.getBoundingClientRect();
+          if (!(rect.width > 0 && rect.height > 0)) {
+            return;
+          }
+          const x = clamp01((event.clientX - rect.left) / rect.width);
+          const y = clamp01((event.clientY - rect.top) / rect.height);
+          const { side, point } = reversingPreviewActivePoint;
+          if (!setReversingPointFromPreview(side, point, x, y)) {
+            return;
+          }
+          const description = getReversingPointLabel(side, point);
+          setReversingPreviewStatus(
+            `${description} point updated. Click the preview to refine or choose another point.`,
+            { persistent: true },
+          );
+        });
       }
 
       if (reversingNudgeButtons.length) {

--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -1127,10 +1127,10 @@
                       type="button"
                       class="reversing-point-button"
                       data-side="left"
-                      data-reversing-pick="near"
+                      data-reversing-pick="far"
                       aria-pressed="false"
                     >
-                      Select on Preview
+                      Select on preview
                     </button>
                   </div>
                   <div class="reversing-line-fields">
@@ -1170,10 +1170,10 @@
                       type="button"
                       class="reversing-point-button"
                       data-side="left"
-                      data-reversing-pick="far"
+                      data-reversing-pick="near"
                       aria-pressed="false"
                     >
-                      Select on preview
+                      Select on Preview
                     </button>
                   </div>
                   <div class="reversing-line-fields">
@@ -1217,10 +1217,10 @@
                       type="button"
                       class="reversing-point-button"
                       data-side="right"
-                      data-reversing-pick="near"
+                      data-reversing-pick="far"
                       aria-pressed="false"
                     >
-                      Select on Preview
+                      Select on preview
                     </button>
                   </div>
                   <div class="reversing-line-fields">
@@ -1260,10 +1260,10 @@
                       type="button"
                       class="reversing-point-button"
                       data-side="right"
-                      data-reversing-pick="far"
+                      data-reversing-pick="near"
                       aria-pressed="false"
                     >
-                      Select on preview
+                      Select on Preview
                     </button>
                   </div>
                   <div class="reversing-line-fields">

--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -308,16 +308,16 @@
         font-size: 0.85rem;
         opacity: 0.75;
       }
-      .reversing-segment {
+      .reversing-line-point {
         display: flex;
         flex-direction: column;
         gap: 0.75rem;
         margin-bottom: 1.25rem;
       }
-      .reversing-segment:last-of-type {
+      .reversing-line-point:last-of-type {
         margin-bottom: 0;
       }
-      .reversing-segment-header {
+      .reversing-line-header {
         display: flex;
         align-items: center;
         gap: 0.5rem;
@@ -329,17 +329,25 @@
         border-radius: 50%;
         display: inline-block;
       }
-      .reversing-segment-fields {
+      .reversing-line-fields {
         display: grid;
         gap: 0.75rem;
         grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
       }
-      .reversing-segment-fields label {
+      .reversing-line-fields label {
         display: flex;
         flex-direction: column;
         gap: 0.4rem;
         font-size: 0.9rem;
         margin: 0;
+      }
+      .reversing-line-note {
+        margin: -0.3rem 0 1.25rem;
+        font-size: 0.85rem;
+        opacity: 0.75;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
       }
       .reversing-preview {
         display: flex;
@@ -1195,198 +1203,78 @@
                     —
                   </output>
                 </div>
-                <div class="reversing-segment" data-side="left" data-segment="0">
-                  <div class="reversing-segment-header">
+                <div class="reversing-line-point" data-side="left" data-point="far">
+                  <div class="reversing-line-header">
                     <span class="reversing-colour" style="background: #66bb6a;"></span>
-                    <span>Far segment</span>
+                    <span>Far point</span>
                   </div>
-                  <div class="reversing-segment-fields">
+                  <div class="reversing-line-fields">
                     <label>
-                      Start horizontal (%)
+                      Horizontal (%)
                       <input
                         type="number"
                         min="0"
                         max="100"
                         step="0.5"
                         inputmode="decimal"
-                        data-reversing-field="start-x"
-                        data-segment="0"
+                        data-reversing-field="far-x"
                         data-side="left"
                         data-axis="x"
                       />
                     </label>
                     <label>
-                      Start vertical (%)
+                      Vertical (%)
                       <input
                         type="number"
                         min="0"
                         max="100"
                         step="0.5"
                         inputmode="decimal"
-                        data-reversing-field="start-y"
-                        data-segment="0"
-                        data-side="left"
-                        data-axis="y"
-                      />
-                    </label>
-                    <label>
-                      End horizontal (%)
-                      <input
-                        type="number"
-                        min="0"
-                        max="100"
-                        step="0.5"
-                        inputmode="decimal"
-                        data-reversing-field="end-x"
-                        data-segment="0"
-                        data-side="left"
-                        data-axis="x"
-                      />
-                    </label>
-                    <label>
-                      End vertical (%)
-                      <input
-                        type="number"
-                        min="0"
-                        max="100"
-                        step="0.5"
-                        inputmode="decimal"
-                        data-reversing-field="end-y"
-                        data-segment="0"
+                        data-reversing-field="far-y"
                         data-side="left"
                         data-axis="y"
                       />
                     </label>
                   </div>
                 </div>
-                <div class="reversing-segment" data-side="left" data-segment="1">
-                  <div class="reversing-segment-header">
-                    <span class="reversing-colour" style="background: #ffc107;"></span>
-                    <span>Mid segment</span>
-                  </div>
-                  <div class="reversing-segment-fields">
-                    <label>
-                      Start horizontal (%)
-                      <input
-                        type="number"
-                        min="0"
-                        max="100"
-                        step="0.5"
-                        inputmode="decimal"
-                        data-reversing-field="start-x"
-                        data-segment="1"
-                        data-side="left"
-                        data-axis="x"
-                      />
-                    </label>
-                    <label>
-                      Start vertical (%)
-                      <input
-                        type="number"
-                        min="0"
-                        max="100"
-                        step="0.5"
-                        inputmode="decimal"
-                        data-reversing-field="start-y"
-                        data-segment="1"
-                        data-side="left"
-                        data-axis="y"
-                      />
-                    </label>
-                    <label>
-                      End horizontal (%)
-                      <input
-                        type="number"
-                        min="0"
-                        max="100"
-                        step="0.5"
-                        inputmode="decimal"
-                        data-reversing-field="end-x"
-                        data-segment="1"
-                        data-side="left"
-                        data-axis="x"
-                      />
-                    </label>
-                    <label>
-                      End vertical (%)
-                      <input
-                        type="number"
-                        min="0"
-                        max="100"
-                        step="0.5"
-                        inputmode="decimal"
-                        data-reversing-field="end-y"
-                        data-segment="1"
-                        data-side="left"
-                        data-axis="y"
-                      />
-                    </label>
-                  </div>
-                </div>
-                <div class="reversing-segment" data-side="left" data-segment="2">
-                  <div class="reversing-segment-header">
+                <div class="reversing-line-point" data-side="left" data-point="near">
+                  <div class="reversing-line-header">
                     <span class="reversing-colour" style="background: #ef5350;"></span>
-                    <span>Near segment</span>
+                    <span>Near point</span>
                   </div>
-                  <div class="reversing-segment-fields">
+                  <div class="reversing-line-fields">
                     <label>
-                      Start horizontal (%)
+                      Horizontal (%)
                       <input
                         type="number"
                         min="0"
                         max="100"
                         step="0.5"
                         inputmode="decimal"
-                        data-reversing-field="start-x"
-                        data-segment="2"
+                        data-reversing-field="near-x"
                         data-side="left"
                         data-axis="x"
                       />
                     </label>
                     <label>
-                      Start vertical (%)
+                      Vertical (%)
                       <input
                         type="number"
                         min="0"
                         max="100"
                         step="0.5"
                         inputmode="decimal"
-                        data-reversing-field="start-y"
-                        data-segment="2"
-                        data-side="left"
-                        data-axis="y"
-                      />
-                    </label>
-                    <label>
-                      End horizontal (%)
-                      <input
-                        type="number"
-                        min="0"
-                        max="100"
-                        step="0.5"
-                        inputmode="decimal"
-                        data-reversing-field="end-x"
-                        data-segment="2"
-                        data-side="left"
-                        data-axis="x"
-                      />
-                    </label>
-                    <label>
-                      End vertical (%)
-                      <input
-                        type="number"
-                        min="0"
-                        max="100"
-                        step="0.5"
-                        inputmode="decimal"
-                        data-reversing-field="end-y"
-                        data-segment="2"
+                        data-reversing-field="near-y"
                         data-side="left"
                         data-axis="y"
                       />
                     </label>
                   </div>
                 </div>
+                <p class="reversing-line-note muted">
+                  <span class="reversing-colour" style="background: #ffc107;"></span>
+                  Mid segment spacing updates automatically between the far and near points.
+                </p>
               </fieldset>
               <fieldset class="reversing-side" data-side="right">
                 <legend>Right guide</legend>
@@ -1460,198 +1348,78 @@
                     —
                   </output>
                 </div>
-                <div class="reversing-segment" data-side="right" data-segment="0">
-                  <div class="reversing-segment-header">
+                <div class="reversing-line-point" data-side="right" data-point="far">
+                  <div class="reversing-line-header">
                     <span class="reversing-colour" style="background: #66bb6a;"></span>
-                    <span>Far segment</span>
+                    <span>Far point</span>
                   </div>
-                  <div class="reversing-segment-fields">
+                  <div class="reversing-line-fields">
                     <label>
-                      Start horizontal (%)
+                      Horizontal (%)
                       <input
                         type="number"
                         min="0"
                         max="100"
                         step="0.5"
                         inputmode="decimal"
-                        data-reversing-field="start-x"
-                        data-segment="0"
+                        data-reversing-field="far-x"
                         data-side="right"
                         data-axis="x"
                       />
                     </label>
                     <label>
-                      Start vertical (%)
+                      Vertical (%)
                       <input
                         type="number"
                         min="0"
                         max="100"
                         step="0.5"
                         inputmode="decimal"
-                        data-reversing-field="start-y"
-                        data-segment="0"
-                        data-side="right"
-                        data-axis="y"
-                      />
-                    </label>
-                    <label>
-                      End horizontal (%)
-                      <input
-                        type="number"
-                        min="0"
-                        max="100"
-                        step="0.5"
-                        inputmode="decimal"
-                        data-reversing-field="end-x"
-                        data-segment="0"
-                        data-side="right"
-                        data-axis="x"
-                      />
-                    </label>
-                    <label>
-                      End vertical (%)
-                      <input
-                        type="number"
-                        min="0"
-                        max="100"
-                        step="0.5"
-                        inputmode="decimal"
-                        data-reversing-field="end-y"
-                        data-segment="0"
+                        data-reversing-field="far-y"
                         data-side="right"
                         data-axis="y"
                       />
                     </label>
                   </div>
                 </div>
-                <div class="reversing-segment" data-side="right" data-segment="1">
-                  <div class="reversing-segment-header">
-                    <span class="reversing-colour" style="background: #ffc107;"></span>
-                    <span>Mid segment</span>
-                  </div>
-                  <div class="reversing-segment-fields">
-                    <label>
-                      Start horizontal (%)
-                      <input
-                        type="number"
-                        min="0"
-                        max="100"
-                        step="0.5"
-                        inputmode="decimal"
-                        data-reversing-field="start-x"
-                        data-segment="1"
-                        data-side="right"
-                        data-axis="x"
-                      />
-                    </label>
-                    <label>
-                      Start vertical (%)
-                      <input
-                        type="number"
-                        min="0"
-                        max="100"
-                        step="0.5"
-                        inputmode="decimal"
-                        data-reversing-field="start-y"
-                        data-segment="1"
-                        data-side="right"
-                        data-axis="y"
-                      />
-                    </label>
-                    <label>
-                      End horizontal (%)
-                      <input
-                        type="number"
-                        min="0"
-                        max="100"
-                        step="0.5"
-                        inputmode="decimal"
-                        data-reversing-field="end-x"
-                        data-segment="1"
-                        data-side="right"
-                        data-axis="x"
-                      />
-                    </label>
-                    <label>
-                      End vertical (%)
-                      <input
-                        type="number"
-                        min="0"
-                        max="100"
-                        step="0.5"
-                        inputmode="decimal"
-                        data-reversing-field="end-y"
-                        data-segment="1"
-                        data-side="right"
-                        data-axis="y"
-                      />
-                    </label>
-                  </div>
-                </div>
-                <div class="reversing-segment" data-side="right" data-segment="2">
-                  <div class="reversing-segment-header">
+                <div class="reversing-line-point" data-side="right" data-point="near">
+                  <div class="reversing-line-header">
                     <span class="reversing-colour" style="background: #ef5350;"></span>
-                    <span>Near segment</span>
+                    <span>Near point</span>
                   </div>
-                  <div class="reversing-segment-fields">
+                  <div class="reversing-line-fields">
                     <label>
-                      Start horizontal (%)
+                      Horizontal (%)
                       <input
                         type="number"
                         min="0"
                         max="100"
                         step="0.5"
                         inputmode="decimal"
-                        data-reversing-field="start-x"
-                        data-segment="2"
+                        data-reversing-field="near-x"
                         data-side="right"
                         data-axis="x"
                       />
                     </label>
                     <label>
-                      Start vertical (%)
+                      Vertical (%)
                       <input
                         type="number"
                         min="0"
                         max="100"
                         step="0.5"
                         inputmode="decimal"
-                        data-reversing-field="start-y"
-                        data-segment="2"
-                        data-side="right"
-                        data-axis="y"
-                      />
-                    </label>
-                    <label>
-                      End horizontal (%)
-                      <input
-                        type="number"
-                        min="0"
-                        max="100"
-                        step="0.5"
-                        inputmode="decimal"
-                        data-reversing-field="end-x"
-                        data-segment="2"
-                        data-side="right"
-                        data-axis="x"
-                      />
-                    </label>
-                    <label>
-                      End vertical (%)
-                      <input
-                        type="number"
-                        min="0"
-                        max="100"
-                        step="0.5"
-                        inputmode="decimal"
-                        data-reversing-field="end-y"
-                        data-segment="2"
+                        data-reversing-field="near-y"
                         data-side="right"
                         data-axis="y"
                       />
                     </label>
                   </div>
                 </div>
+                <p class="reversing-line-note muted">
+                  <span class="reversing-colour" style="background: #ffc107;"></span>
+                  Mid segment spacing updates automatically between the far and near points.
+                </p>
               </fieldset>
             </div>
             <div class="form-actions">
@@ -1902,10 +1670,10 @@
       const reversingInputMap = new Map();
       if (reversingInputs.length) {
         for (const input of reversingInputs) {
-          if (!input.dataset.side || !input.dataset.segment || !input.dataset.reversingField) {
+          if (!input.dataset.side || !input.dataset.reversingField) {
             continue;
           }
-          const key = `${input.dataset.side}|${input.dataset.segment}|${input.dataset.reversingField}`;
+          const key = `${input.dataset.side}|${input.dataset.reversingField}`;
           reversingInputMap.set(key, input);
           input.addEventListener("input", () => {
             input.dataset.userEdited = "true";
@@ -1954,13 +1722,24 @@
       let reversingPreviewStatusTimer = null;
       let reversingPreviewLoading = false;
       const REVERSING_NUDGE_STEP = 1;
-      const REVERSING_SEGMENTS_PER_SIDE = 3;
+      const REVERSING_SEGMENT_RATIOS = [
+        { start: 0.0, end: 0.25 },
+        { start: 0.375, end: 0.625 },
+        { start: 0.75, end: 1.0 },
+      ];
+      const REVERSING_SEGMENTS_PER_SIDE = REVERSING_SEGMENT_RATIOS.length;
       const REVERSING_SEGMENT_COLOURS = ["#66bb6a", "#ffc107", "#ef5350"];
       const REVERSING_PREVIEW_DEFAULT_RATIO = "16 / 9";
       const REVERSING_ANGLE_STEP_DEGREES = 1.5;
-      const DEFAULT_REVERSING_SIDE_VECTORS = {
-        left: { dx: -0.2, dy: 0.16 },
-        right: { dx: 0.2, dy: 0.16 },
+      const DEFAULT_REVERSING_LINES = {
+        left: {
+          near: { x: 0.14, y: 0.86 },
+          far: { x: 0.52, y: 0.18 },
+        },
+        right: {
+          near: { x: 0.86, y: 0.86 },
+          far: { x: 0.48, y: 0.18 },
+        },
       };
       const reversingSideVectors = {
         left: null,
@@ -2166,7 +1945,7 @@
         }
       }
 
-      function setReversingInputValue(input, normalised) {
+      function updateReversingInputValue(input, normalised, options = {}) {
         if (!(input instanceof HTMLInputElement)) {
           return;
         }
@@ -2176,7 +1955,11 @@
         } else {
           input.value = formatPercentageValue(percent);
         }
-        delete input.dataset.userEdited;
+        if (options.markEdited === true) {
+          input.dataset.userEdited = "true";
+        } else if (options.clearEdited !== false) {
+          delete input.dataset.userEdited;
+        }
       }
 
       function setReversingPreviewStatus(message, options = {}) {
@@ -2325,33 +2108,14 @@
           left: Array.from({ length: REVERSING_SEGMENTS_PER_SIDE }, () => null),
           right: Array.from({ length: REVERSING_SEGMENTS_PER_SIDE }, () => null),
         };
-        if (!reversingInputMap.size) {
-          return geometry;
-        }
-        const sides = ["left", "right"];
-        for (const side of sides) {
+        for (const side of ["left", "right"]) {
+          const line = readReversingLine(side);
+          if (!line) {
+            continue;
+          }
+          const segments = buildSegmentsFromLine(line);
           for (let index = 0; index < REVERSING_SEGMENTS_PER_SIDE; index += 1) {
-            const startXInput = reversingInputMap.get(`${side}|${index}|start-x`);
-            const startYInput = reversingInputMap.get(`${side}|${index}|start-y`);
-            const endXInput = reversingInputMap.get(`${side}|${index}|end-x`);
-            const endYInput = reversingInputMap.get(`${side}|${index}|end-y`);
-            const startX = parseReversingPreviewValue(startXInput);
-            const startY = parseReversingPreviewValue(startYInput);
-            const endX = parseReversingPreviewValue(endXInput);
-            const endY = parseReversingPreviewValue(endYInput);
-            if (
-              startX === null ||
-              startY === null ||
-              endX === null ||
-              endY === null
-            ) {
-              geometry[side][index] = null;
-            } else {
-              geometry[side][index] = {
-                start: { x: startX, y: startY },
-                end: { x: endX, y: endY },
-              };
-            }
+            geometry[side][index] = segments[index] || null;
           }
         }
         return geometry;
@@ -2438,30 +2202,25 @@
         if (!reversingInputMap.size) {
           return;
         }
-        const sides = ["left", "right"];
-        for (const side of sides) {
+        for (const side of ["left", "right"]) {
           const segments = Array.isArray(config?.[side]) ? config[side] : [];
-          for (let index = 0; index < REVERSING_SEGMENTS_PER_SIDE; index += 1) {
-            const segment = segments[index] || null;
-            const start = segment && segment.start ? segment.start : null;
-            const end = segment && segment.end ? segment.end : null;
-            const mappings = {
-              "start-x": start && typeof start.x === "number" ? start.x : null,
-              "start-y": start && typeof start.y === "number" ? start.y : null,
-              "end-x": end && typeof end.x === "number" ? end.x : null,
-              "end-y": end && typeof end.y === "number" ? end.y : null,
-            };
-            for (const [field, value] of Object.entries(mappings)) {
-              const key = `${side}|${index}|${field}`;
-              const input = reversingInputMap.get(key);
-              if (!(input instanceof HTMLInputElement)) {
-                continue;
-              }
-              if (!forceUpdate && input.dataset.userEdited === "true") {
-                continue;
-              }
-              setReversingInputValue(input, value);
+          const line = extractLineFromSegments(segments);
+          const mappings = {
+            "far-x": line?.far?.x ?? null,
+            "far-y": line?.far?.y ?? null,
+            "near-x": line?.near?.x ?? null,
+            "near-y": line?.near?.y ?? null,
+          };
+          for (const [field, value] of Object.entries(mappings)) {
+            const key = `${side}|${field}`;
+            const input = reversingInputMap.get(key);
+            if (!(input instanceof HTMLInputElement)) {
+              continue;
             }
+            if (!forceUpdate && input.dataset.userEdited === "true") {
+              continue;
+            }
+            updateReversingInputValue(input, value);
           }
         }
         refreshReversingSideVectors();
@@ -2477,22 +2236,7 @@
         setReversingInputsDisabled(!enabled);
         updateReversingAidsStatus(config);
         updateReversingAidsInputs(config, forceUpdate);
-        refreshReversingSideVectors();
         drawReversingPreviewOverlay();
-      }
-
-      function readReversingInput(input) {
-        if (!(input instanceof HTMLInputElement)) {
-          throw new Error("Reversing aids input missing.");
-        }
-        const raw = parseFloat(input.value);
-        if (!Number.isFinite(raw)) {
-          throw new Error("Enter numeric values between 0 and 100.");
-        }
-        if (raw < 0 || raw > 100) {
-          throw new Error("Values must be between 0 and 100.");
-        }
-        return raw / 100;
       }
 
       function collectReversingAidsPayload() {
@@ -2504,92 +2248,233 @@
           left: [],
           right: [],
         };
-        const sides = ["left", "right"];
-        for (const side of sides) {
-          for (let index = 0; index < REVERSING_SEGMENTS_PER_SIDE; index += 1) {
-            const startX = reversingInputMap.get(`${side}|${index}|start-x`);
-            const startY = reversingInputMap.get(`${side}|${index}|start-y`);
-            const endX = reversingInputMap.get(`${side}|${index}|end-x`);
-            const endY = reversingInputMap.get(`${side}|${index}|end-y`);
-            if (!startX || !startY || !endX || !endY) {
-              throw new Error("Reversing aids inputs are missing.");
-            }
-            payload[side].push({
-              start: {
-                x: readReversingInput(startX),
-                y: readReversingInput(startY),
-              },
-              end: {
-                x: readReversingInput(endX),
-                y: readReversingInput(endY),
-              },
-            });
+        for (const side of ["left", "right"]) {
+          const line = readReversingLine(side);
+          if (!line) {
+            throw new Error("Reversing aids inputs are missing.");
           }
+          const segments = buildSegmentsFromLine(line);
+          if (segments.length !== REVERSING_SEGMENTS_PER_SIDE) {
+            throw new Error("Reversing aids inputs are incomplete.");
+          }
+          payload[side] = segments.map((segment) => ({
+            start: { x: segment.start.x, y: segment.start.y },
+            end: { x: segment.end.x, y: segment.end.y },
+          }));
         }
         return payload;
       }
 
-      function getReversingSegmentInputs(side, index) {
-        if (!reversingInputMap.size) {
+      function clamp01(value) {
+        if (typeof value !== "number" || Number.isNaN(value)) {
+          return 0;
+        }
+        if (value <= 0) {
+          return 0;
+        }
+        if (value >= 1) {
+          return 1;
+        }
+        return value;
+      }
+
+      function getReversingLineInputs(side) {
+        if (!side) {
           return null;
         }
         return {
-          startX: reversingInputMap.get(`${side}|${index}|start-x`) || null,
-          startY: reversingInputMap.get(`${side}|${index}|start-y`) || null,
-          endX: reversingInputMap.get(`${side}|${index}|end-x`) || null,
-          endY: reversingInputMap.get(`${side}|${index}|end-y`) || null,
+          farX: reversingInputMap.get(`${side}|far-x`) || null,
+          farY: reversingInputMap.get(`${side}|far-y`) || null,
+          nearX: reversingInputMap.get(`${side}|near-x`) || null,
+          nearY: reversingInputMap.get(`${side}|near-y`) || null,
         };
       }
 
-      function readReversingSegmentStart(side, index) {
-        const inputs = getReversingSegmentInputs(side, index);
+      function readReversingLine(side) {
+        const inputs = getReversingLineInputs(side);
         if (!inputs) {
           return null;
         }
-        const startX = parseReversingPreviewValue(inputs.startX);
-        const startY = parseReversingPreviewValue(inputs.startY);
-        if (startX === null || startY === null) {
-          return null;
-        }
-        return { x: startX, y: startY };
-      }
-
-      function readReversingSegmentVector(side, index) {
-        const inputs = getReversingSegmentInputs(side, index);
-        if (!inputs) {
-          return null;
-        }
-        const startX = parseReversingPreviewValue(inputs.startX);
-        const startY = parseReversingPreviewValue(inputs.startY);
-        const endX = parseReversingPreviewValue(inputs.endX);
-        const endY = parseReversingPreviewValue(inputs.endY);
+        const farX = parseReversingPreviewValue(inputs.farX);
+        const farY = parseReversingPreviewValue(inputs.farY);
+        const nearX = parseReversingPreviewValue(inputs.nearX);
+        const nearY = parseReversingPreviewValue(inputs.nearY);
         if (
-          startX === null ||
-          startY === null ||
-          endX === null ||
-          endY === null
+          farX === null ||
+          farY === null ||
+          nearX === null ||
+          nearY === null
         ) {
           return null;
         }
-        return { dx: endX - startX, dy: endY - startY };
+        return {
+          near: { x: nearX, y: nearY },
+          far: { x: farX, y: farY },
+        };
       }
 
-      function computeSideVector(side) {
-        for (let index = 0; index < REVERSING_SEGMENTS_PER_SIDE; index += 1) {
-          const vector = readReversingSegmentVector(side, index);
-          if (vector) {
-            return vector;
+      function writeReversingLine(side, line, options = {}) {
+        const inputs = getReversingLineInputs(side);
+        if (!inputs) {
+          return;
+        }
+        const entries = [
+          { input: inputs.farX, value: line?.far?.x ?? null },
+          { input: inputs.farY, value: line?.far?.y ?? null },
+          { input: inputs.nearX, value: line?.near?.x ?? null },
+          { input: inputs.nearY, value: line?.near?.y ?? null },
+        ];
+        for (const entry of entries) {
+          const element = entry.input;
+          if (!(element instanceof HTMLInputElement)) {
+            continue;
+          }
+          if (options.force !== true && element.dataset.userEdited === "true") {
+            continue;
+          }
+          updateReversingInputValue(element, entry.value, {
+            clearEdited: options.clearEdited !== false,
+            markEdited: options.markEdited === true,
+          });
+        }
+      }
+
+      function extractLineFromSegments(segments) {
+        if (!Array.isArray(segments)) {
+          return null;
+        }
+        let near = null;
+        let far = null;
+        for (const segment of segments) {
+          if (!segment || typeof segment !== "object") {
+            continue;
+          }
+          const { start, end } = segment;
+          if (
+            !near &&
+            start &&
+            typeof start.x === "number" &&
+            typeof start.y === "number"
+          ) {
+            near = { x: clamp01(start.x), y: clamp01(start.y) };
+          }
+          if (
+            end &&
+            typeof end.x === "number" &&
+            typeof end.y === "number"
+          ) {
+            far = { x: clamp01(end.x), y: clamp01(end.y) };
           }
         }
-        return null;
+        if (!near || !far) {
+          return null;
+        }
+        return { near, far };
+      }
+
+      function buildSegmentsFromLine(line) {
+        if (!line || !line.near || !line.far) {
+          return [];
+        }
+        const dx = line.far.x - line.near.x;
+        const dy = line.far.y - line.near.y;
+        return REVERSING_SEGMENT_RATIOS.map(({ start, end }) => ({
+          start: {
+            x: clamp01(line.near.x + dx * start),
+            y: clamp01(line.near.y + dy * start),
+          },
+          end: {
+            x: clamp01(line.near.x + dx * end),
+            y: clamp01(line.near.y + dy * end),
+          },
+        }));
+      }
+
+      function clampVectorForSide(side, vector, nearOverride = null) {
+        const baseDx =
+          typeof vector?.dx === "number" && Number.isFinite(vector.dx) ? vector.dx : 0;
+        const baseDy =
+          typeof vector?.dy === "number" && Number.isFinite(vector.dy) ? vector.dy : 0;
+        let near = nearOverride;
+        if (!near) {
+          const line = readReversingLine(side);
+          if (line) {
+            near = line.near;
+          } else if (DEFAULT_REVERSING_LINES[side]) {
+            near = DEFAULT_REVERSING_LINES[side].near;
+          } else {
+            return { dx: 0, dy: 0 };
+          }
+        }
+        const minDx = near.x - 1;
+        const maxDx = near.x;
+        const minDy = near.y - 1;
+        const maxDy = near.y;
+        return {
+          dx: Math.min(maxDx, Math.max(minDx, baseDx)),
+          dy: Math.min(maxDy, Math.max(minDy, baseDy)),
+        };
+      }
+
+      function setReversingSideVector(side, vector, options = {}) {
+        const inputs = getReversingLineInputs(side);
+        if (!inputs) {
+          return false;
+        }
+        let nearX = parseReversingPreviewValue(inputs.nearX);
+        let nearY = parseReversingPreviewValue(inputs.nearY);
+        if (nearX === null || nearY === null) {
+          const fallback = DEFAULT_REVERSING_LINES[side];
+          if (!fallback) {
+            return false;
+          }
+          nearX = fallback.near.x;
+          nearY = fallback.near.y;
+          if (inputs.nearX instanceof HTMLInputElement) {
+            updateReversingInputValue(inputs.nearX, nearX, {
+              clearEdited: options.clearEdited !== false,
+              markEdited: options.markEdited === true,
+            });
+          }
+          if (inputs.nearY instanceof HTMLInputElement) {
+            updateReversingInputValue(inputs.nearY, nearY, {
+              clearEdited: options.clearEdited !== false,
+              markEdited: options.markEdited === true,
+            });
+          }
+        }
+        const clamped = clampVectorForSide(side, vector, { x: nearX, y: nearY });
+        const farX = clamp01(nearX - clamped.dx);
+        const farY = clamp01(nearY - clamped.dy);
+        if (inputs.farX instanceof HTMLInputElement) {
+          updateReversingInputValue(inputs.farX, farX, {
+            clearEdited: options.clearEdited !== false,
+            markEdited: options.markEdited === true,
+          });
+        }
+        if (inputs.farY instanceof HTMLInputElement) {
+          updateReversingInputValue(inputs.farY, farY, {
+            clearEdited: options.clearEdited !== false,
+            markEdited: options.markEdited === true,
+          });
+        }
+        reversingSideVectors[side] = {
+          dx: nearX - farX,
+          dy: nearY - farY,
+        };
+        updateReversingAngleValue(side);
+        return true;
       }
 
       function updateReversingSideVectorFromInputs(side) {
-        const vector = computeSideVector(side);
-        if (!vector) {
+        const line = readReversingLine(side);
+        if (!line) {
           return false;
         }
-        reversingSideVectors[side] = { dx: vector.dx, dy: vector.dy };
+        reversingSideVectors[side] = {
+          dx: line.near.x - line.far.x,
+          dy: line.near.y - line.far.y,
+        };
         updateReversingAngleValue(side);
         return true;
       }
@@ -2597,152 +2482,51 @@
       function ensureReversingSideVector(side) {
         if (!reversingSideVectors[side]) {
           if (!updateReversingSideVectorFromInputs(side)) {
-            const fallback = DEFAULT_REVERSING_SIDE_VECTORS[side] || {
-              dx: 0,
-              dy: 0,
-            };
-            reversingSideVectors[side] = { dx: fallback.dx, dy: fallback.dy };
+            const fallback = DEFAULT_REVERSING_LINES[side];
+            if (fallback) {
+              writeReversingLine(side, fallback, { force: true });
+              reversingSideVectors[side] = {
+                dx: fallback.near.x - fallback.far.x,
+                dy: fallback.near.y - fallback.far.y,
+              };
+            } else {
+              reversingSideVectors[side] = { dx: 0, dy: 0 };
+            }
             updateReversingAngleValue(side);
           }
         }
         return reversingSideVectors[side];
       }
 
-      function clampVectorForSide(side, vector) {
-        if (
-          !vector ||
-          typeof vector.dx !== "number" ||
-          typeof vector.dy !== "number"
-        ) {
-          return { dx: 0, dy: 0 };
-        }
-        const baseDx = Number.isFinite(vector.dx) ? vector.dx : 0;
-        const baseDy = Number.isFinite(vector.dy) ? vector.dy : 0;
-        let limit = 1;
-        let constrained = false;
-        for (let index = 0; index < REVERSING_SEGMENTS_PER_SIDE; index += 1) {
-          const start = readReversingSegmentStart(side, index);
-          if (!start) {
-            continue;
-          }
-          if (baseDx > 0) {
-            const ratio = (1 - start.x) / baseDx;
-            if (Number.isFinite(ratio)) {
-              limit = Math.min(limit, ratio);
-              constrained = true;
-            }
-          } else if (baseDx < 0) {
-            const ratio = start.x / -baseDx;
-            if (Number.isFinite(ratio)) {
-              limit = Math.min(limit, ratio);
-              constrained = true;
-            }
-          }
-          if (baseDy > 0) {
-            const ratio = (1 - start.y) / baseDy;
-            if (Number.isFinite(ratio)) {
-              limit = Math.min(limit, ratio);
-              constrained = true;
-            }
-          } else if (baseDy < 0) {
-            const ratio = start.y / -baseDy;
-            if (Number.isFinite(ratio)) {
-              limit = Math.min(limit, ratio);
-              constrained = true;
-            }
-          }
-        }
-        if (!constrained || !Number.isFinite(limit) || limit > 1) {
-          limit = 1;
-        }
-        if (limit < 0) {
-          limit = 0;
-        }
-        return { dx: baseDx * limit, dy: baseDy * limit };
-      }
-
-      function applyVectorToSide(side, vector, options = {}) {
-        if (
-          !vector ||
-          typeof vector.dx !== "number" ||
-          typeof vector.dy !== "number"
-        ) {
-          return false;
-        }
-        let skipSegment = null;
-        let skipFields = null;
-        if (options.skip && typeof options.skip.segment === "number") {
-          const numeric = Number(options.skip.segment);
-          if (Number.isFinite(numeric)) {
-            skipSegment = numeric;
-          }
-          const fields = options.skip.fields;
-          if (fields instanceof Set) {
-            skipFields = fields;
-          } else if (Array.isArray(fields)) {
-            skipFields = new Set(fields);
-          }
-        }
-        let changed = false;
-        for (let index = 0; index < REVERSING_SEGMENTS_PER_SIDE; index += 1) {
-          const inputs = getReversingSegmentInputs(side, index);
-          if (!inputs) {
-            continue;
-          }
-          const startX = parseReversingPreviewValue(inputs.startX);
-          const startY = parseReversingPreviewValue(inputs.startY);
-          if (startX === null || startY === null) {
-            continue;
-          }
-          const endXInput = inputs.endX;
-          const endYInput = inputs.endY;
-          if (
-            !(endXInput instanceof HTMLInputElement) ||
-            !(endYInput instanceof HTMLInputElement)
-          ) {
-            continue;
-          }
-          const endX = Math.min(1, Math.max(0, startX + vector.dx));
-          const endY = Math.min(1, Math.max(0, startY + vector.dy));
-          const endXPercent = endX * 100;
-          const endYPercent = endY * 100;
-          const formattedX = formatPercentageValue(endXPercent);
-          const formattedY = formatPercentageValue(endYPercent);
-          if (!(skipSegment === index && skipFields?.has("end-x"))) {
-            if (endXInput.value !== formattedX) {
-              endXInput.value = formattedX;
-              changed = true;
-            }
-            endXInput.dataset.userEdited = "true";
-          }
-          if (!(skipSegment === index && skipFields?.has("end-y"))) {
-            if (endYInput.value !== formattedY) {
-              endYInput.value = formattedY;
-              changed = true;
-            }
-            endYInput.dataset.userEdited = "true";
-          }
-        }
-        return changed;
-      }
-
-      function setReversingSideVector(side, vector, options = {}) {
-        const clamped = clampVectorForSide(side, vector);
-        reversingSideVectors[side] = { dx: clamped.dx, dy: clamped.dy };
-        updateReversingAngleValue(side);
-        return applyVectorToSide(side, clamped, options);
-      }
-
       function refreshReversingSideVectors() {
         for (const side of ["left", "right"]) {
           if (!updateReversingSideVectorFromInputs(side)) {
-            const fallback = DEFAULT_REVERSING_SIDE_VECTORS[side] || {
-              dx: 0,
-              dy: 0,
-            };
-            reversingSideVectors[side] = { dx: fallback.dx, dy: fallback.dy };
+            const fallback = DEFAULT_REVERSING_LINES[side];
+            if (fallback) {
+              writeReversingLine(side, fallback, { force: true });
+              reversingSideVectors[side] = {
+                dx: fallback.near.x - fallback.far.x,
+                dy: fallback.near.y - fallback.far.y,
+              };
+            } else {
+              reversingSideVectors[side] = { dx: 0, dy: 0 };
+            }
             updateReversingAngleValue(side);
           }
+        }
+      }
+
+      function handleReversingInputEdit(input) {
+        if (!(input instanceof HTMLInputElement)) {
+          return;
+        }
+        const side = input.dataset.side;
+        const field = input.dataset.reversingField;
+        if (!side || !field) {
+          return;
+        }
+        if (field === "near-x" || field === "near-y" || field === "far-x" || field === "far-y") {
+          updateReversingSideVectorFromInputs(side);
         }
       }
 
@@ -2777,34 +2561,6 @@
           output.textContent = "—";
         } else {
           output.textContent = `${formatPercentageValue(angle)}°`;
-        }
-      }
-
-      function handleReversingInputEdit(input) {
-        if (!(input instanceof HTMLInputElement)) {
-          return;
-        }
-        const side = input.dataset.side;
-        const field = input.dataset.reversingField;
-        const segment = Number.parseInt(input.dataset.segment || "", 10);
-        if (!side || !field || !Number.isFinite(segment)) {
-          return;
-        }
-        if (field.startsWith("start-")) {
-          const vector = ensureReversingSideVector(side);
-          if (vector) {
-            applyVectorToSide(side, vector);
-            updateReversingAngleValue(side);
-          }
-        } else if (field.startsWith("end-")) {
-          const vector = readReversingSegmentVector(side, segment);
-          if (!vector) {
-            return;
-          }
-          const skipFields = new Set([field]);
-          setReversingSideVector(side, vector, {
-            skip: { segment, fields: skipFields },
-          });
         }
       }
 
@@ -2843,7 +2599,7 @@
           dx: Math.cos(angle) * magnitude,
           dy: Math.sin(angle) * magnitude,
         };
-        return setReversingSideVector(side, rotated);
+        return setReversingSideVector(side, rotated, { markEdited: true });
       }
 
       function adjustReversingSide(side, deltaX, deltaY) {
@@ -2869,11 +2625,7 @@
             input.dataset.userEdited = "true";
           }
         }
-        const vector = ensureReversingSideVector(side);
-        if (vector) {
-          applyVectorToSide(side, vector);
-          updateReversingAngleValue(side);
-        }
+        updateReversingSideVectorFromInputs(side);
         drawReversingPreviewOverlay();
       }
 

--- a/tests/test_app_reversing_aids.py
+++ b/tests/test_app_reversing_aids.py
@@ -1,0 +1,144 @@
+import json
+import types
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("numpy")
+pytest.importorskip("httpx")
+
+from fastapi.testclient import TestClient
+
+from rev_cam import app as app_module
+from rev_cam.distance import DistanceCalibration, DistanceReading
+
+
+@pytest.fixture
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    class _StubMonitor:
+        def __init__(
+            self,
+            *args,
+            calibration: DistanceCalibration | None = None,
+            **kwargs,
+        ) -> None:
+            self._timestamp = 0.0
+            self._raw_value = 1.2
+            if calibration is None:
+                self._calibration = DistanceCalibration()
+            else:
+                self._calibration = DistanceCalibration(calibration.offset_m, calibration.scale)
+
+        def read(self) -> DistanceReading:
+            self._timestamp += 0.1
+            return DistanceReading(
+                available=True,
+                distance_m=self._raw_value,
+                raw_distance_m=self._raw_value,
+                timestamp=self._timestamp,
+                error=None,
+            )
+
+        def set_calibration(
+            self,
+            calibration: DistanceCalibration | None = None,
+            *,
+            offset_m: float | None = None,
+            scale: float | None = None,
+        ) -> DistanceCalibration:
+            if calibration is not None:
+                self._calibration = DistanceCalibration(calibration.offset_m, calibration.scale)
+            else:
+                current = self._calibration
+                self._calibration = DistanceCalibration(
+                    offset_m=current.offset_m if offset_m is None else offset_m,
+                    scale=current.scale if scale is None else scale,
+                )
+            return self._calibration
+
+        def get_calibration(self) -> DistanceCalibration:
+            return self._calibration
+
+    class _StubBatteryMonitor:
+        def read(self) -> object:
+            return types.SimpleNamespace(to_dict=lambda: {})
+
+    class _StubSupervisor:
+        def start(self) -> None:
+            return None
+
+        async def aclose(self) -> None:
+            return None
+
+    monkeypatch.setattr(app_module, "DistanceMonitor", lambda *args, **kwargs: _StubMonitor(*args, **kwargs))
+    monkeypatch.setattr(app_module, "BatteryMonitor", lambda *args, **kwargs: _StubBatteryMonitor())
+    monkeypatch.setattr(app_module, "BatterySupervisor", lambda *args, **kwargs: _StubSupervisor())
+    monkeypatch.setattr(app_module, "create_battery_overlay", lambda *args, **kwargs: (lambda frame: frame))
+    monkeypatch.setattr(app_module, "create_distance_overlay", lambda *args, **kwargs: (lambda frame: frame))
+    monkeypatch.setattr(app_module, "create_reversing_aids_overlay", lambda *args, **kwargs: (lambda frame: frame))
+
+    config_file = tmp_path / "config.json"
+    app = app_module.create_app(config_file)
+    with TestClient(app) as test_client:
+        test_client.config_path = config_file
+        yield test_client
+
+
+def test_reversing_aids_defaults(client: TestClient) -> None:
+    response = client.get("/api/reversing-aids")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["enabled"] is True
+    assert isinstance(payload.get("left"), list)
+    assert isinstance(payload.get("right"), list)
+    assert len(payload["left"]) == 3
+    assert len(payload["right"]) == 3
+
+
+def test_reversing_aids_update(client: TestClient) -> None:
+    payload = {
+        "enabled": False,
+        "left": [
+            {"start": {"x": 0.58, "y": 0.15}, "end": {"x": 0.38, "y": 0.32}},
+            {"start": {"x": 0.48, "y": 0.45}, "end": {"x": 0.28, "y": 0.63}},
+            {"start": {"x": 0.4, "y": 0.7}, "end": {"x": 0.2, "y": 0.88}},
+        ],
+        "right": [
+            {"start": {"x": 0.42, "y": 0.15}, "end": {"x": 0.62, "y": 0.32}},
+            {"start": {"x": 0.52, "y": 0.45}, "end": {"x": 0.72, "y": 0.63}},
+            {"start": {"x": 0.6, "y": 0.7}, "end": {"x": 0.8, "y": 0.88}},
+        ],
+    }
+    response = client.post("/api/reversing-aids", json=payload)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["enabled"] is False
+    assert body["left"][0]["start"]["x"] == pytest.approx(payload["left"][0]["start"]["x"])
+
+    config_file = Path(client.config_path)
+    data = json.loads(config_file.read_text())
+    stored = data["reversing_aids"]
+    assert stored["enabled"] is False
+    assert stored["left"][0]["start"]["x"] == pytest.approx(payload["left"][0]["start"]["x"])
+
+
+def test_reversing_aids_validation_error(client: TestClient) -> None:
+    invalid_payload = {
+        "enabled": True,
+        "left": [
+            {"start": {"x": -0.1, "y": 0.2}, "end": {"x": 0.3, "y": 0.35}},
+            {"start": {"x": 0.4, "y": 0.5}, "end": {"x": 0.25, "y": 0.65}},
+            {"start": {"x": 0.35, "y": 0.7}, "end": {"x": 0.2, "y": 0.85}},
+        ],
+        "right": [
+            {"start": {"x": 0.5, "y": 0.2}, "end": {"x": 0.7, "y": 0.35}},
+            {"start": {"x": 0.6, "y": 0.5}, "end": {"x": 0.8, "y": 0.65}},
+            {"start": {"x": 0.7, "y": 0.7}, "end": {"x": 0.9, "y": 0.85}},
+        ],
+    }
+    response = client.post("/api/reversing-aids", json=invalid_payload)
+    assert response.status_code == 400
+    detail = response.json().get("detail")
+    assert isinstance(detail, str)
+    assert "reversing" in detail.lower()
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,5 @@
 from pathlib import Path
-
-from pathlib import Path
+import math
 
 import pytest
 
@@ -9,8 +8,10 @@ from rev_cam.config import (
     ConfigManager,
     DistanceZones,
     Orientation,
+    ReversingAidPoint,
     ReversingAidsConfig,
     StreamSettings,
+    generate_reversing_segments,
     DEFAULT_BATTERY_CAPACITY_MAH,
     DEFAULT_CAMERA_CHOICE,
     DEFAULT_REVERSING_AIDS,
@@ -166,23 +167,41 @@ def test_default_reversing_aids(tmp_path: Path) -> None:
 def test_reversing_aids_persistence(tmp_path: Path) -> None:
     config_file = tmp_path / "config.json"
     manager = ConfigManager(config_file)
+    left_line = (
+        ReversingAidPoint(0.18, 0.9),
+        ReversingAidPoint(0.58, 0.22),
+    )
+    right_line = (
+        ReversingAidPoint(0.82, 0.9),
+        ReversingAidPoint(0.42, 0.22),
+    )
     payload = {
         "enabled": False,
-        "left": [
-            {"start": {"x": 0.55, "y": 0.12}, "end": {"x": 0.36, "y": 0.3}},
-            {"start": {"x": 0.46, "y": 0.42}, "end": {"x": 0.27, "y": 0.6}},
-            {"start": {"x": 0.38, "y": 0.66}, "end": {"x": 0.19, "y": 0.84}},
-        ],
-        "right": [
-            {"start": {"x": 0.45, "y": 0.12}, "end": {"x": 0.64, "y": 0.3}},
-            {"start": {"x": 0.54, "y": 0.42}, "end": {"x": 0.73, "y": 0.6}},
-            {"start": {"x": 0.62, "y": 0.66}, "end": {"x": 0.81, "y": 0.84}},
-        ],
+        "left": [segment.to_dict() for segment in generate_reversing_segments(*left_line)],
+        "right": [segment.to_dict() for segment in generate_reversing_segments(*right_line)],
     }
     updated = manager.set_reversing_aids(payload)
     assert isinstance(updated, ReversingAidsConfig)
     reloaded = ConfigManager(config_file)
     assert reloaded.get_reversing_aids() == updated
+
+
+def test_generate_reversing_segments_align() -> None:
+    near = ReversingAidPoint(0.24, 0.88)
+    far = ReversingAidPoint(0.6, 0.28)
+    segments = generate_reversing_segments(near, far)
+
+    assert len(segments) == 3
+    assert segments[0].start == near
+    assert segments[-1].end == far
+
+    expected_dx = far.x - near.x
+    expected_dy = far.y - near.y
+    for segment in segments:
+        for point in (segment.start, segment.end):
+            dx = point.x - near.x
+            dy = point.y - near.y
+            assert math.isclose(dx * expected_dy, dy * expected_dx, rel_tol=1e-9, abs_tol=1e-9)
 
 
 def test_reversing_aids_validation(tmp_path: Path) -> None:

--- a/tests/test_reversing_aids.py
+++ b/tests/test_reversing_aids.py
@@ -1,0 +1,33 @@
+import pytest
+
+pytest.importorskip("numpy")
+
+import numpy as np
+
+from rev_cam.config import DEFAULT_REVERSING_AIDS, ReversingAidsConfig
+from rev_cam.reversing_aids import create_reversing_aids_overlay
+
+
+def test_reversing_aids_overlay_draws_segments() -> None:
+    overlay = create_reversing_aids_overlay(lambda: DEFAULT_REVERSING_AIDS)
+    frame = np.zeros((200, 300, 3), dtype=np.uint8)
+    result = overlay(frame)
+
+    assert result is frame
+    assert np.any(result != 0)
+
+
+def test_reversing_aids_overlay_disabled() -> None:
+    config = ReversingAidsConfig(enabled=False)
+    overlay = create_reversing_aids_overlay(lambda: config)
+    frame = np.zeros((120, 160, 3), dtype=np.uint8)
+    result = overlay(frame)
+
+    assert not np.any(result)
+
+
+def test_reversing_aids_overlay_handles_non_numpy() -> None:
+    overlay = create_reversing_aids_overlay(lambda: DEFAULT_REVERSING_AIDS)
+    frame = [[0, 0, 0], [0, 0, 0]]
+    assert overlay(frame) == frame
+


### PR DESCRIPTION
## Summary
- add configuration structures and persistence for reversing aid overlays
- render reversing aids on the live stream using the configurable geometry
- extend the settings UI with a new reversing aids tab and nudge controls
- cover configuration, overlay, and API behaviour with automated tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf3ad637248332844a9bcf4683b251