### PR TITLE
Add configurable distance geometry UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,13 +248,15 @@ mounted on your vehicle. The mounting geometry card lets you enter the sensor's
 height above the ground (default 1.5&nbsp;m) and the angle away from vertical
 (default 40°). RevCam stores these values in `config.json`, displays a diagram of
 the installation, and uses basic trigonometry to calculate the projected ground
-distance (the point where the sensor's line meets the road) as
-`height × tan(angle)`. The projected distance is shown alongside live readings
-and is available through the `/api/distance` and `/api/distance/geometry`
-endpoints. A Google-style toggle on the card lets you choose whether the
-dashboard, overlap overlay, and development logs report the raw sensor
-measurement or the projected ground distance. The preference is persisted in
-`config.json` so the chosen mode survives reboots.
+distance (the point where the sensor's line meets the road). When live distance
+data is available the horizontal component of the reading is used,
+`distance × sin(angle)`, and the stored mounting geometry provides the fallback
+`height × tan(angle)` shown on the geometry card. The projected distance is
+reported alongside live readings and is available through the `/api/distance`
+and `/api/distance/geometry` endpoints. A Google-style toggle on the card lets
+you choose whether the dashboard, overlap overlay, and development logs report
+the raw sensor measurement or the projected ground distance. The preference is
+persisted in `config.json` so the chosen mode survives reboots.
 
 ### Development machine installation
 

--- a/README.md
+++ b/README.md
@@ -241,6 +241,18 @@ alternate adapter. The installation helper installs it automatically when
 possible and otherwise reports a warning so you can install it manually prior to
 changing the bus number.
 
+#### Configuring mounting geometry
+
+Open the **Distance** tab in the settings UI to record how the VL53L1X is
+mounted on your vehicle. The mounting geometry card lets you enter the sensor's
+height above the ground (default 1.5&nbsp;m) and the angle away from vertical
+(default 40°). RevCam stores these values in `config.json`, displays a diagram of
+the installation, and uses basic trigonometry to calculate the projected ground
+distance (the point where the sensor's line meets the road) as
+`height × tan(angle)`. The projected distance is shown alongside live readings
+and is available through the `/api/distance` and `/api/distance/geometry`
+endpoints.
+
 ### Development machine installation
 
 For local development on non-Pi machines a regular virtual environment is

--- a/README.md
+++ b/README.md
@@ -251,7 +251,10 @@ the installation, and uses basic trigonometry to calculate the projected ground
 distance (the point where the sensor's line meets the road) as
 `height × tan(angle)`. The projected distance is shown alongside live readings
 and is available through the `/api/distance` and `/api/distance/geometry`
-endpoints.
+endpoints. A Google-style toggle on the card lets you choose whether the
+dashboard, overlap overlay, and development logs report the raw sensor
+measurement or the projected ground distance. The preference is persisted in
+`config.json` so the chosen mode survives reboots.
 
 ### Development machine installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rev-cam"
-version = "0.2.9"
+version = "0.2.10"
 description = "Low-latency Raspberry Pi reversing camera MJPEG server"
 readme = "README.md"
 authors = [{name = "RevCam Team"}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rev-cam"
-version = "0.2.8"
+version = "0.2.9"
 description = "Low-latency Raspberry Pi reversing camera MJPEG server"
 readme = "README.md"
 authors = [{name = "RevCam Team"}]

--- a/src/rev_cam/app.py
+++ b/src/rev_cam/app.py
@@ -41,9 +41,15 @@ def _load_static(name: str) -> str:
     return path.read_text(encoding="utf-8")
 
 
-def _project_ground_distance(mounting: DistanceMounting) -> float | None:
+def _project_ground_distance(
+    mounting: DistanceMounting, measured_distance: float | None = None
+) -> float | None:
     angle_rad = math.radians(mounting.mount_angle_deg)
-    projection = mounting.mount_height_m * math.tan(angle_rad)
+    projection: float
+    if measured_distance is not None and math.isfinite(measured_distance):
+        projection = float(measured_distance) * math.sin(angle_rad)
+    else:
+        projection = mounting.mount_height_m * math.tan(angle_rad)
     return projection if math.isfinite(projection) else None
 
 
@@ -278,7 +284,7 @@ def create_app(
             mounting = config_manager.get_distance_mounting()
         if use_projected is None:
             use_projected = config_manager.get_distance_use_projected()
-        projection = _project_ground_distance(mounting)
+        projection = _project_ground_distance(mounting, reading.distance_m)
         display_distance = _select_display_distance(
             reading.distance_m,
             projection,

--- a/src/rev_cam/config.py
+++ b/src/rev_cam/config.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import math
 from dataclasses import dataclass, asdict
 from pathlib import Path
 from threading import Lock
@@ -28,6 +29,36 @@ from .distance import (
 )
 
 DEFAULT_DISTANCE_OVERLAY_ENABLED = True
+
+
+@dataclass(frozen=True, slots=True)
+class DistanceMounting:
+    """Represents the physical installation of the distance sensor."""
+
+    mount_height_m: float = 1.5
+    mount_angle_deg: float = 40.0
+
+    def __post_init__(self) -> None:
+        try:
+            height = float(self.mount_height_m)
+            angle = float(self.mount_angle_deg)
+        except (TypeError, ValueError) as exc:  # pragma: no cover - defensive branch
+            raise ValueError("Distance mounting values must be numeric") from exc
+        if not math.isfinite(height) or height <= 0:
+            raise ValueError("Mount height must be a positive finite value")
+        if not math.isfinite(angle) or angle < 0 or angle >= 90:
+            raise ValueError("Mount angle must be between 0 and 90 degrees")
+        object.__setattr__(self, "mount_height_m", height)
+        object.__setattr__(self, "mount_angle_deg", angle)
+
+    def to_dict(self) -> dict[str, float]:
+        return {
+            "mount_height_m": float(self.mount_height_m),
+            "mount_angle_deg": float(self.mount_angle_deg),
+        }
+
+
+DEFAULT_DISTANCE_MOUNTING = DistanceMounting()
 
 
 @dataclass(frozen=True, slots=True)
@@ -440,6 +471,34 @@ def _parse_distance_calibration(
     return DistanceCalibration(offset, scale)
 
 
+def _parse_distance_mounting(
+    value: Any, *, default: DistanceMounting
+) -> DistanceMounting:
+    if value is None:
+        return default
+    if isinstance(value, DistanceMounting):
+        return DistanceMounting(value.mount_height_m, value.mount_angle_deg)
+    if isinstance(value, Mapping):
+        payload = value.get("geometry") if "geometry" in value else value
+        if not isinstance(payload, Mapping):
+            raise ValueError("Distance geometry must provide 'mount_height_m' and 'mount_angle_deg'")
+        height_raw = payload.get("mount_height_m", payload.get("height", default.mount_height_m))
+        angle_raw = payload.get("mount_angle_deg", payload.get("angle", default.mount_angle_deg))
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        items = list(value)
+        if len(items) != 2:
+            raise ValueError("Distance geometry sequence must contain two values")
+        height_raw, angle_raw = items
+    else:
+        raise ValueError("Unsupported distance geometry value")
+    try:
+        height = float(height_raw)
+        angle = float(angle_raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Distance geometry values must be numeric") from exc
+    return DistanceMounting(height, angle)
+
+
 def _parse_distance_overlay_enabled(value: Any, *, default: bool) -> bool:
     if value is None:
         return default
@@ -533,6 +592,7 @@ class ConfigManager:
             self._distance_zones,
             self._distance_calibration,
             self._distance_overlay_enabled,
+            self._distance_mounting,
             self._battery_limits,
             self._battery_capacity,
             self._stream_settings,
@@ -564,6 +624,7 @@ class ConfigManager:
                 DEFAULT_DISTANCE_ZONES,
                 DEFAULT_DISTANCE_CALIBRATION,
                 DEFAULT_DISTANCE_OVERLAY_ENABLED,
+                DEFAULT_DISTANCE_MOUNTING,
                 DEFAULT_BATTERY_LIMITS,
                 DEFAULT_BATTERY_CAPACITY_MAH,
                 DEFAULT_STREAM_SETTINGS,
@@ -596,6 +657,9 @@ class ConfigManager:
             distance_overlay_enabled = _parse_distance_overlay_enabled(
                 distance_payload, default=DEFAULT_DISTANCE_OVERLAY_ENABLED
             )
+            distance_mounting = _parse_distance_mounting(
+                distance_payload, default=DEFAULT_DISTANCE_MOUNTING
+            )
 
             battery_payload = payload.get("battery")
             battery_limits = _parse_battery_limits(
@@ -622,6 +686,7 @@ class ConfigManager:
                 distance_zones,
                 distance_calibration,
                 distance_overlay_enabled,
+                distance_mounting,
                 battery_limits,
                 battery_capacity,
                 stream_settings,
@@ -639,6 +704,7 @@ class ConfigManager:
                 "zones": self._distance_zones.to_dict(),
                 "calibration": self._distance_calibration.to_dict(),
                 "overlay_enabled": self._distance_overlay_enabled,
+                "geometry": self._distance_mounting.to_dict(),
             },
             "battery": {
                 "limits": self._battery_limits.to_dict(),
@@ -724,6 +790,19 @@ class ConfigManager:
             self._save()
         return enabled
 
+    def get_distance_mounting(self) -> DistanceMounting:
+        with self._lock:
+            return self._distance_mounting
+
+    def set_distance_mounting(
+        self, data: Mapping[str, Any] | Sequence[object] | DistanceMounting
+    ) -> DistanceMounting:
+        mounting = _parse_distance_mounting(data, default=self._distance_mounting)
+        with self._lock:
+            self._distance_mounting = mounting
+            self._save()
+        return mounting
+
     def get_battery_limits(self) -> BatteryLimits:
         with self._lock:
             return self._battery_limits
@@ -784,4 +863,6 @@ __all__ = [
     "ReversingAidPoint",
     "generate_reversing_segments",
     "DEFAULT_REVERSING_AIDS",
+    "DistanceMounting",
+    "DEFAULT_DISTANCE_MOUNTING",
 ]

--- a/src/rev_cam/config.py
+++ b/src/rev_cam/config.py
@@ -611,6 +611,7 @@ class ConfigManager:
         DistanceZones,
         DistanceCalibration,
         bool,
+        DistanceMounting,
         BatteryLimits,
         int,
         StreamSettings,

--- a/src/rev_cam/distance.py
+++ b/src/rev_cam/distance.py
@@ -581,10 +581,26 @@ _ZONE_LABELS = {
     "unavailable": "N/A",
 }
 
+
+def _projected_distance_from_mounting(mounting) -> float | None:
+    if mounting is None:
+        return None
+    try:
+        height = float(getattr(mounting, "mount_height_m"))
+        angle = float(getattr(mounting, "mount_angle_deg"))
+    except (AttributeError, TypeError, ValueError):
+        return None
+    angle_rad = math.radians(angle)
+    projection = height * math.tan(angle_rad)
+    return projection if math.isfinite(projection) else None
+
 def create_distance_overlay(
     monitor: DistanceMonitor,
     zonedist_provider: Callable[[], DistanceZones],
     enabled_provider: Callable[[], bool] | None = None,
+    *,
+    geometry_provider: Callable[[], object] | None = None,
+    display_mode_provider: Callable[[], bool] | None = None,
 ):
     """Return an overlay function that renders the current distance reading."""
 
@@ -597,13 +613,41 @@ def create_distance_overlay(
             return frame
 
         zones = zonedist_provider()
-        zone = zones.classify(reading.distance_m)
-        return _render_distance_overlay(frame, reading, zone)
+        mounting = geometry_provider() if geometry_provider is not None else None
+        projection = _projected_distance_from_mounting(mounting)
+        use_projected = False
+        if display_mode_provider is not None:
+            try:
+                use_projected = bool(display_mode_provider())
+            except Exception:  # pragma: no cover - defensive guard
+                use_projected = False
+        if use_projected and projection is not None and math.isfinite(projection):
+            display_value = float(projection)
+        elif reading.distance_m is not None and math.isfinite(reading.distance_m):
+            display_value = float(reading.distance_m)
+        else:
+            display_value = None
+        zone_distance = display_value if display_value is not None else reading.distance_m
+        zone = zones.classify(zone_distance)
+        return _render_distance_overlay(
+            frame,
+            reading,
+            zone,
+            display_distance=display_value,
+            projected_mode=use_projected and display_value is not None,
+        )
 
     return _overlay
 
 
-def _render_distance_overlay(frame, reading: DistanceReading, zone: str | None):
+def _render_distance_overlay(
+    frame,
+    reading: DistanceReading,
+    zone: str | None,
+    *,
+    display_distance: float | None = None,
+    projected_mode: bool = False,
+):
     if _np is None or not isinstance(frame, _np.ndarray):  # pragma: no cover - optional guard
         return frame
 
@@ -615,8 +659,9 @@ def _render_distance_overlay(frame, reading: DistanceReading, zone: str | None):
     colour = _ZONE_COLOURS.get(zone_key, _ZONE_COLOURS["unavailable"])
     label = _ZONE_LABELS.get(zone_key, _ZONE_LABELS["unavailable"])
 
-    if reading.distance_m is not None and math.isfinite(reading.distance_m):
-        distance_text = f"{reading.distance_m:.1f} m"
+    value = display_distance if display_distance is not None else reading.distance_m
+    if value is not None and math.isfinite(value):
+        distance_text = f"{value:.1f} m"
     else:
         distance_text = "---"
 
@@ -628,6 +673,8 @@ def _render_distance_overlay(frame, reading: DistanceReading, zone: str | None):
         (distance_text, main_scale, 0.8),
         (label, secondary_scale, 0.55),
     ]
+    if projected_mode:
+        line_specs.append(("PROJECTED", secondary_scale, 0.45))
 
     measurements: list[tuple[int, int]] = []
     for text, scale, _ in line_specs:

--- a/src/rev_cam/distance.py
+++ b/src/rev_cam/distance.py
@@ -641,7 +641,6 @@ def create_distance_overlay(
             reading,
             zone,
             display_distance=display_value,
-            projected_mode=use_projected and display_value is not None,
         )
 
     return _overlay
@@ -653,7 +652,6 @@ def _render_distance_overlay(
     zone: str | None,
     *,
     display_distance: float | None = None,
-    projected_mode: bool = False,
 ):
     if _np is None or not isinstance(frame, _np.ndarray):  # pragma: no cover - optional guard
         return frame
@@ -680,8 +678,6 @@ def _render_distance_overlay(
         (distance_text, main_scale, 0.8),
         (label, secondary_scale, 0.55),
     ]
-    if projected_mode:
-        line_specs.append(("PROJECTED", secondary_scale, 0.45))
 
     measurements: list[tuple[int, int]] = []
     for text, scale, _ in line_specs:

--- a/src/rev_cam/distance.py
+++ b/src/rev_cam/distance.py
@@ -582,7 +582,7 @@ _ZONE_LABELS = {
 }
 
 
-def _projected_distance_from_mounting(mounting) -> float | None:
+def _projected_distance_from_mounting(mounting, measured_distance) -> float | None:
     if mounting is None:
         return None
     try:
@@ -591,7 +591,14 @@ def _projected_distance_from_mounting(mounting) -> float | None:
     except (AttributeError, TypeError, ValueError):
         return None
     angle_rad = math.radians(angle)
-    projection = height * math.tan(angle_rad)
+    projection: float
+    if measured_distance is not None and math.isfinite(measured_distance):
+        try:
+            projection = float(measured_distance) * math.sin(angle_rad)
+        except (TypeError, ValueError):
+            return None
+    else:
+        projection = height * math.tan(angle_rad)
     return projection if math.isfinite(projection) else None
 
 def create_distance_overlay(
@@ -614,7 +621,7 @@ def create_distance_overlay(
 
         zones = zonedist_provider()
         mounting = geometry_provider() if geometry_provider is not None else None
-        projection = _projected_distance_from_mounting(mounting)
+        projection = _projected_distance_from_mounting(mounting, reading.distance_m)
         use_projected = False
         if display_mode_provider is not None:
             try:

--- a/src/rev_cam/static/images/distance-diagram.svg
+++ b/src/rev_cam/static/images/distance-diagram.svg
@@ -38,7 +38,7 @@
     >
       Projected ground distance
     </text>
-    <text x="44" y="44" fill="#ffb347" font-family="Inter, sans-serif" font-size="16">θ</text>
+    <text x="36" y="44" fill="#ffb347" font-family="Inter, sans-serif" font-size="16">θ</text>
     <text
       x="190"
       y="178"

--- a/src/rev_cam/static/images/distance-diagram.svg
+++ b/src/rev_cam/static/images/distance-diagram.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 300" role="img" aria-labelledby="title desc">
+  <title id="title">Distance sensor mounting diagram</title>
+  <desc id="desc">Diagram showing a distance sensor mounted above the ground at height h and angled theta from vertical, forming a right triangle to the ground distance.</desc>
+  <defs>
+    <linearGradient id="groundGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#2d3142" />
+      <stop offset="100%" stop-color="#1f2230" />
+    </linearGradient>
+    <linearGradient id="skyGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#10131a" />
+      <stop offset="100%" stop-color="#181b26" />
+    </linearGradient>
+  </defs>
+  <rect width="480" height="300" fill="url(#skyGradient)" rx="16" ry="16" />
+  <rect y="232" width="480" height="68" fill="url(#groundGradient)" />
+  <g transform="translate(120,40)">
+    <path d="M0,192 L280,192" stroke="#5c637a" stroke-width="4" stroke-linecap="round" />
+    <path d="M0,0 L0,192" stroke="#5c637a" stroke-width="4" stroke-linecap="round" />
+    <path d="M0,0 L280,192" fill="rgba(88, 135, 255, 0.18)" stroke="#2f95ff" stroke-width="3" />
+    <circle cx="0" cy="0" r="10" fill="#0a84ff" />
+    <g transform="translate(-38,-20)">
+      <rect width="64" height="28" rx="6" ry="6" fill="#1f2636" stroke="#0a84ff" stroke-width="2" />
+      <text x="32" y="18" fill="#f5f7fb" font-family="Inter, sans-serif" font-size="14" text-anchor="middle">Sensor</text>
+    </g>
+    <path d="M-14,0 L-14,192" stroke="#8f9bb7" stroke-width="2" stroke-dasharray="6 6" />
+    <path d="M0,192 L0,204" stroke="#f5f7fb" stroke-width="2" />
+    <path d="M280,192 L280,204" stroke="#f5f7fb" stroke-width="2" />
+    <path d="M-12,192 L-24,204" stroke="#f5f7fb" stroke-width="2" />
+    <path d="M-12,0 L-24,12" stroke="#f5f7fb" stroke-width="2" />
+    <text x="-40" y="100" fill="#c8d1e5" font-family="Inter, sans-serif" font-size="16" transform="rotate(-90,-40,100)">h</text>
+    <text x="140" y="220" fill="#c8d1e5" font-family="Inter, sans-serif" font-size="16">Projected distance</text>
+    <path d="M32,32 A40 40 0 0 1 62,72" fill="none" stroke="#ff9f0a" stroke-width="3" />
+    <text x="70" y="76" fill="#ffb347" font-family="Inter, sans-serif" font-size="16">θ</text>
+    <text x="150" y="150" fill="#9fb7ff" font-family="Inter, sans-serif" font-size="16">Ground plane</text>
+  </g>
+</svg>

--- a/src/rev_cam/static/images/distance-diagram.svg
+++ b/src/rev_cam/static/images/distance-diagram.svg
@@ -38,13 +38,6 @@
     >
       Projected ground distance
     </text>
-    <path
-      d="M2,66 A78 78 0 0 1 74,44"
-      fill="none"
-      stroke="#ff9f0a"
-      stroke-width="3"
-      stroke-linecap="round"
-    />
     <text x="88" y="50" fill="#ffb347" font-family="Inter, sans-serif" font-size="16">θ</text>
     <text
       x="190"

--- a/src/rev_cam/static/images/distance-diagram.svg
+++ b/src/rev_cam/static/images/distance-diagram.svg
@@ -28,9 +28,33 @@
     <path d="M-12,192 L-24,204" stroke="#f5f7fb" stroke-width="2" />
     <path d="M-12,0 L-24,12" stroke="#f5f7fb" stroke-width="2" />
     <text x="-40" y="100" fill="#c8d1e5" font-family="Inter, sans-serif" font-size="16" transform="rotate(-90,-40,100)">h</text>
-    <text x="140" y="220" fill="#c8d1e5" font-family="Inter, sans-serif" font-size="16">Projected distance</text>
-    <path d="M32,32 A40 40 0 0 1 62,72" fill="none" stroke="#ff9f0a" stroke-width="3" />
-    <text x="70" y="76" fill="#ffb347" font-family="Inter, sans-serif" font-size="16">θ</text>
-    <text x="150" y="150" fill="#9fb7ff" font-family="Inter, sans-serif" font-size="16">Ground plane</text>
+    <text
+      x="150"
+      y="216"
+      fill="#c8d1e5"
+      font-family="Inter, sans-serif"
+      font-size="16"
+      text-anchor="middle"
+    >
+      Projected ground distance
+    </text>
+    <path
+      d="M2,66 A78 78 0 0 1 74,44"
+      fill="none"
+      stroke="#ff9f0a"
+      stroke-width="3"
+      stroke-linecap="round"
+    />
+    <text x="88" y="50" fill="#ffb347" font-family="Inter, sans-serif" font-size="16">θ</text>
+    <text
+      x="190"
+      y="178"
+      fill="#9fb7ff"
+      font-family="Inter, sans-serif"
+      font-size="16"
+      text-anchor="middle"
+    >
+      Ground plane
+    </text>
   </g>
 </svg>

--- a/src/rev_cam/static/images/distance-diagram.svg
+++ b/src/rev_cam/static/images/distance-diagram.svg
@@ -18,7 +18,7 @@
     <path d="M0,0 L0,192" stroke="#5c637a" stroke-width="4" stroke-linecap="round" />
     <path d="M0,0 L280,192" fill="rgba(88, 135, 255, 0.18)" stroke="#2f95ff" stroke-width="3" />
     <circle cx="0" cy="0" r="10" fill="#0a84ff" />
-    <g transform="translate(-38,-20)">
+    <g transform="translate(-38,-32)">
       <rect width="64" height="28" rx="6" ry="6" fill="#1f2636" stroke="#0a84ff" stroke-width="2" />
       <text x="32" y="18" fill="#f5f7fb" font-family="Inter, sans-serif" font-size="14" text-anchor="middle">Sensor</text>
     </g>
@@ -38,7 +38,7 @@
     >
       Projected ground distance
     </text>
-    <text x="88" y="50" fill="#ffb347" font-family="Inter, sans-serif" font-size="16">θ</text>
+    <text x="44" y="44" fill="#ffb347" font-family="Inter, sans-serif" font-size="16">θ</text>
     <text
       x="190"
       y="178"

--- a/src/rev_cam/static/images/favicon.svg
+++ b/src/rev_cam/static/images/favicon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0a84ff" />
+      <stop offset="100%" stop-color="#38bdf8" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#g)" />
+  <path
+    fill="#f5f7fb"
+    d="M22 16h14c8.84 0 14 5.12 14 12 0 5.26-3.08 9.2-8.1 10.9L42 48h-8.4l-4.9-8.6H26V48h-6V16Zm12.8 16.6c3.54 0 5.7-2 5.7-4.6 0-2.9-2.12-4.6-5.7-4.6H26v9.2h8.8Z"
+  />
+</svg>

--- a/src/rev_cam/static/index.html
+++ b/src/rev_cam/static/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>RevCam Live View</title>
+    <link rel="icon" type="image/svg+xml" href="images/favicon.svg" />
     <style>
       :root {
         color-scheme: dark;

--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -1206,6 +1206,11 @@
         display: grid;
         gap: var(--stack-gap);
       }
+      .distance-geometry-controls {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-xl);
+      }
       .distance-geometry-form label {
         display: flex;
         flex-direction: column;
@@ -1231,6 +1236,91 @@
         font-size: 1.4rem;
         font-weight: 600;
         letter-spacing: -0.01em;
+      }
+      .distance-display-controls {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-sm);
+        padding: var(--stack-gap);
+        border-radius: var(--radius-md);
+        background: var(--surface-soft);
+        border: 1px solid var(--border-subtle);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+      }
+      .distance-display-mode {
+        font-weight: 600;
+        letter-spacing: 0.02em;
+      }
+      .distance-display-mode[data-mode="projected"] {
+        color: var(--accent);
+      }
+      .material-toggle-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-lg);
+        flex-wrap: wrap;
+      }
+      .material-switch {
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+        cursor: pointer;
+        min-width: 3rem;
+      }
+      .material-switch input {
+        position: absolute;
+        opacity: 0;
+        width: 0;
+        height: 0;
+      }
+      .material-track {
+        position: relative;
+        width: 3rem;
+        height: 1.6rem;
+        border-radius: var(--radius-pill);
+        background: rgba(255, 255, 255, 0.08);
+        box-shadow: inset 0 0 0 1px var(--border-subtle);
+        transition: background var(--transition), box-shadow var(--transition);
+        display: inline-flex;
+        align-items: center;
+      }
+      .material-thumb {
+        position: absolute;
+        top: 50%;
+        left: 0.18rem;
+        transform: translate(0, -50%);
+        width: 1.25rem;
+        height: 1.25rem;
+        border-radius: 50%;
+        background: var(--text-primary);
+        box-shadow: 0 6px 14px rgba(10, 132, 255, 0.28);
+        transition: transform var(--transition), background var(--transition), width var(--transition);
+      }
+      .material-switch input:checked + .material-track {
+        background: var(--accent);
+        box-shadow: inset 0 0 0 1px var(--accent-active), 0 6px 16px rgba(10, 132, 255, 0.25);
+      }
+      .material-switch input:checked + .material-track .material-thumb {
+        transform: translate(1.55rem, -50%);
+        background: var(--text-on-accent);
+        box-shadow: 0 6px 16px rgba(10, 132, 255, 0.35);
+      }
+      .material-switch input:focus-visible + .material-track {
+        outline: none;
+        box-shadow: inset 0 0 0 1px var(--accent-active), 0 0 0 4px var(--accent-soft);
+      }
+      .material-switch input:active + .material-track .material-thumb {
+        width: 1.35rem;
+      }
+      .material-switch input:disabled + .material-track {
+        opacity: 0.5;
+        cursor: not-allowed;
+        box-shadow: inset 0 0 0 1px var(--border-muted);
+      }
+      .material-switch input:disabled + .material-track .material-thumb {
+        background: var(--text-muted);
+        box-shadow: none;
       }
       .zone-badge.clear {
         color: var(--success);
@@ -1670,38 +1760,80 @@
                   <em>h × tan&nbsp;θ</em>.
                 </figcaption>
               </figure>
-              <form id="distance-geometry-form" class="distance-geometry-form">
-                <label>
-                  Mount height (m)
-                  <input
-                    type="number"
-                    name="mount_height_m"
-                    min="0.1"
-                    max="5"
-                    step="0.01"
-                    inputmode="decimal"
-                  />
-                </label>
-                <label>
-                  Mount angle (° from vertical)
-                  <input
-                    type="number"
-                    name="mount_angle_deg"
-                    min="0"
-                    max="89"
-                    step="0.1"
-                    inputmode="decimal"
-                  />
-                </label>
-                <div class="distance-geometry-result">
-                  <span class="distance-geometry-result-label">Projected ground distance</span>
-                  <span class="distance-geometry-result-value" id="distance-projected-value">—</span>
+              <div class="distance-geometry-controls">
+                <form id="distance-geometry-form" class="distance-geometry-form">
+                  <label>
+                    Mount height (m)
+                    <input
+                      type="number"
+                      name="mount_height_m"
+                      min="0.1"
+                      max="5"
+                      step="0.01"
+                      inputmode="decimal"
+                    />
+                  </label>
+                  <label>
+                    Mount angle (° from vertical)
+                    <input
+                      type="number"
+                      name="mount_angle_deg"
+                      min="0"
+                      max="89"
+                      step="0.1"
+                      inputmode="decimal"
+                    />
+                  </label>
+                  <div class="distance-geometry-result">
+                    <span class="distance-geometry-result-label">Projected ground distance</span>
+                    <span class="distance-geometry-result-value" id="distance-projected-value">—</span>
+                  </div>
+                  <div class="form-actions">
+                    <button type="submit">Save geometry</button>
+                    <div id="distance-geometry-status" class="muted helper-text status-text"></div>
+                  </div>
+                </form>
+                <div class="distance-display-controls">
+                  <div
+                    class="distance-display-mode"
+                    id="distance-display-mode"
+                    data-mode="actual"
+                    role="status"
+                    aria-live="polite"
+                  >
+                    Display mode: Actual sensor distance
+                  </div>
+                  <div class="material-toggle-row">
+                    <div class="toggle-text" id="distance-display-text">
+                      <h3 id="distance-display-heading">Projected distance display</h3>
+                      <p id="distance-display-description" class="muted helper-text">
+                        Show the projected ground distance instead of the raw sensor measurement across the
+                        settings, overlap, and development views.
+                      </p>
+                    </div>
+                    <label
+                      class="material-switch"
+                      aria-labelledby="distance-display-heading"
+                      aria-describedby="distance-display-description"
+                    >
+                      <input
+                        type="checkbox"
+                        id="distance-display-toggle"
+                        aria-describedby="distance-display-description"
+                      />
+                      <span class="material-track" aria-hidden="true">
+                        <span class="material-thumb"></span>
+                      </span>
+                    </label>
+                  </div>
+                  <p
+                    id="distance-display-status"
+                    class="muted helper-text status-text"
+                    role="status"
+                    aria-live="polite"
+                  ></p>
                 </div>
-                <div class="form-actions">
-                  <button type="submit">Save geometry</button>
-                  <div id="distance-geometry-status" class="muted helper-text status-text"></div>
-                </div>
-              </form>
+              </div>
             </div>
           </section>
 
@@ -2383,6 +2515,9 @@
       const distanceRefreshButton = document.getElementById("distance-refresh");
       const distanceOverlayToggle = document.getElementById("distance-overlay-toggle");
       const distanceOverlayStatus = document.getElementById("distance-overlay-status");
+      const distanceDisplayToggle = document.getElementById("distance-display-toggle");
+      const distanceDisplayStatus = document.getElementById("distance-display-status");
+      const distanceDisplayMode = document.getElementById("distance-display-mode");
       const distanceGeometryForm = document.getElementById("distance-geometry-form");
       const distanceGeometryStatus = document.getElementById("distance-geometry-status");
       const distanceGeometrySubmit = distanceGeometryForm
@@ -2416,6 +2551,7 @@
       let distanceLoading = false;
       let distanceCalibrationStatusTimer = null;
       let distanceOverlayStatusTimer = null;
+      let distanceDisplayStatusTimer = null;
       let distanceGeometryStatusTimer = null;
       let distanceGeometrySaving = false;
       const developmentToggle = document.getElementById("development-toggle");
@@ -3688,6 +3824,28 @@
         }
       }
 
+      function setDistanceDisplayStatus(message, options = {}) {
+        if (!distanceDisplayStatus) {
+          return;
+        }
+        if (distanceDisplayStatusTimer) {
+          window.clearTimeout(distanceDisplayStatusTimer);
+          distanceDisplayStatusTimer = null;
+        }
+        distanceDisplayStatus.textContent = message || "";
+        if (message && options.persistent !== true) {
+          distanceDisplayStatusTimer = window.setTimeout(() => {
+            if (
+              distanceDisplayStatus &&
+              distanceDisplayStatus.textContent === message
+            ) {
+              distanceDisplayStatus.textContent = "";
+            }
+            distanceDisplayStatusTimer = null;
+          }, 4000);
+        }
+      }
+
       function setDistanceGeometryStatus(message, options = {}) {
         if (!distanceGeometryStatus) {
           return;
@@ -3716,6 +3874,50 @@
         }
         const text = value.toFixed(fractionDigits);
         return text.replace(/(\.\d*?)0+$/, "$1").replace(/\.$/, "");
+      }
+
+      function getDisplayDistance(data) {
+        if (!data || typeof data !== "object") {
+          return null;
+        }
+        if (
+          typeof data.display_distance_m === "number" &&
+          Number.isFinite(data.display_distance_m)
+        ) {
+          return data.display_distance_m;
+        }
+        if (typeof data.distance_m === "number" && Number.isFinite(data.distance_m)) {
+          return data.distance_m;
+        }
+        return null;
+      }
+
+      function getDistanceModeLabel(data) {
+        const projected = data && data.use_projected_distance === true;
+        return projected ? "Projected distance" : "Actual distance";
+      }
+
+      function updateDistanceDisplayModeIndicator(useProjected) {
+        if (!distanceDisplayMode) {
+          return;
+        }
+        const active = useProjected === true;
+        distanceDisplayMode.dataset.mode = active ? "projected" : "actual";
+        const label = active ? "Projected ground distance" : "Actual sensor distance";
+        distanceDisplayMode.textContent = `Display mode: ${label}`;
+      }
+
+      function updateDistanceDisplayToggle(enabled, options = {}) {
+        if (!(distanceDisplayToggle instanceof HTMLInputElement)) {
+          return;
+        }
+        const shouldForce = options.forceUpdate === true;
+        if (!shouldForce && distanceDisplayToggle.dataset.userToggled === "true") {
+          return;
+        }
+        const desired = enabled === true;
+        distanceDisplayToggle.checked = desired;
+        distanceDisplayToggle.dataset.serverValue = desired ? "true" : "false";
       }
 
       function updateDistanceCalibrationInputs(calibration, forceUpdate = false) {
@@ -3813,10 +4015,22 @@
           distanceSummary.textContent = fallback;
           return;
         }
+        const displayValue = getDisplayDistance(data);
         const zoneKey =
           typeof data.zone === "string" ? data.zone.toLowerCase() : "clear";
         const label = DISTANCE_ZONE_LABELS[zoneKey] || DISTANCE_ZONE_LABELS.clear;
-        distanceSummary.textContent = `${formatDistance(data.distance_m)} • ${label}`;
+        const parts = [];
+        if (displayValue !== null) {
+          parts.push(formatDistance(displayValue));
+        } else {
+          parts.push("—");
+        }
+        parts.push(label);
+        const modeLabel = getDistanceModeLabel(data);
+        if (modeLabel) {
+          parts.push(modeLabel);
+        }
+        distanceSummary.textContent = parts.join(" • ");
       }
 
       function updateDistanceOverlayToggle(enabled, options = {}) {
@@ -3833,14 +4047,11 @@
       }
 
       function applyDistanceData(data, options = {}) {
+        const displayValue = getDisplayDistance(data);
+        const useProjected = data && data.use_projected_distance === true;
         if (distanceValue) {
-          if (
-            data &&
-            data.available === true &&
-            typeof data.distance_m === "number" &&
-            Number.isFinite(data.distance_m)
-          ) {
-            distanceValue.textContent = formatDistance(data.distance_m);
+          if (displayValue !== null && Number.isFinite(displayValue)) {
+            distanceValue.textContent = formatDistance(displayValue);
           } else {
             distanceValue.textContent = "—";
           }
@@ -3870,6 +4081,13 @@
             ? data.projected_distance_m
             : null;
         updateProjectedDistanceDisplay(projected);
+        updateDistanceDisplayModeIndicator(useProjected);
+        updateDistanceDisplayToggle(useProjected, {
+          forceUpdate:
+            options.updateInputs === true ||
+            options.updateCalibration === true ||
+            options.updateGeometry === true,
+        });
         if (distanceOverlayToggle) {
           const enabled = data && data.overlay_enabled === true;
           const forceUpdate = options.updateInputs === true || options.updateCalibration === true;
@@ -3938,6 +4156,8 @@
           typeof data.distance_m === "number" && Number.isFinite(data.distance_m)
             ? data.distance_m
             : null;
+        const displayValue = getDisplayDistance(data);
+        const modeLabel = getDistanceModeLabel(data);
         const available = data && data.available === true;
         const zoneKey =
           data && typeof data.zone === "string" && data.zone.trim().length > 0
@@ -3951,6 +4171,8 @@
         const signature = JSON.stringify({
           raw: rawValue !== null ? Number(rawValue.toFixed(4)) : null,
           filtered: filteredValue !== null ? Number(filteredValue.toFixed(4)) : null,
+          display: displayValue !== null ? Number(displayValue.toFixed(4)) : null,
+          mode: modeLabel,
           available,
           zone: zoneKey,
           timestamp: timestampValue !== null ? Number(timestampValue.toFixed(3)) : null,
@@ -4004,6 +4226,11 @@
         }
         if (filteredValue !== null) {
           parts.push(`Filtered: ${formatDistance(filteredValue)}`);
+        }
+        if (modeLabel) {
+          const displayText =
+            displayValue !== null ? formatDistance(displayValue) : "unavailable";
+          parts.push(`${modeLabel}: ${displayText}`);
         }
         parts.push(available ? "Sensor available" : "Sensor unavailable");
         valuesElement.textContent = parts.join(" • ");
@@ -4858,6 +5085,61 @@
       if (developmentDistanceClear) {
         developmentDistanceClear.addEventListener("click", () => {
           clearDevelopmentDistanceLog();
+        });
+      }
+
+      if (distanceDisplayToggle instanceof HTMLInputElement) {
+        distanceDisplayToggle.dataset.serverValue = distanceDisplayToggle.checked
+          ? "true"
+          : "false";
+        distanceDisplayToggle.addEventListener("change", async () => {
+          if (!(distanceDisplayToggle instanceof HTMLInputElement)) {
+            return;
+          }
+          const previous = distanceDisplayToggle.dataset.serverValue === "true";
+          const desired = distanceDisplayToggle.checked;
+          distanceDisplayToggle.dataset.userToggled = "true";
+          distanceDisplayToggle.disabled = true;
+          setDistanceDisplayStatus("Updating display mode…", { persistent: true });
+          try {
+            const response = await fetch("/api/distance/display", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ use_projected_distance: desired }),
+            });
+            if (!response.ok) {
+              let errorDetail = "Unable to update display mode.";
+              try {
+                const errorData = await response.json();
+                if (errorData && typeof errorData.detail === "string") {
+                  errorDetail = errorData.detail;
+                }
+              } catch (err) {
+                console.error(err);
+              }
+              throw new Error(errorDetail);
+            }
+            const result = await response.json();
+            applyDistanceData(result);
+            const saved = result && result.use_projected_distance === true;
+            updateDistanceDisplayToggle(saved, { forceUpdate: true });
+            setDistanceDisplayStatus(
+              saved
+                ? "Showing projected ground distance"
+                : "Showing actual sensor distance",
+            );
+          } catch (error) {
+            console.error(error);
+            updateDistanceDisplayToggle(previous, { forceUpdate: true });
+            const message =
+              error && typeof error.message === "string" && error.message
+                ? error.message
+                : "Unable to update display mode.";
+            setDistanceDisplayStatus(message, { persistent: true });
+          } finally {
+            distanceDisplayToggle.disabled = false;
+            delete distanceDisplayToggle.dataset.userToggled;
+          }
         });
       }
 

--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>RevCam Settings</title>
+    <link rel="icon" type="image/svg+xml" href="images/favicon.svg" />
     <style>
       :root {
         color-scheme: dark;
@@ -2605,6 +2606,7 @@
               if (distanceGeometryStatus) {
                 distanceGeometryStatus.textContent = "";
               }
+              refreshProjectedDistanceFromGeometry();
             });
           }
         }
@@ -3987,6 +3989,56 @@
         }
       }
 
+      function computeProjectedDistanceFromGeometry(geometry) {
+        if (!geometry || typeof geometry !== "object") {
+          return null;
+        }
+        const heightValue =
+          typeof geometry.mount_height_m === "number"
+            ? geometry.mount_height_m
+            : Number.parseFloat(geometry.mount_height_m);
+        const angleValue =
+          typeof geometry.mount_angle_deg === "number"
+            ? geometry.mount_angle_deg
+            : Number.parseFloat(geometry.mount_angle_deg);
+        if (!Number.isFinite(heightValue) || !Number.isFinite(angleValue)) {
+          return null;
+        }
+        const angleRadians = (angleValue * Math.PI) / 180;
+        const tangent = Math.tan(angleRadians);
+        if (!Number.isFinite(tangent)) {
+          return null;
+        }
+        const projection = heightValue * tangent;
+        return Number.isFinite(projection) ? projection : null;
+      }
+
+      function getDistanceGeometryInputValues() {
+        if (!distanceGeometryInputs) {
+          return null;
+        }
+        const heightInput = distanceGeometryInputs.height;
+        const angleInput = distanceGeometryInputs.angle;
+        if (!(heightInput instanceof HTMLInputElement) || !(angleInput instanceof HTMLInputElement)) {
+          return null;
+        }
+        const height = Number.parseFloat(heightInput.value);
+        const angle = Number.parseFloat(angleInput.value);
+        if (!Number.isFinite(height) || !Number.isFinite(angle)) {
+          return null;
+        }
+        return { mount_height_m: height, mount_angle_deg: angle };
+      }
+
+      function refreshProjectedDistanceFromGeometry(sourceGeometry = null) {
+        let candidate = computeProjectedDistanceFromGeometry(sourceGeometry);
+        if (candidate === null) {
+          const inputGeometry = getDistanceGeometryInputValues();
+          candidate = computeProjectedDistanceFromGeometry(inputGeometry);
+        }
+        updateProjectedDistanceDisplay(candidate);
+      }
+
       function updateProjectedDistanceDisplay(value) {
         if (!distanceProjectedValue) {
           return;
@@ -4075,12 +4127,8 @@
           const forceUpdate = options.updateGeometry === true;
           updateDistanceGeometryInputs(data.geometry, forceUpdate);
         }
-        const projected =
-          data && typeof data.projected_distance_m === "number" &&
-          Number.isFinite(data.projected_distance_m)
-            ? data.projected_distance_m
-            : null;
-        updateProjectedDistanceDisplay(projected);
+        const geometryForDisplay = data && data.geometry ? data.geometry : null;
+        refreshProjectedDistanceFromGeometry(geometryForDisplay);
         updateDistanceDisplayModeIndicator(useProjected);
         updateDistanceDisplayToggle(useProjected, {
           forceUpdate:

--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -1176,6 +1176,62 @@
         letter-spacing: 0.08em;
         text-transform: uppercase;
       }
+      .distance-geometry-layout {
+        display: grid;
+        gap: var(--stack-gap-lg);
+        align-items: start;
+      }
+      @media (min-width: 900px) {
+        .distance-geometry-layout {
+          grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+        }
+      }
+      .distance-geometry-figure {
+        margin: 0;
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-sm);
+        align-items: center;
+        text-align: center;
+      }
+      .distance-geometry-figure img {
+        max-width: 100%;
+        height: auto;
+        border-radius: var(--radius-md);
+        background: var(--surface-muted);
+        border: 1px solid var(--border-subtle);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+      }
+      .distance-geometry-form {
+        display: grid;
+        gap: var(--stack-gap);
+      }
+      .distance-geometry-form label {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-sm);
+        margin: 0;
+      }
+      .distance-geometry-result {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-xs);
+        padding: var(--stack-gap);
+        border-radius: var(--radius-md);
+        background: var(--surface-soft);
+        border: 1px solid var(--border-muted);
+      }
+      .distance-geometry-result-label {
+        font-size: 0.85rem;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: var(--text-muted);
+      }
+      .distance-geometry-result-value {
+        font-size: 1.4rem;
+        font-weight: 600;
+        letter-spacing: -0.01em;
+      }
       .zone-badge.clear {
         color: var(--success);
         background: var(--success-soft);
@@ -1594,6 +1650,59 @@
               role="status"
               aria-live="polite"
             ></p>
+          </section>
+
+          <section class="card distance-geometry-card">
+            <h2>Mounting geometry</h2>
+            <p class="muted helper-text">
+              Configure the sensor height and tilt to calculate the projected ground distance using
+              basic trigonometry.
+            </p>
+            <div class="distance-geometry-layout">
+              <figure class="distance-geometry-figure">
+                <img
+                  src="images/distance-diagram.svg"
+                  alt="Diagram showing the sensor mounted above the ground with labelled height and projected distance"
+                />
+                <figcaption class="muted helper-text">
+                  The distance sensor is mounted height <em>h</em> above the ground and angled
+                  <em>θ</em> from vertical, producing a ground distance of
+                  <em>h × tan&nbsp;θ</em>.
+                </figcaption>
+              </figure>
+              <form id="distance-geometry-form" class="distance-geometry-form">
+                <label>
+                  Mount height (m)
+                  <input
+                    type="number"
+                    name="mount_height_m"
+                    min="0.1"
+                    max="5"
+                    step="0.01"
+                    inputmode="decimal"
+                  />
+                </label>
+                <label>
+                  Mount angle (° from vertical)
+                  <input
+                    type="number"
+                    name="mount_angle_deg"
+                    min="0"
+                    max="89"
+                    step="0.1"
+                    inputmode="decimal"
+                  />
+                </label>
+                <div class="distance-geometry-result">
+                  <span class="distance-geometry-result-label">Projected ground distance</span>
+                  <span class="distance-geometry-result-value" id="distance-projected-value">—</span>
+                </div>
+                <div class="form-actions">
+                  <button type="submit">Save geometry</button>
+                  <div id="distance-geometry-status" class="muted helper-text status-text"></div>
+                </div>
+              </form>
+            </div>
           </section>
 
           <form id="distance-calibration-form" class="card">
@@ -2274,6 +2383,18 @@
       const distanceRefreshButton = document.getElementById("distance-refresh");
       const distanceOverlayToggle = document.getElementById("distance-overlay-toggle");
       const distanceOverlayStatus = document.getElementById("distance-overlay-status");
+      const distanceGeometryForm = document.getElementById("distance-geometry-form");
+      const distanceGeometryStatus = document.getElementById("distance-geometry-status");
+      const distanceGeometrySubmit = distanceGeometryForm
+        ? distanceGeometryForm.querySelector('button[type="submit"]')
+        : null;
+      const distanceProjectedValue = document.getElementById("distance-projected-value");
+      const distanceGeometryInputs = distanceGeometryForm
+        ? {
+            height: distanceGeometryForm.querySelector('input[name="mount_height_m"]'),
+            angle: distanceGeometryForm.querySelector('input[name="mount_angle_deg"]'),
+          }
+        : null;
       const distanceZonesForm = document.getElementById("distance-zones-form");
       const distanceZonesStatus = document.getElementById("distance-zones-status");
       const distanceInputs = distanceZonesForm
@@ -2295,6 +2416,8 @@
       let distanceLoading = false;
       let distanceCalibrationStatusTimer = null;
       let distanceOverlayStatusTimer = null;
+      let distanceGeometryStatusTimer = null;
+      let distanceGeometrySaving = false;
       const developmentToggle = document.getElementById("development-toggle");
       const developmentStatus = document.getElementById("development-status");
       const developmentDistanceCard = document.getElementById("development-distance-card");
@@ -2333,6 +2456,18 @@
               input.dataset.userEdited = "true";
               if (distanceCalibrationStatus) {
                 distanceCalibrationStatus.textContent = "";
+              }
+            });
+          }
+        }
+      }
+      if (distanceGeometryInputs) {
+        for (const input of Object.values(distanceGeometryInputs)) {
+          if (input instanceof HTMLInputElement) {
+            input.addEventListener("input", () => {
+              input.dataset.userEdited = "true";
+              if (distanceGeometryStatus) {
+                distanceGeometryStatus.textContent = "";
               }
             });
           }
@@ -3553,6 +3688,28 @@
         }
       }
 
+      function setDistanceGeometryStatus(message, options = {}) {
+        if (!distanceGeometryStatus) {
+          return;
+        }
+        if (distanceGeometryStatusTimer) {
+          window.clearTimeout(distanceGeometryStatusTimer);
+          distanceGeometryStatusTimer = null;
+        }
+        distanceGeometryStatus.textContent = message || "";
+        if (message && options.persistent !== true) {
+          distanceGeometryStatusTimer = window.setTimeout(() => {
+            if (
+              distanceGeometryStatus &&
+              distanceGeometryStatus.textContent === message
+            ) {
+              distanceGeometryStatus.textContent = "";
+            }
+            distanceGeometryStatusTimer = null;
+          }, 4000);
+        }
+      }
+
       function formatCalibrationValue(value, fractionDigits) {
         if (typeof value !== "number" || !Number.isFinite(value)) {
           return "";
@@ -3603,6 +3760,39 @@
             input.value = "";
           }
           delete input.dataset.userEdited;
+        }
+      }
+
+      function updateDistanceGeometryInputs(geometry, forceUpdate = false) {
+        if (!distanceGeometryInputs || typeof geometry !== "object" || geometry === null) {
+          return;
+        }
+        const heightInput = distanceGeometryInputs.height;
+        const angleInput = distanceGeometryInputs.angle;
+        if (
+          heightInput instanceof HTMLInputElement &&
+          (forceUpdate || heightInput.dataset.userEdited !== "true")
+        ) {
+          heightInput.value = formatCalibrationValue(geometry.mount_height_m, 2);
+          delete heightInput.dataset.userEdited;
+        }
+        if (
+          angleInput instanceof HTMLInputElement &&
+          (forceUpdate || angleInput.dataset.userEdited !== "true")
+        ) {
+          angleInput.value = formatCalibrationValue(geometry.mount_angle_deg, 1);
+          delete angleInput.dataset.userEdited;
+        }
+      }
+
+      function updateProjectedDistanceDisplay(value) {
+        if (!distanceProjectedValue) {
+          return;
+        }
+        if (typeof value === "number" && Number.isFinite(value)) {
+          distanceProjectedValue.textContent = formatDistancePrecise(value, 2);
+        } else {
+          distanceProjectedValue.textContent = "—";
         }
       }
 
@@ -3670,6 +3860,16 @@
           const forceUpdate = options.updateCalibration === true || options.updateInputs === true;
           updateDistanceCalibrationInputs(data.calibration, forceUpdate);
         }
+        if (data && data.geometry) {
+          const forceUpdate = options.updateGeometry === true;
+          updateDistanceGeometryInputs(data.geometry, forceUpdate);
+        }
+        const projected =
+          data && typeof data.projected_distance_m === "number" &&
+          Number.isFinite(data.projected_distance_m)
+            ? data.projected_distance_m
+            : null;
+        updateProjectedDistanceDisplay(projected);
         if (distanceOverlayToggle) {
           const enabled = data && data.overlay_enabled === true;
           const forceUpdate = options.updateInputs === true || options.updateCalibration === true;
@@ -4811,6 +5011,69 @@
             setDistanceCalibrationStatus(message, { persistent: true });
           } finally {
             distanceZeroButton.disabled = false;
+          }
+        });
+      }
+
+      if (distanceGeometryForm) {
+        distanceGeometryForm.addEventListener("submit", async (event) => {
+          event.preventDefault();
+          if (!distanceGeometryInputs || distanceGeometrySaving) {
+            return;
+          }
+          const heightInput = distanceGeometryInputs.height;
+          const angleInput = distanceGeometryInputs.angle;
+          const height =
+            heightInput instanceof HTMLInputElement
+              ? Number.parseFloat(heightInput.value)
+              : Number.NaN;
+          const angle =
+            angleInput instanceof HTMLInputElement
+              ? Number.parseFloat(angleInput.value)
+              : Number.NaN;
+          if (!Number.isFinite(height) || height <= 0) {
+            setDistanceGeometryStatus("Enter a positive mount height.");
+            return;
+          }
+          if (!Number.isFinite(angle) || angle < 0 || angle >= 90) {
+            setDistanceGeometryStatus("Angle must be between 0° and 90°.");
+            return;
+          }
+          setDistanceGeometryStatus("Saving…", { persistent: true });
+          if (distanceGeometrySubmit instanceof HTMLButtonElement) {
+            distanceGeometrySubmit.disabled = true;
+          }
+          distanceGeometrySaving = true;
+          try {
+            const response = await fetch("/api/distance/geometry", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ mount_height_m: height, mount_angle_deg: angle }),
+            });
+            if (!response.ok) {
+              let detail = "Unable to save geometry.";
+              try {
+                const payload = await response.json();
+                if (payload && typeof payload.detail === "string") {
+                  detail = payload.detail;
+                }
+              } catch (err) {
+                console.error(err);
+              }
+              setDistanceGeometryStatus(detail, { persistent: true });
+              return;
+            }
+            const payload = await response.json();
+            applyDistanceData(payload, { updateGeometry: true });
+            setDistanceGeometryStatus("Geometry saved");
+          } catch (error) {
+            console.error(error);
+            setDistanceGeometryStatus("Unable to save geometry.", { persistent: true });
+          } finally {
+            distanceGeometrySaving = false;
+            if (distanceGeometrySubmit instanceof HTMLButtonElement) {
+              distanceGeometrySubmit.disabled = false;
+            }
           }
         });
       }

--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -4122,29 +4122,16 @@
           return;
         }
         const displayValue = getDisplayDistance(data);
-        const actualValue =
-          typeof data.distance_m === "number" && Number.isFinite(data.distance_m)
-            ? data.distance_m
-            : null;
-        const projectedValue =
-          typeof data.projected_distance_m === "number" &&
-          Number.isFinite(data.projected_distance_m)
-            ? data.projected_distance_m
-            : null;
         const zoneKey =
           typeof data.zone === "string" ? data.zone.toLowerCase() : "clear";
         const label = DISTANCE_ZONE_LABELS[zoneKey] || DISTANCE_ZONE_LABELS.clear;
         const parts = [];
-        const actualLabel = actualValue !== null ? formatDistance(actualValue) : "—";
-        const projectedLabel =
-          projectedValue !== null ? formatDistance(projectedValue) : "—";
-        parts.push(`Actual ${actualLabel}`);
-        parts.push(`Projected ${projectedLabel}`);
         if (displayValue !== null) {
-          const modeLabel = getDistanceModeLabel(data);
-          if (modeLabel) {
-            parts.push(`${modeLabel} shown`);
-          }
+          parts.push(formatDistance(displayValue));
+        }
+        const modeLabel = getDistanceModeLabel(data);
+        if (modeLabel) {
+          parts.push(`${modeLabel} shown`);
         }
         parts.push(label);
         distanceSummary.textContent = parts.join(" • ");

--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -1177,6 +1177,31 @@
         letter-spacing: 0.08em;
         text-transform: uppercase;
       }
+      .distance-details {
+        display: grid;
+        gap: var(--stack-gap);
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+        margin-top: var(--stack-gap);
+      }
+      .distance-details div {
+        background: var(--surface-soft);
+        padding: var(--stack-gap);
+        border-radius: var(--radius-md);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-xs);
+      }
+      .distance-details dt {
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--text-muted);
+      }
+      .distance-details dd {
+        margin: 0;
+        font-size: 1.1rem;
+        font-weight: 600;
+      }
       .distance-geometry-layout {
         display: grid;
         gap: var(--stack-gap-lg);
@@ -1704,6 +1729,16 @@
               <span class="distance-value" id="distance-value">—</span>
               <span class="distance-zone zone-badge unavailable" id="distance-zone">N/A</span>
             </div>
+            <dl class="distance-details" aria-live="polite">
+              <div>
+                <dt>Actual distance</dt>
+                <dd id="distance-actual-reading">—</dd>
+              </div>
+              <div>
+                <dt>Projected distance</dt>
+                <dd id="distance-projected-reading">—</dd>
+              </div>
+            </dl>
             <p id="distance-error" class="distance-error muted helper-text"></p>
             <div class="distance-actions">
               <button type="button" id="distance-refresh" class="secondary-button">
@@ -2512,6 +2547,8 @@
       const distanceSummary = document.getElementById("distance-summary");
       const distanceValue = document.getElementById("distance-value");
       const distanceZone = document.getElementById("distance-zone");
+      const distanceActualReadingValue = document.getElementById("distance-actual-reading");
+      const distanceProjectedReadingValue = document.getElementById("distance-projected-reading");
       const distanceError = document.getElementById("distance-error");
       const distanceRefreshButton = document.getElementById("distance-refresh");
       const distanceOverlayToggle = document.getElementById("distance-overlay-toggle");
@@ -4050,6 +4087,23 @@
         }
       }
 
+      function updateDistanceReadingDetails(actual, projected) {
+        if (distanceActualReadingValue) {
+          if (typeof actual === "number" && Number.isFinite(actual)) {
+            distanceActualReadingValue.textContent = formatDistancePrecise(actual, 2);
+          } else {
+            distanceActualReadingValue.textContent = "—";
+          }
+        }
+        if (distanceProjectedReadingValue) {
+          if (typeof projected === "number" && Number.isFinite(projected)) {
+            distanceProjectedReadingValue.textContent = formatDistancePrecise(projected, 2);
+          } else {
+            distanceProjectedReadingValue.textContent = "—";
+          }
+        }
+      }
+
       function updateDistanceSummary(data) {
         if (!distanceSummary) {
           return;
@@ -4068,20 +4122,31 @@
           return;
         }
         const displayValue = getDisplayDistance(data);
+        const actualValue =
+          typeof data.distance_m === "number" && Number.isFinite(data.distance_m)
+            ? data.distance_m
+            : null;
+        const projectedValue =
+          typeof data.projected_distance_m === "number" &&
+          Number.isFinite(data.projected_distance_m)
+            ? data.projected_distance_m
+            : null;
         const zoneKey =
           typeof data.zone === "string" ? data.zone.toLowerCase() : "clear";
         const label = DISTANCE_ZONE_LABELS[zoneKey] || DISTANCE_ZONE_LABELS.clear;
         const parts = [];
+        const actualLabel = actualValue !== null ? formatDistance(actualValue) : "—";
+        const projectedLabel =
+          projectedValue !== null ? formatDistance(projectedValue) : "—";
+        parts.push(`Actual ${actualLabel}`);
+        parts.push(`Projected ${projectedLabel}`);
         if (displayValue !== null) {
-          parts.push(formatDistance(displayValue));
-        } else {
-          parts.push("—");
+          const modeLabel = getDistanceModeLabel(data);
+          if (modeLabel) {
+            parts.push(`${modeLabel} shown`);
+          }
         }
         parts.push(label);
-        const modeLabel = getDistanceModeLabel(data);
-        if (modeLabel) {
-          parts.push(modeLabel);
-        }
         distanceSummary.textContent = parts.join(" • ");
       }
 
@@ -4101,6 +4166,16 @@
       function applyDistanceData(data, options = {}) {
         const displayValue = getDisplayDistance(data);
         const useProjected = data && data.use_projected_distance === true;
+        const actualValue =
+          data && typeof data.distance_m === "number" && Number.isFinite(data.distance_m)
+            ? data.distance_m
+            : null;
+        const projectedValue =
+          data &&
+          typeof data.projected_distance_m === "number" &&
+          Number.isFinite(data.projected_distance_m)
+            ? data.projected_distance_m
+            : null;
         if (distanceValue) {
           if (displayValue !== null && Number.isFinite(displayValue)) {
             distanceValue.textContent = formatDistance(displayValue);
@@ -4108,6 +4183,7 @@
             distanceValue.textContent = "—";
           }
         }
+        updateDistanceReadingDetails(actualValue, projectedValue);
         const zoneKey = data && typeof data.zone === "string" ? data.zone.toLowerCase() : null;
         updateDistanceBadge(zoneKey);
         updateDistanceSummary(data);

--- a/src/rev_cam/version.py
+++ b/src/rev_cam/version.py
@@ -1,6 +1,6 @@
 """Application version metadata."""
 
-APP_VERSION = "0.2.7"
+APP_VERSION = "0.2.9"
 """Human readable application version displayed in the UI."""
 
 __all__ = ["APP_VERSION"]

--- a/src/rev_cam/version.py
+++ b/src/rev_cam/version.py
@@ -1,6 +1,6 @@
 """Application version metadata."""
 
-APP_VERSION = "0.2.9"
+APP_VERSION = "0.2.10"
 """Human readable application version displayed in the UI."""
 
 __all__ = ["APP_VERSION"]

--- a/tests/test_app_distance.py
+++ b/tests/test_app_distance.py
@@ -230,3 +230,10 @@ def test_distance_geometry_update_persists(client: TestClient) -> None:
     geometry = config_data["distance"]["geometry"]
     assert geometry["mount_height_m"] == pytest.approx(1.9)
     assert geometry["mount_angle_deg"] == pytest.approx(32.0)
+
+
+def test_distance_diagram_image_served(client: TestClient) -> None:
+    response = client.get("/images/distance-diagram.svg")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("image/svg+xml")
+    assert "<svg" in response.text

--- a/tests/test_app_distance.py
+++ b/tests/test_app_distance.py
@@ -118,9 +118,8 @@ def test_distance_endpoint_returns_reading(client: TestClient) -> None:
     assert payload["geometry"]["mount_angle_deg"] == pytest.approx(
         DEFAULT_DISTANCE_MOUNTING.mount_angle_deg
     )
-    expected_projection = (
-        DEFAULT_DISTANCE_MOUNTING.mount_height_m
-        * math.tan(math.radians(DEFAULT_DISTANCE_MOUNTING.mount_angle_deg))
+    expected_projection = payload["distance_m"] * math.sin(
+        math.radians(DEFAULT_DISTANCE_MOUNTING.mount_angle_deg)
     )
     assert payload["projected_distance_m"] == pytest.approx(expected_projection)
 
@@ -229,9 +228,8 @@ def test_distance_display_mode_toggle(client: TestClient) -> None:
     assert response.status_code == 200
     payload = response.json()
     assert payload["use_projected_distance"] is True
-    expected_projection = (
-        DEFAULT_DISTANCE_MOUNTING.mount_height_m
-        * math.tan(math.radians(DEFAULT_DISTANCE_MOUNTING.mount_angle_deg))
+    expected_projection = payload["distance_m"] * math.sin(
+        math.radians(DEFAULT_DISTANCE_MOUNTING.mount_angle_deg)
     )
     assert payload["projected_distance_m"] == pytest.approx(expected_projection)
     assert payload["display_distance_m"] == pytest.approx(expected_projection)
@@ -242,7 +240,10 @@ def test_distance_display_mode_toggle(client: TestClient) -> None:
     assert follow_up.status_code == 200
     follow_payload = follow_up.json()
     assert follow_payload["use_projected_distance"] is True
-    assert follow_payload["display_distance_m"] == pytest.approx(expected_projection)
+    follow_expected = follow_payload["distance_m"] * math.sin(
+        math.radians(DEFAULT_DISTANCE_MOUNTING.mount_angle_deg)
+    )
+    assert follow_payload["display_distance_m"] == pytest.approx(follow_expected)
 
 
 def test_distance_geometry_update_persists(client: TestClient) -> None:
@@ -254,7 +255,7 @@ def test_distance_geometry_update_persists(client: TestClient) -> None:
     payload = response.json()
     assert payload["geometry"]["mount_height_m"] == pytest.approx(1.9)
     assert payload["geometry"]["mount_angle_deg"] == pytest.approx(32.0)
-    expected_projection = 1.9 * math.tan(math.radians(32.0))
+    expected_projection = payload["distance_m"] * math.sin(math.radians(32.0))
     assert payload["projected_distance_m"] == pytest.approx(expected_projection)
     config_data = json.loads(Path(client.config_path).read_text())
     geometry = config_data["distance"]["geometry"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,6 +17,7 @@ from rev_cam.config import (
     DEFAULT_CAMERA_CHOICE,
     DEFAULT_REVERSING_AIDS,
     DEFAULT_DISTANCE_MOUNTING,
+    DEFAULT_DISTANCE_USE_PROJECTED,
 )
 from rev_cam.distance import DistanceCalibration
 
@@ -93,6 +94,20 @@ def test_default_distance_mounting(tmp_path: Path) -> None:
     assert isinstance(mounting, DistanceMounting)
     assert mounting.mount_height_m == pytest.approx(DEFAULT_DISTANCE_MOUNTING.mount_height_m)
     assert mounting.mount_angle_deg == pytest.approx(DEFAULT_DISTANCE_MOUNTING.mount_angle_deg)
+
+
+def test_default_distance_display_mode(tmp_path: Path) -> None:
+    manager = ConfigManager(tmp_path / "config.json")
+    assert manager.get_distance_use_projected() is DEFAULT_DISTANCE_USE_PROJECTED
+
+
+def test_distance_display_mode_persistence(tmp_path: Path) -> None:
+    config_file = tmp_path / "config.json"
+    manager = ConfigManager(config_file)
+    updated = manager.set_distance_use_projected(True)
+    assert updated is True
+    reloaded = ConfigManager(config_file)
+    assert reloaded.get_distance_use_projected() is True
 
 
 def test_distance_calibration_persistence(tmp_path: Path) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,6 +7,7 @@ from rev_cam.battery import BatteryLimits
 from rev_cam.config import (
     ConfigManager,
     DistanceZones,
+    DistanceMounting,
     Orientation,
     ReversingAidPoint,
     ReversingAidsConfig,
@@ -15,6 +16,7 @@ from rev_cam.config import (
     DEFAULT_BATTERY_CAPACITY_MAH,
     DEFAULT_CAMERA_CHOICE,
     DEFAULT_REVERSING_AIDS,
+    DEFAULT_DISTANCE_MOUNTING,
 )
 from rev_cam.distance import DistanceCalibration
 
@@ -85,6 +87,14 @@ def test_default_distance_calibration(tmp_path: Path) -> None:
     assert calibration.scale == pytest.approx(1.0)
 
 
+def test_default_distance_mounting(tmp_path: Path) -> None:
+    manager = ConfigManager(tmp_path / "config.json")
+    mounting = manager.get_distance_mounting()
+    assert isinstance(mounting, DistanceMounting)
+    assert mounting.mount_height_m == pytest.approx(DEFAULT_DISTANCE_MOUNTING.mount_height_m)
+    assert mounting.mount_angle_deg == pytest.approx(DEFAULT_DISTANCE_MOUNTING.mount_angle_deg)
+
+
 def test_distance_calibration_persistence(tmp_path: Path) -> None:
     config_file = tmp_path / "config.json"
     manager = ConfigManager(config_file)
@@ -98,6 +108,23 @@ def test_distance_calibration_validation(tmp_path: Path) -> None:
     manager = ConfigManager(tmp_path / "config.json")
     with pytest.raises(ValueError):
         manager.set_distance_calibration({"offset_m": "invalid", "scale": 1.0})
+
+
+def test_distance_mounting_persistence(tmp_path: Path) -> None:
+    config_file = tmp_path / "config.json"
+    manager = ConfigManager(config_file)
+    updated = manager.set_distance_mounting({"mount_height_m": 1.8, "mount_angle_deg": 35.0})
+    assert isinstance(updated, DistanceMounting)
+    reloaded = ConfigManager(config_file)
+    assert reloaded.get_distance_mounting() == updated
+
+
+def test_distance_mounting_validation(tmp_path: Path) -> None:
+    manager = ConfigManager(tmp_path / "config.json")
+    with pytest.raises(ValueError):
+        manager.set_distance_mounting({"mount_height_m": -1.0, "mount_angle_deg": 40.0})
+    with pytest.raises(ValueError):
+        manager.set_distance_mounting({"mount_height_m": 1.0, "mount_angle_deg": 120.0})
 
 
 def test_default_battery_limits(tmp_path: Path):


### PR DESCRIPTION
## Summary
- add persistent configuration for distance sensor mounting geometry
- expose new API endpoints and include projected ground distance in distance responses
- refresh the settings UI with a mounting diagram, editable inputs, and projected distance display
- cover new functionality with updated unit tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d8fedbe5908332a9c8dd569f9124a5