### PR TITLE
Revamp live view status and battery UI

### DIFF
--- a/src/rev_cam/static/index.html
+++ b/src/rev_cam/static/index.html
@@ -5,10 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>RevCam Live View</title>
     <style>
+      :root {
+        color-scheme: dark;
+      }
       body {
         margin: 0;
         font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-        background-color: #111;
+        background: radial-gradient(circle at top, #1a1a1a 0%, #0a0a0a 55%, #030303 100%);
         color: #f5f5f5;
         display: flex;
         flex-direction: column;
@@ -16,132 +19,333 @@
       }
       header,
       footer {
-        padding: 0.75rem 1rem;
-        background: rgba(0, 0, 0, 0.6);
+        padding: 0.85rem 1.2rem;
+        background: rgba(12, 12, 12, 0.6);
+        backdrop-filter: blur(18px) saturate(125%);
+        -webkit-backdrop-filter: blur(18px) saturate(125%);
         display: flex;
         align-items: center;
         justify-content: space-between;
         flex-wrap: wrap;
+        gap: 1rem;
+        box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
+      }
+      header {
+        border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+      }
+      footer {
+        border-top: 1px solid rgba(255, 255, 255, 0.05);
+        box-shadow: 0 -18px 40px rgba(0, 0, 0, 0.45);
+      }
+      strong.brand {
+        font-size: 1.25rem;
+        letter-spacing: 0.04em;
+      }
+      .pill {
+        display: inline-flex;
+        align-items: center;
         gap: 0.75rem;
+        padding: 0.5rem 1rem;
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.08);
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        box-shadow: 0 18px 38px rgba(0, 0, 0, 0.35);
+        backdrop-filter: blur(22px);
+        -webkit-backdrop-filter: blur(22px);
+        min-width: 0;
       }
       main {
         flex: 1 1 auto;
         display: flex;
         align-items: center;
         justify-content: center;
-        padding: 1rem;
+        padding: clamp(1rem, 4vw, 3rem);
       }
       img#stream {
-        width: 100%;
-        max-width: 1000px;
-        background: #000;
-        border-radius: 8px;
+        display: block;
+        width: min(100%, max(320px, calc(100vh - 6rem)));
+        max-width: min(1100px, max(360px, calc(100vh - 3rem)));
+        background: linear-gradient(160deg, rgba(5, 5, 5, 0.85), rgba(25, 25, 25, 0.7));
+        border-radius: 18px;
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        box-shadow: 0 40px 90px rgba(0, 0, 0, 0.6);
+        transition: box-shadow 0.3s ease;
       }
       button {
-        background: #0a84ff;
+        background: linear-gradient(135deg, #0a84ff, #256bff);
         color: #fff;
         border: none;
-        padding: 0.5rem 1rem;
+        padding: 0.6rem 1.25rem;
         border-radius: 999px;
         font-size: 1rem;
+        font-weight: 600;
         cursor: pointer;
+        transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+      }
+      button:not(:disabled):hover,
+      button:not(:disabled):focus-visible {
+        background: linear-gradient(135deg, #2196ff, #4da6ff);
+        box-shadow: 0 12px 26px rgba(10, 132, 255, 0.35);
+        transform: translateY(-1px);
+      }
+      button:focus-visible {
+        outline: 2px solid rgba(255, 255, 255, 0.85);
+        outline-offset: 3px;
       }
       button:disabled {
         opacity: 0.5;
         cursor: not-allowed;
+        box-shadow: none;
+        transform: none;
       }
       .control-group {
         display: flex;
-        gap: 0.5rem;
+        gap: 0.6rem;
         flex-wrap: wrap;
       }
       a.settings-link {
-        color: #0a84ff;
+        color: #8ab4ff;
         text-decoration: none;
         font-weight: 600;
+        padding: 0.4rem 0.6rem;
+        border-radius: 999px;
+        transition: color 0.2s ease, background 0.2s ease;
       }
-      #status {
-        font-size: 0.9rem;
-        opacity: 0.8;
+      a.settings-link:hover,
+      a.settings-link:focus-visible {
+        color: #c7d7ff;
+        background: rgba(138, 180, 255, 0.15);
       }
-      #battery-indicator {
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
-        margin-left: auto;
-        min-width: 0;
+      a.settings-link:focus-visible {
+        outline: 2px solid rgba(138, 180, 255, 0.5);
+        outline-offset: 3px;
       }
-      #battery-status {
-        display: flex;
-        flex-direction: column;
-        align-items: flex-end;
-        line-height: 1.1;
-      }
-      #battery-text {
+      .status-pill {
+        color: #94a3b8;
+        gap: 0.75rem;
         font-weight: 600;
-        font-size: 0.9rem;
       }
-      #battery-details {
-        font-size: 0.7rem;
-        opacity: 0.7;
-        white-space: nowrap;
+      .status-icon {
+        width: 1.6rem;
+        height: 1.6rem;
+        flex: 0 0 auto;
       }
-      .battery-icon {
-        position: relative;
-        width: 2.4rem;
-        height: 1rem;
-        border: 2px solid currentColor;
-        border-radius: 3px;
-        box-sizing: border-box;
-        display: inline-flex;
-        align-items: stretch;
-        color: #f5f5f5;
+      .status-icon .icon {
+        opacity: 0;
+        transition: opacity 0.25s ease;
       }
-      .battery-icon::after {
-        content: "";
-        position: absolute;
-        right: -6px;
-        top: 25%;
-        width: 4px;
-        height: 50%;
-        border-radius: 1px;
-        background: currentColor;
+      .status-pill.is-live .icon-live,
+      .status-pill.is-paused .icon-paused,
+      .status-pill.is-error .icon-error,
+      .status-pill.is-busy .icon-busy {
+        opacity: 1;
       }
-      .battery-level {
-        width: 0%;
-        background: currentColor;
-        transition: width 0.3s ease;
+      .status-pill.is-live {
+        color: #4ade80;
       }
-      .battery-icon.low {
+      .status-pill.is-paused {
+        color: #facc15;
+      }
+      .status-pill.is-error {
         color: #ff453a;
       }
-      .battery-icon.charging {
+      .status-pill.is-busy {
+        color: #38bdf8;
+      }
+      .status-pill.is-charging {
+        box-shadow: 0 20px 44px rgba(48, 209, 88, 0.28);
+      }
+      .status-copy {
+        display: flex;
+        flex-direction: column;
+        line-height: 1.1;
+        gap: 0.15rem;
+        min-width: 0;
+      }
+      #status {
+        font-size: 0.95rem;
+        font-weight: 600;
+        white-space: nowrap;
+      }
+      #status-subtext {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.25rem;
+        font-size: 0.75rem;
+        font-weight: 500;
+        letter-spacing: 0.02em;
+        opacity: 0.75;
+        white-space: nowrap;
+      }
+      #status-subtext:empty {
+        display: none;
+      }
+      #status-subtext::before {
+        content: "⚡";
+        font-size: 0.8rem;
+      }
+      #battery-indicator {
+        align-items: center;
+      }
+      .battery-pill {
+        font-weight: 600;
+        color: #f5f5f5;
+      }
+      .battery-pill.low {
+        color: #ff453a;
+        box-shadow: 0 20px 44px rgba(255, 69, 58, 0.32);
+      }
+      .battery-pill.charging {
         color: #30d158;
+        box-shadow: 0 24px 48px rgba(48, 209, 88, 0.3);
       }
-      .battery-icon.unavailable {
-        color: rgba(245, 245, 245, 0.4);
+      .battery-pill.unavailable {
+        color: rgba(245, 245, 245, 0.45);
+        box-shadow: none;
       }
-      @media (max-width: 520px) {
-        #battery-indicator {
-          width: 100%;
-          margin-left: 0;
-          justify-content: flex-start;
+      .battery-icon {
+        width: 2.6rem;
+        height: 1.5rem;
+        flex: 0 0 auto;
+      }
+      .battery-outline {
+        fill: none;
+        stroke: currentColor;
+        stroke-width: 2;
+        opacity: 0.85;
+      }
+      .battery-terminal {
+        fill: currentColor;
+        opacity: 0.85;
+      }
+      .battery-fill {
+        fill: currentColor;
+        opacity: 0.9;
+        transition: width 0.35s ease;
+      }
+      .battery-bolt {
+        fill: currentColor;
+        opacity: 0;
+        transition: opacity 0.3s ease;
+      }
+      .battery-pill.charging .battery-bolt {
+        opacity: 1;
+      }
+      .battery-copy {
+        display: flex;
+        flex-direction: column;
+        line-height: 1.1;
+        gap: 0.15rem;
+        align-items: flex-start;
+        min-width: 0;
+      }
+      #battery-text {
+        font-size: 0.95rem;
+      }
+      #battery-details {
+        font-size: 0.72rem;
+        opacity: 0.75;
+        white-space: nowrap;
+      }
+      @media (max-width: 960px) {
+        img#stream {
+          border-radius: 16px;
+          box-shadow: 0 28px 70px rgba(0, 0, 0, 0.55);
         }
-        #battery-status {
-          align-items: flex-start;
+      }
+      @media (max-width: 640px) {
+        header,
+        footer {
+          align-items: stretch;
+        }
+        .status-pill,
+        .battery-pill {
+          width: 100%;
+        }
+        #status,
+        #status-subtext,
+        #battery-details {
+          white-space: normal;
+        }
+        .control-group {
+          width: 100%;
+          justify-content: center;
+        }
+        footer {
+          justify-content: center;
+          text-align: center;
         }
       }
     </style>
   </head>
   <body>
     <header>
-      <strong>RevCam</strong>
-      <div id="status">Initialising…</div>
-      <div id="battery-indicator" aria-live="polite" aria-label="Battery unavailable">
-        <span class="battery-icon unavailable" id="battery-icon" aria-hidden="true">
-          <span class="battery-level" id="battery-level"></span>
-        </span>
-        <div id="battery-status">
+      <strong class="brand">RevCam</strong>
+      <div class="pill status-pill is-busy" id="status-pill" role="status" aria-live="polite">
+        <svg class="status-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <g class="icon icon-live">
+            <path
+              d="M4 10a8 8 0 0 1 16 0"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.8"
+              stroke-linecap="round"
+            ></path>
+            <path
+              d="M7.5 13a4.5 4.5 0 0 1 9 0"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.8"
+              stroke-linecap="round"
+            ></path>
+            <circle cx="12" cy="16" r="2.2" fill="currentColor"></circle>
+          </g>
+          <g class="icon icon-paused">
+            <rect x="7" y="6.5" width="3.5" height="11" rx="1" fill="currentColor"></rect>
+            <rect x="13.5" y="6.5" width="3.5" height="11" rx="1" fill="currentColor"></rect>
+          </g>
+          <g class="icon icon-busy">
+            <circle
+              cx="12"
+              cy="12"
+              r="7"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.8"
+              stroke-linecap="round"
+              stroke-dasharray="32"
+              stroke-dashoffset="8"
+            ></circle>
+            <circle cx="12" cy="4.5" r="1.6" fill="currentColor"></circle>
+          </g>
+          <g class="icon icon-error">
+            <path d="M12 5l7 12H5z" fill="currentColor"></path>
+          </g>
+        </svg>
+        <div class="status-copy">
+          <span id="status">Initialising…</span>
+          <span id="status-subtext"></span>
+        </div>
+      </div>
+      <div
+        id="battery-indicator"
+        class="pill battery-pill unavailable"
+        aria-live="polite"
+        aria-label="Battery unavailable"
+      >
+        <svg
+          class="battery-icon"
+          id="battery-icon"
+          viewBox="0 0 52 28"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <rect class="battery-outline" x="2" y="6" width="36" height="16" rx="4" ry="4"></rect>
+          <rect class="battery-fill" id="battery-level" x="4" y="8" width="0" height="12" rx="3" ry="3"></rect>
+          <rect class="battery-terminal" x="38" y="11" width="8" height="6" rx="1.5" ry="1.5"></rect>
+          <path class="battery-bolt" d="M27 9l-4 6h3l-1 6 4-7h-3l1-5z"></path>
+        </svg>
+        <div class="battery-copy">
           <span id="battery-text">—%</span>
           <span id="battery-details">Battery unavailable</span>
         </div>
@@ -169,51 +373,102 @@
       const batteryLevel = document.getElementById("battery-level");
       const batteryText = document.getElementById("battery-text");
       const batteryDetails = document.getElementById("battery-details");
+      const statusPill = document.getElementById("status-pill");
+      const statusSubtext = document.getElementById("status-subtext");
+      const BATTERY_LEVEL_MAX = 32;
+      const STATUS_CLASSES = ["is-live", "is-paused", "is-error", "is-busy"];
+      function applyStatusState(reference) {
+        if (!statusPill) {
+          return;
+        }
+        const descriptor = typeof reference === "string" ? reference.toLowerCase() : "";
+        statusPill.classList.remove(...STATUS_CLASSES);
+        let targetClass = "is-busy";
+        if (descriptor.includes("error") || descriptor.includes("fail") || descriptor.includes("lost")) {
+          targetClass = "is-error";
+        } else if (descriptor.includes("pause") || descriptor.includes("stop")) {
+          targetClass = "is-paused";
+        } else if (descriptor.includes("stream") || descriptor.includes("live") || descriptor.includes("play")) {
+          targetClass = "is-live";
+        }
+        statusPill.classList.add(targetClass);
+      }
+
+      function setStatus(message, stateHint) {
+        if (statusLabel) {
+          statusLabel.textContent = message;
+        }
+        applyStatusState(stateHint || message);
+      }
+
+      function setChargingState(isCharging) {
+        const charging = Boolean(isCharging);
+        if (statusPill) {
+          statusPill.classList.toggle("is-charging", charging);
+        }
+        if (statusSubtext) {
+          statusSubtext.textContent = charging ? "Charging" : "";
+        }
+      }
+
       let reconnectTimer = null;
       let batteryTimer = null;
       let shouldStream = false;
+      setStatus(statusLabel ? statusLabel.textContent : "Initialising…", "busy");
 
       function updateBatteryUI(data) {
-        if (!batteryIcon || !batteryLevel || !batteryText || !batteryDetails) {
+        if (
+          !batteryIndicator ||
+          !batteryIcon ||
+          !batteryLevel ||
+          !batteryText ||
+          !batteryDetails
+        ) {
           return;
         }
+        batteryIndicator.classList.remove("low", "charging", "unavailable");
         batteryIcon.classList.remove("low", "charging", "unavailable");
 
         if (!data || data.available !== true || typeof data.percentage !== "number") {
+          batteryIndicator.classList.add("unavailable");
           batteryIcon.classList.add("unavailable");
-          batteryLevel.style.width = "0%";
-          batteryText.textContent = "—";
+          batteryLevel.setAttribute("width", "0");
+          batteryText.textContent = "—%";
           const fallback =
             data && typeof data.error === "string" && data.error.trim()
               ? data.error.trim()
               : "Battery unavailable";
           batteryDetails.textContent = fallback;
-          if (batteryIndicator) {
-            batteryIndicator.setAttribute("aria-label", fallback);
-          }
+          batteryIndicator.setAttribute("aria-label", fallback);
+          setChargingState(false);
           return;
         }
 
         const rawPercentage = Number(data.percentage);
         if (!Number.isFinite(rawPercentage)) {
+          batteryIndicator.classList.add("unavailable");
           batteryIcon.classList.add("unavailable");
-          batteryLevel.style.width = "0%";
-          batteryText.textContent = "—";
+          batteryLevel.setAttribute("width", "0");
+          batteryText.textContent = "—%";
           batteryDetails.textContent = "Battery unavailable";
-          if (batteryIndicator) {
-            batteryIndicator.setAttribute("aria-label", "Battery unavailable");
-          }
+          batteryIndicator.setAttribute("aria-label", "Battery unavailable");
+          setChargingState(false);
           return;
         }
 
         const percentage = Math.max(0, Math.min(100, rawPercentage));
-        batteryLevel.style.width = `${percentage}%`;
+        const fillWidth = Math.round((percentage / 100) * BATTERY_LEVEL_MAX);
+        const clampedWidth = Math.max(0, Math.min(BATTERY_LEVEL_MAX, fillWidth));
+        const visibleWidth = clampedWidth > 0 ? Math.max(3, clampedWidth) : 0;
+        batteryLevel.setAttribute("width", String(visibleWidth));
         const rounded = Math.round(percentage);
         batteryText.textContent = `${rounded}%`;
 
         if (data.charging === true) {
+          batteryIndicator.classList.add("charging");
           batteryIcon.classList.add("charging");
         } else if (percentage <= 20) {
+          batteryIndicator.classList.add("low");
           batteryIcon.classList.add("low");
         }
 
@@ -232,12 +487,11 @@
         }
         const detailText = detailParts.join(" · ") || "Battery OK";
         batteryDetails.textContent = detailText;
-        if (batteryIndicator) {
-          batteryIndicator.setAttribute(
-            "aria-label",
-            `Battery ${rounded}%, ${detailParts.join(", ") || "status"}`,
-          );
-        }
+        batteryIndicator.setAttribute(
+          "aria-label",
+          `Battery ${rounded}%, ${detailParts.join(", ") || "status"}`,
+        );
+        setChargingState(data.charging === true);
       }
 
       async function refreshBattery() {
@@ -288,7 +542,7 @@
         clearReconnectTimer();
         toggleButton.textContent = "Pause stream";
         toggleButton.setAttribute("aria-pressed", "true");
-        statusLabel.textContent = message;
+        setStatus(message, "busy");
         const cacheBuster = Date.now();
         streamElement.src = `/stream/mjpeg?cb=${cacheBuster}`;
       }
@@ -298,7 +552,7 @@
         clearReconnectTimer();
         streamElement.src = "";
         streamElement.removeAttribute("src");
-        statusLabel.textContent = message;
+        setStatus(message, "paused");
         toggleButton.textContent = "Start stream";
         toggleButton.setAttribute("aria-pressed", "false");
       }
@@ -311,9 +565,7 @@
         const originalLabel = snapshotButton.textContent;
         snapshotButton.disabled = true;
         snapshotButton.textContent = "Saving…";
-        if (statusLabel) {
-          statusLabel.textContent = "Capturing snapshot…";
-        }
+        setStatus("Capturing snapshot…", "busy");
 
         try {
           const response = await fetch("/api/camera/snapshot", { cache: "no-store" });
@@ -331,24 +583,22 @@
           anchor.click();
           document.body.removeChild(anchor);
           setTimeout(() => URL.revokeObjectURL(url), 1000);
-          if (statusLabel) {
-            statusLabel.textContent = "Snapshot saved";
-            setTimeout(() => {
-              if (statusLabel.textContent === "Snapshot saved") {
-                statusLabel.textContent = previousStatus || (shouldStream ? "Streaming" : "Streaming paused");
-              }
-            }, 2000);
-          }
+          setStatus("Snapshot saved", "live");
+          setTimeout(() => {
+            if (statusLabel && statusLabel.textContent === "Snapshot saved") {
+              const fallback = previousStatus || (shouldStream ? "Streaming" : "Streaming paused");
+              setStatus(fallback);
+            }
+          }, 2000);
         } catch (error) {
           console.error("Snapshot error", error);
-          if (statusLabel) {
-            statusLabel.textContent = "Snapshot failed";
-            setTimeout(() => {
-              if (statusLabel.textContent === "Snapshot failed") {
-                statusLabel.textContent = previousStatus || (shouldStream ? "Streaming" : "Streaming paused");
-              }
-            }, 2500);
-          }
+          setStatus("Snapshot failed", "error");
+          setTimeout(() => {
+            if (statusLabel && statusLabel.textContent === "Snapshot failed") {
+              const fallback = previousStatus || (shouldStream ? "Streaming" : "Streaming paused");
+              setStatus(fallback);
+            }
+          }, 2500);
         } finally {
           snapshotButton.disabled = false;
           snapshotButton.textContent = originalLabel;
@@ -359,12 +609,12 @@
         if (!shouldStream) {
           return;
         }
-        statusLabel.textContent = "Streaming";
+        setStatus("Streaming", "live");
       });
 
       streamElement.addEventListener("error", (event) => {
         console.error("Stream error", event);
-        statusLabel.textContent = "Connection lost – retrying…";
+        setStatus("Connection lost – retrying…", "error");
         scheduleReconnect();
       });
 


### PR DESCRIPTION
## Summary
- restyle the live view header/footer with glassmorphism pills for the status and battery blocks, including new status iconography and charging subtext
- overhaul the CSS to support the translucent layout, responsive stream sizing, and refreshed button/link interactions
- update the client script to drive the new DOM structure, including SVG battery fill handling and smarter status state management

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0076540708332bd6842fa5892f34c