### PR TITLE
Add Wi-Fi autoconnect startup logic and systemd helpers

### DIFF
--- a/PRReadme.txt
+++ b/PRReadme.txt
@@ -103,9 +103,15 @@ diagnostics report the device as available.
 
 7. Optional: enable the service on boot
 --------------------------------------
-Follow the instructions in `README.md` to create a systemd service or use a
-process manager of your choice. Ensure the service activates the virtual
-environment before launching `uvicorn`.
+Install the bundled systemd unit and start RevCam immediately:
+
+```bash
+./scripts/install_service.sh
+```
+
+Use `./scripts/revcamctl.sh stop` to pause the managed instance while updating
+code, then `./scripts/revcamctl.sh start` (or `restart`) once you're ready to
+test again.
 
 Troubleshooting
 ---------------

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ that future driver-assistance overlays can be injected on the server without maj
   control.
 - Built-in mDNS advertisement so `motion.local:9000` resolves on iOS clients
   even when the RevCam hotspot is active.
+- Automatic Wi-Fi selection on boot with hotspot fallback when no saved
+  networks are reachable.
 
 ## Project layout
 
@@ -309,6 +311,32 @@ EOF
 After reloading the service (or rebooting) `nmcli general permissions` should
 list `yes` for the `org.freedesktop.NetworkManager.*` capabilities and RevCam's
 hotspot toggle will succeed.
+
+### Installing the RevCam service
+
+RevCam ships with helper scripts for managing a systemd service on Raspberry Pi
+OS. Run the installer once to create `/etc/systemd/system/revcam.service`, start
+the application immediately, and enable it for future boots:
+
+```bash
+./scripts/install_service.sh
+```
+
+By default the service launches `scripts/run_with_sudo.sh --host 0.0.0.0 --port
+9000` from the current checkout. Set `REVCAM_SERVICE_NAME` before running the
+installer to use a custom unit name (for example `REVCAM_SERVICE_NAME=revcam-dev`).
+
+During development you can stop the managed instance without disabling the unit
+entirely:
+
+```bash
+./scripts/revcamctl.sh stop
+```
+
+When you're ready to resume testing, restart the service with
+`./scripts/revcamctl.sh start` (or `restart`). The helper also exposes `status`,
+`enable`, and `disable` subcommands which forward to `systemctl` for quick
+inspection and lifecycle management.
 
 ### Hotspot hostname and development-mode rollback
 

--- a/scripts/install_service.sh
+++ b/scripts/install_service.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SERVICE_NAME="${REVCAM_SERVICE_NAME:-revcam}"
+if [[ "${SERVICE_NAME}" != *.service ]]; then
+    SERVICE_NAME="${SERVICE_NAME}.service"
+fi
+
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RUNNER="${PROJECT_DIR}/scripts/run_with_sudo.sh"
+if [[ ! -x "${RUNNER}" ]]; then
+    echo "Expected helper ${RUNNER} to exist" >&2
+    exit 1
+fi
+
+if [[ -n "${REVCAM_VENV:-}" ]]; then
+    export VIRTUAL_ENV="${REVCAM_VENV}"
+    export PATH="${REVCAM_VENV}/bin:${PATH}"
+fi
+
+SERVICE_PATH="/etc/systemd/system/${SERVICE_NAME}"
+
+echo "Installing ${SERVICE_NAME} for RevCam from ${PROJECT_DIR}" >&2
+sudo tee "${SERVICE_PATH}" > /dev/null <<UNIT
+[Unit]
+Description=RevCam reversing camera server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=${PROJECT_DIR}
+ExecStart=${RUNNER} --host 0.0.0.0 --port 9000
+ExecStop=/bin/kill -s SIGINT \$MAINPID
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now "${SERVICE_NAME}"
+
+cat <<INFO
+RevCam service installed.
+Use './scripts/revcamctl.sh status' to verify the service state.
+INFO

--- a/scripts/revcamctl.sh
+++ b/scripts/revcamctl.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SERVICE_NAME="${REVCAM_SERVICE_NAME:-revcam}"
+if [[ "${SERVICE_NAME}" != *.service ]]; then
+    SERVICE_NAME="${SERVICE_NAME}.service"
+fi
+
+if [[ $# -lt 1 ]]; then
+    cat <<USAGE
+Usage: ${0##*/} <command>
+Commands:
+  status    Show current service status
+  start     Start the RevCam service
+  stop      Stop the RevCam service
+  restart   Restart the RevCam service
+  enable    Enable and start the service on boot
+  disable   Disable and stop the service
+USAGE
+    exit 1
+fi
+
+command="$1"
+shift || true
+
+case "${command}" in
+    status)
+        sudo systemctl status "${SERVICE_NAME}" "$@"
+        ;;
+    start)
+        sudo systemctl start "${SERVICE_NAME}" "$@"
+        ;;
+    stop)
+        sudo systemctl stop "${SERVICE_NAME}" "$@"
+        ;;
+    restart)
+        sudo systemctl restart "${SERVICE_NAME}" "$@"
+        ;;
+    enable)
+        sudo systemctl enable --now "${SERVICE_NAME}" "$@"
+        ;;
+    disable)
+        sudo systemctl disable --now "${SERVICE_NAME}" "$@"
+        ;;
+    *)
+        echo "Unknown command: ${command}" >&2
+        exit 2
+        ;;
+esac

--- a/src/rev_cam/app.py
+++ b/src/rev_cam/app.py
@@ -507,6 +507,12 @@ def create_app(
         nonlocal camera, active_camera_choice, streamer, webrtc_manager, active_resolution
         nonlocal stream_error, webrtc_error
         await led_ring.set_pattern("boot")
+        try:
+            await run_in_threadpool(wifi_manager.auto_connect_known_networks)
+        except WiFiError as exc:
+            logger.warning("Automatic Wi-Fi selection failed: %s", exc)
+        except Exception:  # pragma: no cover - defensive logging
+            logger.exception("Unexpected error while selecting Wi-Fi network")
         selection = config_manager.get_camera()
         resolution = config_manager.get_resolution()
         camera, active_camera_choice = _build_camera(

--- a/tests/test_app_diagnostics.py
+++ b/tests/test_app_diagnostics.py
@@ -78,6 +78,9 @@ def _apply_app_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
         def close(self) -> None:  # pragma: no cover - used indirectly
             return None
 
+        def auto_connect_known_networks(self):  # pragma: no cover - framework hook
+            return None
+
     def _create_camera(choice: str, *args, **kwargs):
         return _StubCamera()
 


### PR DESCRIPTION
## Summary
- add WiFiManager.auto_connect_known_networks to join the strongest saved network with hotspot fallback and invoke it during app startup
- provide systemd install/control scripts and documentation updates for managing the RevCam service on boot
- cover the new behaviour with unit tests and stub updates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d93f88a99c8332b0764c047bc157b8