### PR TITLE
Fix zeroconf event loop blocking in mDNS advertiser

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rev-cam"
-version = "0.2.6"
+version = "0.2.7"
 description = "Low-latency Raspberry Pi reversing camera MJPEG server"
 readme = "README.md"
 authors = [{name = "RevCam Team"}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rev-cam"
-version = "0.2.5"
+version = "0.2.6"
 description = "Low-latency Raspberry Pi reversing camera MJPEG server"
 readme = "README.md"
 authors = [{name = "RevCam Team"}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rev-cam"
-version = "0.2.4"
+version = "0.2.5"
 description = "Low-latency Raspberry Pi reversing camera MJPEG server"
 readme = "README.md"
 authors = [{name = "RevCam Team"}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rev-cam"
-version = "0.2.3"
+version = "0.2.4"
 description = "Low-latency Raspberry Pi reversing camera MJPEG server"
 readme = "README.md"
 authors = [{name = "RevCam Team"}]

--- a/src/rev_cam/app.py
+++ b/src/rev_cam/app.py
@@ -681,6 +681,15 @@ def create_app(
             raise HTTPException(status_code=503, detail=str(exc)) from exc
         return status.to_dict()
 
+    @app.get("/api/wifi/log")
+    async def get_wifi_log(limit: int = 50) -> dict[str, object]:
+        try:
+            entries = await run_in_threadpool(wifi_manager.get_connection_log, limit)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.warning("Unable to load Wi-Fi log: %s", exc)
+            raise HTTPException(status_code=503, detail="Unable to load Wi-Fi log") from exc
+        return {"entries": entries}
+
     @app.get("/api/wifi/networks")
     async def list_wifi_networks() -> dict[str, object]:
         try:

--- a/src/rev_cam/mdns.py
+++ b/src/rev_cam/mdns.py
@@ -8,6 +8,7 @@ import shutil
 import subprocess
 import threading
 import time
+from typing import Callable, TypeVar, cast
 
 try:  # pragma: no cover - import guard for optional dependency failures
     from zeroconf import InterfaceChoice, ServiceInfo, Zeroconf
@@ -21,6 +22,9 @@ else:
 
 
 logger = logging.getLogger(__name__)
+
+
+_T = TypeVar("_T")
 
 
 class _BaseAdvertiser:
@@ -65,27 +69,7 @@ class _ZeroconfAdvertiser(_BaseAdvertiser):
         return self._zeroconf
 
     def _create_zeroconf(self) -> Zeroconf:
-        if not self._event_loop_running():
-            return Zeroconf(interfaces=InterfaceChoice.All)
-
-        result: Zeroconf | None = None
-        error: BaseException | None = None
-
-        def _construct() -> None:
-            nonlocal result, error
-            try:
-                result = Zeroconf(interfaces=InterfaceChoice.All)
-            except BaseException as exc:  # pragma: no cover - defensive guard
-                error = exc
-
-        thread = threading.Thread(target=_construct, daemon=True)
-        thread.start()
-        thread.join()
-
-        if error is not None:
-            raise error
-        assert result is not None  # pragma: no cover - defensive
-        return result
+        return self._run_blocking(lambda: Zeroconf(interfaces=InterfaceChoice.All))
 
     @staticmethod
     def _event_loop_running() -> bool:
@@ -94,6 +78,31 @@ class _ZeroconfAdvertiser(_BaseAdvertiser):
         except RuntimeError:
             return False
         return True
+
+    def _run_blocking(self, func: Callable[[], _T]) -> _T:
+        if not self._event_loop_running():
+            return func()
+
+        outcome: object | None = None
+        error: BaseException | None = None
+        finished = threading.Event()
+
+        def _invoke() -> None:
+            nonlocal outcome, error
+            try:
+                outcome = func()
+            except BaseException as exc:  # pragma: no cover - defensive guard
+                error = exc
+            finally:
+                finished.set()
+
+        thread = threading.Thread(target=_invoke, daemon=True)
+        thread.start()
+        finished.wait()
+
+        if error is not None:
+            raise error
+        return cast(_T, outcome)
 
     def _build_service_info(self, ip: ipaddress._BaseAddress) -> ServiceInfo:
         service_name = f"{self._service_name}.{self._service_type}"
@@ -130,13 +139,15 @@ class _ZeroconfAdvertiser(_BaseAdvertiser):
             return
         if self._info is not None:
             try:
-                zeroconf.unregister_service(self._info)
+                self._run_blocking(lambda: zeroconf.unregister_service(self._info))
             except Exception as exc:  # pragma: no cover - best effort cleanup
                 logger.debug("Ignoring mDNS unregister failure: %s", exc)
             self._info = None
         info = self._build_service_info(parsed_ip)
         try:
-            zeroconf.register_service(info, allow_name_change=False)
+            self._run_blocking(
+                lambda: zeroconf.register_service(info, allow_name_change=False)
+            )
         except Exception as exc:  # pragma: no cover - zeroconf runtime issues
             message = (str(exc) or exc.__class__.__name__).strip()
             lowered = message.lower()
@@ -163,7 +174,7 @@ class _ZeroconfAdvertiser(_BaseAdvertiser):
                 self._current_ip = None
                 if self._zeroconf is not None:
                     try:
-                        self._zeroconf.close()
+                        self._run_blocking(self._zeroconf.close)
                     except Exception:  # pragma: no cover - best effort cleanup
                         logger.debug(
                             "Ignoring Zeroconf close failure after permission error",
@@ -184,7 +195,7 @@ class _ZeroconfAdvertiser(_BaseAdvertiser):
         zeroconf = self._zeroconf
         if zeroconf is not None:
             try:
-                zeroconf.unregister_service(self._info)
+                self._run_blocking(lambda: zeroconf.unregister_service(self._info))
             except Exception as exc:  # pragma: no cover - best effort cleanup
                 logger.debug("Ignoring mDNS unregister failure: %s", exc)
         self._info = None
@@ -194,7 +205,7 @@ class _ZeroconfAdvertiser(_BaseAdvertiser):
         self.clear()
         if self._zeroconf is not None:
             try:
-                self._zeroconf.close()
+                self._run_blocking(self._zeroconf.close)
             finally:
                 self._zeroconf = None
 

--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -4436,9 +4436,17 @@
               wifiConnectSelected.textContent = `Selected network: ${ssid}`;
               if (wifiConnectPasswordInput) {
                 wifiConnectPasswordInput.value = "";
-                wifiConnectPasswordInput.placeholder = network.security
-                  ? `Security: ${network.security}`
-                  : "Password (if required)";
+                if (network.known) {
+                  wifiConnectPasswordInput.placeholder = "Saved network – leave blank to use stored password.";
+                  wifiConnectPasswordInput.dataset.knownNetwork = "true";
+                  wifiConnectPasswordInput.title = "Leave blank to reuse the saved credentials.";
+                } else {
+                  wifiConnectPasswordInput.placeholder = network.security
+                    ? `Security: ${network.security}`
+                    : "Password (if required)";
+                  delete wifiConnectPasswordInput.dataset.knownNetwork;
+                  wifiConnectPasswordInput.title = "Enter the network password if required.";
+                }
               }
               if (wifiRollbackInput && typeof wifiRollbackInput.value === "string" && !wifiRollbackInput.value) {
                 wifiRollbackInput.value = "30";

--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -812,6 +812,65 @@
         flex-wrap: wrap;
         gap: var(--space-sm);
       }
+      #wifi-log-section {
+        margin-top: var(--stack-gap-lg);
+        padding: var(--stack-gap-lg);
+        border-radius: var(--radius-lg);
+        background: var(--surface-soft);
+        border: 1px solid var(--border-subtle);
+        display: flex;
+        flex-direction: column;
+        gap: var(--stack-gap);
+      }
+      #wifi-log-section h3 {
+        margin-bottom: 0;
+      }
+      #wifi-log-empty {
+        margin: 0;
+        font-size: 0.9rem;
+        color: var(--text-muted);
+      }
+      #wifi-log-empty.error {
+        color: var(--danger);
+      }
+      #wifi-log {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-sm);
+        max-height: 18rem;
+        overflow-y: auto;
+      }
+      #wifi-log li {
+        padding: var(--space-md) var(--space-lg);
+        border-radius: var(--radius-md);
+        background: var(--surface-panel);
+        border: 1px solid var(--border-subtle);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-xs);
+      }
+      #wifi-log li time {
+        font-size: 0.8rem;
+        color: var(--text-muted);
+        letter-spacing: 0.01em;
+      }
+      #wifi-log li .log-event {
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--accent);
+      }
+      #wifi-log li .log-message {
+        font-size: 0.95rem;
+        line-height: 1.5;
+      }
+      #wifi-log li .log-extra {
+        font-size: 0.8rem;
+        color: var(--text-muted);
+      }
       .battery-card {
         display: flex;
         flex-wrap: wrap;
@@ -1757,6 +1816,11 @@
                 <button type="button" id="wifi-disable-hotspot" class="secondary-button">Disable hotspot</button>
               </div>
             </section>
+            <section id="wifi-log-section">
+              <h3>Recent Wi-Fi activity</h3>
+              <p id="wifi-log-empty" class="muted">No Wi-Fi events recorded yet.</p>
+              <ol id="wifi-log"></ol>
+            </section>
           </section>
         </section>
 
@@ -2093,6 +2157,8 @@
       const wifiHotspotPassword = document.getElementById("wifi-hotspot-password");
       const wifiEnableHotspot = document.getElementById("wifi-enable-hotspot");
       const wifiDisableHotspot = document.getElementById("wifi-disable-hotspot");
+      const wifiLogList = document.getElementById("wifi-log");
+      const wifiLogEmpty = document.getElementById("wifi-log-empty");
       const wifiConnectSsidInput = wifiConnectForm
         ? wifiConnectForm.querySelector('input[name="ssid"]')
         : null;
@@ -2104,6 +2170,9 @@
         : null;
       const HOTSPOT_HOSTNAME = "motion.local";
       const HOTSPOT_DEV_ROLLBACK_DEFAULT = 120;
+      const WIFI_LOG_DEFAULT_EMPTY_MESSAGE = wifiLogEmpty
+        ? wifiLogEmpty.textContent || "No Wi-Fi events recorded yet."
+        : "No Wi-Fi events recorded yet.";
 
       function formatLedPatternName(name) {
         if (typeof name !== "string" || !name) {
@@ -4343,6 +4412,164 @@
         return pieces.join(" ");
       }
 
+      function formatLogTimestamp(timestamp) {
+        if (typeof timestamp !== "number" || !Number.isFinite(timestamp)) {
+          return { display: "", iso: "" };
+        }
+        const date = new Date(timestamp * 1000);
+        if (Number.isNaN(date.getTime())) {
+          return { display: "", iso: "" };
+        }
+        return {
+          display: date.toLocaleString(),
+          iso: date.toISOString(),
+        };
+      }
+
+      function summariseLogStatus(status) {
+        if (!status || typeof status !== "object") {
+          return "";
+        }
+        const parts = [];
+        if (Object.prototype.hasOwnProperty.call(status, "connected")) {
+          parts.push(status.connected ? "Connected" : "Disconnected");
+        }
+        if (status.hotspot_active) {
+          parts.push("Hotspot active");
+        }
+        const name =
+          (typeof status.ssid === "string" && status.ssid.trim()) ||
+          (typeof status.profile === "string" && status.profile.trim()) ||
+          "";
+        if (name) {
+          parts.push(`Network: ${name}`);
+        }
+        if (typeof status.ip_address === "string" && status.ip_address.trim()) {
+          parts.push(`IP: ${status.ip_address.trim()}`);
+        }
+        if (typeof status.mode === "string" && status.mode.trim()) {
+          parts.push(`Mode: ${status.mode.trim()}`);
+        }
+        return parts.join(" • ");
+      }
+
+      function formatLogMetadata(metadata) {
+        if (!metadata || typeof metadata !== "object") {
+          return "";
+        }
+        const labels = {
+          target: "Target",
+          development_mode: "Development mode",
+          requested_rollback: "Requested rollback (s)",
+          effective_rollback: "Rollback window (s)",
+          password_provided: "Password provided",
+          restored_profile: "Restored profile",
+        };
+        const parts = [];
+        for (const [key, value] of Object.entries(metadata)) {
+          if (value === null || value === undefined || value === "") {
+            continue;
+          }
+          const label = labels[key] || key.replace(/_/g, " ");
+          let display = value;
+          if (typeof value === "boolean") {
+            display = value ? "Yes" : "No";
+          } else if (typeof value === "number" && Number.isFinite(value)) {
+            display = Math.round(value * 100) / 100;
+          }
+          parts.push(`${label}: ${display}`);
+        }
+        return parts.join(" • ");
+      }
+
+      function setWifiLogEmpty(message, isError = false) {
+        if (!wifiLogEmpty) {
+          return;
+        }
+        wifiLogEmpty.hidden = false;
+        wifiLogEmpty.textContent = message || WIFI_LOG_DEFAULT_EMPTY_MESSAGE;
+        if (isError) {
+          wifiLogEmpty.classList.add("error");
+        } else {
+          wifiLogEmpty.classList.remove("error");
+        }
+      }
+
+      function renderWifiLog(entries) {
+        if (!wifiLogList) {
+          return;
+        }
+        wifiLogList.innerHTML = "";
+        if (!Array.isArray(entries) || entries.length === 0) {
+          setWifiLogEmpty(WIFI_LOG_DEFAULT_EMPTY_MESSAGE, false);
+          return;
+        }
+        if (wifiLogEmpty) {
+          wifiLogEmpty.hidden = true;
+          wifiLogEmpty.classList.remove("error");
+        }
+        for (const entry of entries) {
+          const item = document.createElement("li");
+          const header = document.createElement("div");
+          header.style.display = "flex";
+          header.style.flexWrap = "wrap";
+          header.style.justifyContent = "space-between";
+          header.style.gap = "0.25rem";
+          const timestamp = formatLogTimestamp(entry && entry.timestamp);
+          if (timestamp.display) {
+            const timeEl = document.createElement("time");
+            timeEl.textContent = timestamp.display;
+            if (timestamp.iso) {
+              timeEl.dateTime = timestamp.iso;
+            }
+            header.appendChild(timeEl);
+          }
+          const eventEl = document.createElement("span");
+          eventEl.className = "log-event";
+          eventEl.textContent = entry && entry.event ? String(entry.event) : "event";
+          header.appendChild(eventEl);
+          item.appendChild(header);
+          const messageEl = document.createElement("div");
+          messageEl.className = "log-message";
+          messageEl.textContent = entry && entry.message ? String(entry.message) : "";
+          item.appendChild(messageEl);
+          const metadataText = formatLogMetadata(entry && entry.metadata);
+          if (metadataText) {
+            const metaEl = document.createElement("div");
+            metaEl.className = "log-extra";
+            metaEl.textContent = metadataText;
+            item.appendChild(metaEl);
+          }
+          const statusText = summariseLogStatus(entry && entry.status);
+          if (statusText) {
+            const statusEl = document.createElement("div");
+            statusEl.className = "log-extra";
+            statusEl.textContent = statusText;
+            item.appendChild(statusEl);
+          }
+          wifiLogList.appendChild(item);
+        }
+      }
+
+      async function refreshWifiLog() {
+        if (!wifiLogList) {
+          return;
+        }
+        try {
+          const response = await fetch("/api/wifi/log?limit=50", { cache: "no-store" });
+          if (!response.ok) {
+            throw new Error("Unable to load Wi-Fi log.");
+          }
+          const data = await response.json();
+          const entries = Array.isArray(data.entries) ? data.entries : [];
+          renderWifiLog(entries);
+        } catch (err) {
+          console.error(err);
+          renderWifiLog([]);
+          setWifiLogEmpty("Unable to load Wi-Fi log.", true);
+        }
+      }
+
       function setWifiFeedback(message, isError = false) {
         if (!wifiFeedback) {
           return;
@@ -4478,12 +4705,13 @@
         if (!wifiSummary) {
           return null;
         }
+        let status = null;
         try {
           const response = await fetch("/api/wifi/status");
           if (!response.ok) {
             throw new Error("Unable to fetch Wi-Fi status");
           }
-          const status = await response.json();
+          status = await response.json();
           wifiSummary.textContent = summariseWifiStatus(status);
           if (wifiHotspotStatus) {
             if (status.hotspot_active) {
@@ -4503,15 +4731,16 @@
           } else if (!wifiFeedback || !wifiFeedback.textContent) {
             setWifiFeedback("", false);
           }
-          return status;
         } catch (err) {
           console.error(err);
           if (wifiSummary) {
             const message = err instanceof Error ? err.message : "Wi-Fi status unavailable.";
             wifiSummary.textContent = message;
           }
-          return null;
+        } finally {
+          await refreshWifiLog();
         }
+        return status;
       }
 
       async function scanWifiNetworks() {

--- a/src/rev_cam/version.py
+++ b/src/rev_cam/version.py
@@ -1,6 +1,6 @@
 """Application version metadata."""
 
-APP_VERSION = "0.2.5"
+APP_VERSION = "0.2.6"
 """Human readable application version displayed in the UI."""
 
 __all__ = ["APP_VERSION"]

--- a/src/rev_cam/version.py
+++ b/src/rev_cam/version.py
@@ -1,6 +1,6 @@
 """Application version metadata."""
 
-APP_VERSION = "0.2.6"
+APP_VERSION = "0.2.7"
 """Human readable application version displayed in the UI."""
 
 __all__ = ["APP_VERSION"]

--- a/src/rev_cam/version.py
+++ b/src/rev_cam/version.py
@@ -1,6 +1,6 @@
 """Application version metadata."""
 
-APP_VERSION = "0.2.3"
+APP_VERSION = "0.2.5"
 """Human readable application version displayed in the UI."""
 
 __all__ = ["APP_VERSION"]

--- a/src/rev_cam/wifi.py
+++ b/src/rev_cam/wifi.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import logging
+from collections import deque
 from dataclasses import dataclass
 import math
 import subprocess
+import threading
 import time
-from typing import Iterable, Sequence
+from typing import Deque, Iterable, Sequence
 
 from .mdns import MDNSAdvertiser
 
@@ -88,6 +90,29 @@ class WiFiStatus:
             "error": self.error,
             "detail": self.detail,
         }
+
+
+@dataclass(slots=True)
+class WiFiLogEntry:
+    """Represents a Wi-Fi operation event for troubleshooting."""
+
+    timestamp: float
+    event: str
+    message: str
+    status: dict[str, object | None] | None = None
+    metadata: dict[str, object | None] | None = None
+
+    def to_dict(self) -> dict[str, object | None]:
+        payload: dict[str, object | None] = {
+            "timestamp": self.timestamp,
+            "event": self.event,
+            "message": self.message,
+        }
+        if self.status is not None:
+            payload["status"] = self.status
+        if self.metadata:
+            payload["metadata"] = self.metadata
+        return payload
 
 
 class WiFiBackend:
@@ -446,6 +471,8 @@ class WiFiManager:
                     "mDNS advertising disabled: %s", exc
                 )
                 self._mdns = None
+        self._log: Deque[WiFiLogEntry] = deque(maxlen=200)
+        self._log_lock = threading.Lock()
         try:
             initial_status = self._backend.get_status()
         except WiFiError:
@@ -487,27 +514,94 @@ class WiFiManager:
             cleaned_password = password if password.strip() else None
         else:
             raise WiFiError("Password must be a string or null")
+        attempt_metadata: dict[str, object | None] = {
+            "target": cleaned_ssid,
+            "development_mode": development_mode,
+        }
+        if rollback_timeout is not None:
+            attempt_metadata["requested_rollback"] = max(0.0, rollback_timeout)
+        attempt_metadata["password_provided"] = cleaned_password is not None
+        self._record_log(
+            "connect_attempt",
+            f"Attempting to connect to {cleaned_ssid}.",
+            metadata=attempt_metadata,
+        )
         previous_status = self._fetch_status()
         previous_profile = previous_status.profile if previous_status.connected else None
-        status = self._backend.connect(cleaned_ssid, cleaned_password)
+        try:
+            status = self._backend.connect(cleaned_ssid, cleaned_password)
+        except WiFiError as exc:
+            message = str(exc).strip() or "Connection failed"
+            self._record_log(
+                "connect_error",
+                f"Connection to {cleaned_ssid} failed: {message}.",
+                metadata=attempt_metadata,
+            )
+            raise
         self._update_mdns(status)
-        if not development_mode:
-            return status
-        timeout = self._rollback_timeout if rollback_timeout is None else max(0.0, rollback_timeout)
-        if timeout <= 0:
-            return status
+        effective_timeout = None
+        if development_mode:
+            base_timeout = (
+                self._rollback_timeout if rollback_timeout is None else max(0.0, rollback_timeout)
+            )
+            effective_timeout = base_timeout
+        result_metadata = dict(attempt_metadata)
+        if effective_timeout is not None:
+            result_metadata["effective_rollback"] = effective_timeout
+        monitor_required = False
         if status.connected and (status.ssid == cleaned_ssid or status.profile == cleaned_ssid):
+            message = f"Connected to {status.ssid or cleaned_ssid}."
+            self._record_log("connect_success", message, status=status, metadata=result_metadata)
+            if not development_mode:
+                return status
+            timeout = effective_timeout
+            if timeout is None or timeout <= 0:
+                return status
+            monitor_required = False
+        else:
+            detail = status.detail or "Connection did not report as active."
+            message = f"Connection to {cleaned_ssid} pending: {detail}"
+            self._record_log("connect_status", message, status=status, metadata=result_metadata)
+            if not development_mode:
+                return status
+            timeout = (
+                effective_timeout
+                if effective_timeout is not None
+                else self._rollback_timeout
+                if rollback_timeout is None
+                else max(0.0, rollback_timeout)
+            )
+            monitor_required = True
+        if timeout <= 0 or not monitor_required:
             return status
+        self._record_log(
+            "connect_monitor",
+            f"Monitoring connection to {cleaned_ssid} for up to {int(math.ceil(timeout))}s before rollback.",
+            status=status,
+            metadata=result_metadata,
+        )
         if not previous_profile:
             detail = status.detail or ""
             status.detail = (
                 f"{detail + ' ' if detail else ''}Development rollback skipped; previous network unknown."
+            )
+            self._record_log(
+                "connect_no_previous_profile",
+                status.detail,
+                status=status,
+                metadata=result_metadata,
             )
             return status
         deadline = time.monotonic() + timeout
         current = status
         while time.monotonic() < deadline:
             if current.connected and (current.ssid == cleaned_ssid or current.profile == cleaned_ssid):
+                self._record_log(
+                    "connect_confirmed",
+                    f"Confirmed connection to {cleaned_ssid} before rollback deadline.",
+                    status=current,
+                    metadata=result_metadata,
+                )
                 return current
             time.sleep(self._poll_interval)
             current = self._fetch_status()
@@ -516,6 +610,14 @@ class WiFiManager:
         restored.detail = (
             f"Connection to {cleaned_ssid} did not establish within {int(math.ceil(timeout))}s; "
             f"restored {previous_status.ssid or previous_profile}."
+        )
+        rollback_metadata = dict(result_metadata)
+        rollback_metadata["restored_profile"] = previous_profile
+        self._record_log(
+            "connect_rollback",
+            restored.detail,
+            status=restored,
+            metadata=rollback_metadata,
         )
         return restored
 
@@ -533,6 +635,18 @@ class WiFiManager:
         if password is not None and password.strip() and len(password.strip()) < 8:
             raise WiFiError("Hotspot password must be at least 8 characters")
         cleaned_password = password.strip() if isinstance(password, str) and password.strip() else None
+        attempt_metadata: dict[str, object | None] = {
+            "target": cleaned_ssid,
+            "development_mode": development_mode,
+            "password_provided": cleaned_password is not None,
+        }
+        if rollback_timeout is not None:
+            attempt_metadata["requested_rollback"] = max(0.0, rollback_timeout)
+        self._record_log(
+            "hotspot_enable_attempt",
+            f"Enabling hotspot {cleaned_ssid}.",
+            metadata=attempt_metadata,
+        )
         try:
             previous_status = self._fetch_status()
         except WiFiError:
@@ -550,23 +664,80 @@ class WiFiManager:
                     "Unable to enable hotspot: not authorized to control networking. "
                     "Ensure RevCam has permission to manage NetworkManager."
                 ) from exc
+            error_message = f"Unable to enable hotspot {cleaned_ssid}: {message}."
+            self._record_log(
+                "hotspot_enable_error",
+                error_message,
+                metadata=attempt_metadata,
+            )
             raise WiFiError(f"Unable to enable hotspot: {message}") from exc
         self._hotspot_profile = status.profile or self._hotspot_profile
         self._update_mdns(status)
-        if not development_mode:
-            return status
-        default_timeout = self._hotspot_rollback_timeout
-        timeout = default_timeout if rollback_timeout is None else max(0.0, rollback_timeout)
-        if timeout <= 0:
-            return status
+        effective_timeout = None
+        if development_mode:
+            base_timeout = (
+                self._hotspot_rollback_timeout
+                if rollback_timeout is None
+                else max(0.0, rollback_timeout)
+            )
+            effective_timeout = base_timeout
+        result_metadata = dict(attempt_metadata)
+        if effective_timeout is not None:
+            result_metadata["effective_rollback"] = effective_timeout
+        monitor_required = False
         if status.hotspot_active:
+            message = f"Hotspot {status.ssid or cleaned_ssid} enabled."
+            self._record_log(
+                "hotspot_enabled",
+                message,
+                status=status,
+                metadata=result_metadata,
+            )
+            if not development_mode:
+                return status
+            timeout = effective_timeout
+            if timeout is None or timeout <= 0:
+                return status
+            monitor_required = False
+        else:
+            detail = status.detail or "Hotspot activation pending."
+            message = f"Hotspot {cleaned_ssid} pending: {detail}"
+            self._record_log(
+                "hotspot_status",
+                message,
+                status=status,
+                metadata=result_metadata,
+            )
+            if not development_mode:
+                return status
+            timeout = (
+                effective_timeout
+                if effective_timeout is not None
+                else self._hotspot_rollback_timeout
+                if rollback_timeout is None
+                else max(0.0, rollback_timeout)
+            )
+            monitor_required = True
+        if timeout <= 0 or not monitor_required:
             return status
+        self._record_log(
+            "hotspot_monitor",
+            f"Monitoring hotspot {cleaned_ssid} for up to {int(math.ceil(timeout))}s before rollback.",
+            status=status,
+            metadata=result_metadata,
+        )
         deadline = time.monotonic() + timeout
         current = status
         while time.monotonic() < deadline:
             if current.hotspot_active:
                 self._hotspot_profile = current.profile or self._hotspot_profile
                 self._update_mdns(current)
+                self._record_log(
+                    "hotspot_confirmed",
+                    f"Hotspot {cleaned_ssid} became active before rollback deadline.",
+                    status=current,
+                    metadata=result_metadata,
+                )
                 return current
             time.sleep(self._poll_interval)
             current = self._fetch_status()
@@ -584,19 +755,53 @@ class WiFiManager:
                 self._hotspot_profile = previous_profile
             elif not restored.hotspot_active:
                 self._hotspot_profile = None
+            rollback_metadata = dict(result_metadata)
+            rollback_metadata["restored_profile"] = previous_profile
+            self._record_log(
+                "hotspot_rollback",
+                restored.detail,
+                status=restored,
+                metadata=rollback_metadata,
+            )
             return restored
         current.detail = (
             f"Hotspot {cleaned_ssid} did not become active within {int(math.ceil(timeout))}s and "
             "no previous connection was available to restore."
         )
         self._update_mdns(current)
+        self._record_log(
+            "hotspot_timeout",
+            current.detail,
+            status=current,
+            metadata=result_metadata,
+        )
         return current
 
     def disable_hotspot(self) -> WiFiStatus:
-        status = self._backend.stop_hotspot(self._hotspot_profile)
+        metadata = {
+            "target": self._hotspot_profile,
+        }
+        self._record_log("hotspot_disable_attempt", "Disabling hotspot.", metadata=metadata)
+        try:
+            status = self._backend.stop_hotspot(self._hotspot_profile)
+        except WiFiError as exc:
+            message = str(exc).strip() or "Unable to disable hotspot"
+            self._record_log(
+                "hotspot_disable_error",
+                f"Hotspot disable failed: {message}.",
+                metadata=metadata,
+            )
+            raise
         self._update_mdns(status)
         if not status.hotspot_active:
             self._hotspot_profile = None
+        detail = status.detail or "Hotspot disabled."
+        self._record_log(
+            "hotspot_disabled",
+            detail,
+            status=status,
+            metadata=metadata,
+        )
         return status
 
     def close(self) -> None:
@@ -614,6 +819,59 @@ class WiFiManager:
         self._update_mdns(status)
         return status
 
+    def get_connection_log(self, limit: int | None = None) -> list[dict[str, object | None]]:
+        """Return recent Wi-Fi connection and hotspot events."""
+
+        with self._log_lock:
+            entries = list(self._log)
+        if limit is not None:
+            try:
+                limit_value = max(1, int(limit))
+            except (TypeError, ValueError):
+                limit_value = 1
+            if len(entries) > limit_value:
+                entries = entries[-limit_value:]
+        return [entry.to_dict() for entry in reversed(entries)]
+
+    def _record_log(
+        self,
+        event: str,
+        message: str,
+        *,
+        status: WiFiStatus | None = None,
+        metadata: dict[str, object | None] | None = None,
+    ) -> None:
+        """Store a troubleshooting entry and mirror it to the logger."""
+
+        status_payload: dict[str, object | None] | None
+        if isinstance(status, WiFiStatus):
+            status_payload = status.to_dict()
+        else:
+            status_payload = None
+        metadata_payload: dict[str, object | None] | None
+        if metadata:
+            metadata_payload = {
+                key: value
+                for key, value in metadata.items()
+                if value is not None
+            }
+        else:
+            metadata_payload = None
+        entry = WiFiLogEntry(
+            timestamp=time.time(),
+            event=event,
+            message=message,
+            status=status_payload,
+            metadata=metadata_payload,
+        )
+        with self._log_lock:
+            self._log.append(entry)
+        logger = logging.getLogger(__name__)
+        if metadata_payload:
+            logger.info("Wi-Fi event %s: %s | metadata=%s", event, message, metadata_payload)
+        else:
+            logger.info("Wi-Fi event %s: %s", event, message)
+
     def _update_mdns(self, status: WiFiStatus) -> None:
         if self._mdns is None:
             return
@@ -630,4 +888,5 @@ __all__ = [
     "WiFiBackend",
     "NMCLIBackend",
     "WiFiManager",
+    "WiFiLogEntry",
 ]

--- a/tests/test_mdns.py
+++ b/tests/test_mdns.py
@@ -1,5 +1,9 @@
+import asyncio
 import logging
+import threading
 import types
+
+import pytest
 
 from rev_cam import mdns
 
@@ -56,3 +60,37 @@ def test_mdns_permission_error_disables_advertising(monkeypatch, caplog) -> None
 
     assert len(_FailingZeroconf.instances) == 1
     assert _FailingZeroconf.instances[0].register_calls == 1
+
+
+def test_mdns_zeroconf_constructed_off_event_loop(monkeypatch) -> None:
+    created_threads: list[int] = []
+    main_thread = threading.get_ident()
+
+    class _ThreadRecordingZeroconf:
+        def __init__(self, interfaces=None) -> None:  # noqa: D401 - simple stub
+            created_threads.append(threading.get_ident())
+
+        def register_service(self, info, allow_name_change=False) -> None:  # noqa: D401
+            del info, allow_name_change
+
+        def unregister_service(self, info) -> None:  # noqa: D401 - simple stub
+            del info
+
+        def close(self) -> None:  # noqa: D401 - simple stub
+            return
+
+    monkeypatch.setattr(mdns, "Zeroconf", _ThreadRecordingZeroconf)
+    monkeypatch.setattr(mdns, "ServiceInfo", _FakeServiceInfo)
+    monkeypatch.setattr(mdns, "InterfaceChoice", types.SimpleNamespace(All="all"))
+
+    advertiser = mdns.MDNSAdvertiser(hostname="test.local")
+
+    async def _invoke() -> None:
+        advertiser.advertise("192.168.1.2")
+
+    asyncio.run(_invoke())
+
+    assert created_threads, "Zeroconf constructor was not called"
+    # Ensure the Zeroconf instance was created on a different thread while the
+    # event loop was running, preventing EventLoopBlocked errors.
+    assert created_threads[0] != main_thread

--- a/tests/test_wifi_nmcli.py
+++ b/tests/test_wifi_nmcli.py
@@ -1,0 +1,64 @@
+import pytest
+
+from rev_cam.wifi import NMCLIBackend, WiFiStatus
+
+
+def _status(ssid: str) -> WiFiStatus:
+    return WiFiStatus(
+        connected=True,
+        ssid=ssid,
+        signal=70,
+        ip_address="192.168.1.2",
+        mode="station",
+        hotspot_active=False,
+        profile=ssid,
+        detail=f"Connected to {ssid}",
+    )
+
+
+def test_nmcli_connect_uses_saved_profile_when_no_password(monkeypatch: pytest.MonkeyPatch) -> None:
+    backend = NMCLIBackend(interface="wlan0")
+    monkeypatch.setattr(backend, "_parse_saved_profiles", lambda: {"Home"})
+    commands: list[list[str]] = []
+
+    def fake_run(args: list[str]) -> str:
+        commands.append(list(args))
+        return ""
+
+    monkeypatch.setattr(backend, "_run", fake_run)
+    monkeypatch.setattr(backend, "get_status", lambda: _status("Home"))
+
+    status = backend.connect("Home", None)
+
+    assert status.ssid == "Home"
+    assert commands == [["nmcli", "connection", "up", "Home", "ifname", "wlan0"]]
+
+
+def test_nmcli_connect_uses_password_for_new_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    backend = NMCLIBackend(interface="wlan0")
+    monkeypatch.setattr(backend, "_parse_saved_profiles", lambda: {"Home"})
+    commands: list[list[str]] = []
+
+    def fake_run(args: list[str]) -> str:
+        commands.append(list(args))
+        return ""
+
+    monkeypatch.setattr(backend, "_run", fake_run)
+    monkeypatch.setattr(backend, "get_status", lambda: _status("Home"))
+
+    status = backend.connect("Home", "supersecret")
+
+    assert status.ssid == "Home"
+    assert commands == [
+        [
+            "nmcli",
+            "device",
+            "wifi",
+            "connect",
+            "Home",
+            "password",
+            "supersecret",
+            "ifname",
+            "wlan0",
+        ]
+    ]


### PR DESCRIPTION
## Summary
- construct the zeroconf advertiser on a background thread when an asyncio event loop is already running to avoid EventLoopBlocked errors
- add a regression test that ensures zeroconf is instantiated off the active event loop

## Testing
- pytest tests/test_mdns.py


------
https://chatgpt.com/codex/tasks/task_e_68d7dde44a808332a1feec785aa8d525