### PR TITLE
Release I2C resources on shutdown

### DIFF
--- a/src/rev_cam/app.py
+++ b/src/rev_cam/app.py
@@ -398,6 +398,8 @@ def create_app(
         if camera:
             await camera.close()
         await battery_supervisor.aclose()
+        await run_in_threadpool(battery_monitor.close)
+        await run_in_threadpool(distance_monitor.close)
         if hasattr(wifi_manager, "close"):
             await run_in_threadpool(wifi_manager.close)
         await led_ring.aclose()


### PR DESCRIPTION
## Summary
- ensure the distance and battery monitors dispose of their sensors and I2C buses when errors occur or the app shuts down
- invoke the monitor cleanup during the FastAPI shutdown hook to avoid leaking hardware handles between restarts
- add unit tests that verify both monitors release their resources and can recreate sensors afterwards

## Testing
- pytest tests/test_distance.py tests/test_battery.py


------
https://chatgpt.com/codex/tasks/task_e_68d82078e7e88332901bdea2246dc46d