### PR TITLE
Persist Wi-Fi credentials across restarts

### DIFF
--- a/src/rev_cam/app.py
+++ b/src/rev_cam/app.py
@@ -23,7 +23,7 @@ from .reversing_aids import create_reversing_aids_overlay
 from .pipeline import FramePipeline
 from .streaming import MJPEGStreamer, WebRTCManager, encode_frame_to_jpeg
 from .version import APP_VERSION
-from .wifi import WiFiError, WiFiManager
+from .wifi import WiFiCredentialStore, WiFiError, WiFiManager
 
 STATIC_DIR = Path(__file__).resolve().parent / "static"
 
@@ -139,7 +139,8 @@ def create_app(
 
     logger = logging.getLogger(__name__)
 
-    config_manager = ConfigManager(Path(config_path))
+    config_path = Path(config_path)
+    config_manager = ConfigManager(config_path)
 
     CALIBRATION_OFFSET_LIMIT = 5.0
     CALIBRATION_SCALE_MIN = 0.5
@@ -192,7 +193,9 @@ def create_app(
         i2c_bus=i2c_bus_override,
         calibration=config_manager.get_distance_calibration(),
     )
-    wifi_manager = wifi_manager or WiFiManager()
+    if wifi_manager is None:
+        credentials_path = config_path.with_name("wifi_credentials.json")
+        wifi_manager = WiFiManager(credential_store=WiFiCredentialStore(credentials_path))
 
     pipeline = FramePipeline(lambda: config_manager.get_orientation())
     pipeline.add_overlay(


### PR DESCRIPTION
## Summary
- add a credential store that persists hotspot and network passwords for the Wi-Fi manager
- have the FastAPI app wire the Wi-Fi manager to the on-disk store and reuse stored passwords when reconnecting
- extend Wi-Fi tests to cover credential persistence across restarts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8fa3648e883328c906493f3802d65