### PR TITLE
Add overlay controls and master gating for video pipeline

### DIFF
--- a/src/rev_cam/static/index.html
+++ b/src/rev_cam/static/index.html
@@ -84,6 +84,15 @@
       header {
         border-bottom: 1px solid var(--border-subtle);
       }
+      .header-panels {
+        display: flex;
+        flex: 1 1 auto;
+        flex-wrap: wrap;
+        justify-content: flex-start;
+        align-items: stretch;
+        gap: var(--space-md);
+        margin-left: auto;
+      }
       footer {
         border-top: 1px solid var(--border-subtle);
         box-shadow: var(--shadow-top-md);
@@ -91,12 +100,13 @@
       strong.brand {
         font-size: 1.25rem;
         letter-spacing: 0.04em;
+        color: var(--success);
       }
       .pill {
         display: inline-flex;
         align-items: center;
         gap: var(--space-md);
-        padding: var(--space-sm) var(--space-lg);
+        padding: calc(var(--space-sm) * 0.35) var(--space-lg);
         border-radius: var(--radius-pill);
         background: var(--surface-1);
         border: 1px solid var(--border-muted);
@@ -104,6 +114,15 @@
         backdrop-filter: blur(22px);
         -webkit-backdrop-filter: blur(22px);
         min-width: 0;
+        transition: box-shadow var(--transition), border-color var(--transition);
+      }
+      .pill.has-success-glow {
+        border-color: rgba(74, 222, 128, 0.45);
+        box-shadow: var(--shadow-sm), var(--glow-success);
+      }
+      .pill.has-danger-glow {
+        border-color: rgba(255, 69, 58, 0.35);
+        box-shadow: var(--shadow-sm), var(--glow-danger);
       }
       main {
         flex: 1 1 auto;
@@ -260,39 +279,116 @@
         gap: var(--space-md);
         font-weight: 600;
         transition: color var(--transition), box-shadow var(--transition);
+        flex: 1 1 clamp(6.25rem, 9vw, 8.6rem);
+      }
+      .header-panels > .pill {
+        min-height: 1.15rem;
       }
       .illumination-pill {
         display: inline-flex;
+        flex: 1 1 clamp(20.8rem, 29.9vw, 28.6rem);
         flex-wrap: wrap;
         align-items: center;
         gap: var(--space-md);
-        padding: var(--space-sm) var(--space-lg);
-        border-radius: var(--radius-pill);
-        background: var(--surface-1);
-        border: 1px solid var(--border-muted);
-        box-shadow: var(--shadow-sm);
-        backdrop-filter: blur(22px);
-        -webkit-backdrop-filter: blur(22px);
+        color: var(--text-primary);
+        transition: color var(--transition), box-shadow var(--transition),
+          border-color var(--transition);
       }
       .illumination-pill.unavailable {
         opacity: 0.6;
+      }
+      .illumination-pill.is-active {
+        color: var(--success);
       }
       .illumination-pill button {
         flex: 0 0 auto;
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        width: 2.75rem;
-        height: 2.75rem;
+        width: 1.375rem;
+        height: 1.375rem;
         padding: 0;
         border-radius: 50%;
+        background: var(--surface-1);
+        border: 1px solid transparent;
+        box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+        transition: transform var(--transition), box-shadow var(--transition),
+          border-color var(--transition), background var(--transition);
+        color: inherit;
+      }
+      .illumination-pill button:not(:disabled):hover,
+      .illumination-pill button:not(:disabled):focus-visible {
+        background: rgba(255, 255, 255, 0.12);
+        border-color: rgba(255, 255, 255, 0.18);
+        box-shadow: 0 14px 32px rgba(0, 0, 0, 0.4);
+        transform: translateY(-1px);
+      }
+      .illumination-pill button:not(:disabled):focus-visible {
+        outline: none;
+        box-shadow: 0 14px 32px rgba(0, 0, 0, 0.4),
+          0 0 0 1px rgba(255, 255, 255, 0.25), 0 0 0 4px rgba(255, 255, 255, 0.08);
+      }
+      .illumination-pill.is-active button {
+        background: rgba(74, 222, 128, 0.12);
+        border-color: rgba(74, 222, 128, 0.45);
+        box-shadow: var(--glow-success);
+      }
+      .illumination-pill.is-active button:not(:disabled):hover,
+      .illumination-pill.is-active button:not(:disabled):focus-visible {
+        background: rgba(74, 222, 128, 0.16);
+        border-color: rgba(74, 222, 128, 0.5);
+        box-shadow: var(--glow-success), 0 0 0 1px rgba(74, 222, 128, 0.55),
+          0 0 0 4px rgba(74, 222, 128, 0.2);
       }
       .illumination-toggle-icon {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        font-size: 1.4rem;
-        line-height: 1;
+        width: 0.9rem;
+        height: 0.9rem;
+      }
+      .illumination-toggle-icon .bulb-glass {
+        fill: rgba(255, 255, 255, 0.12);
+        stroke: currentColor;
+        stroke-width: 1.2;
+      }
+      .illumination-toggle-icon .bulb-base {
+        fill: currentColor;
+        opacity: 0.85;
+      }
+      .illumination-toggle-icon .bulb-filament {
+        stroke: currentColor;
+        stroke-width: 1.5;
+        stroke-linecap: round;
+      }
+      .illumination-toggle-icon .bulb-rays {
+        stroke: currentColor;
+        stroke-width: 1.4;
+        stroke-linecap: round;
+        opacity: 0;
+        transition: opacity var(--transition);
+      }
+      .illumination-pill.is-active .illumination-toggle-icon .bulb-glass {
+        fill: rgba(74, 222, 128, 0.3);
+      }
+      .illumination-pill.is-active .illumination-toggle-icon .bulb-rays {
+        opacity: 1;
+      }
+      .illumination-pill.is-active .illumination-toggle-icon .bulb-filament {
+        stroke-width: 1.8;
+      }
+      .illumination-pill.is-active .illumination-slider input[type="range"] {
+        background: linear-gradient(
+          90deg,
+          rgba(74, 222, 128, 0.45),
+          rgba(74, 222, 128, 0.2)
+        );
+        box-shadow: inset 0 0 0 1px rgba(74, 222, 128, 0.4);
+      }
+      .illumination-pill.is-active .illumination-slider input[type="range"]::-webkit-slider-thumb {
+        background: var(--success);
+        box-shadow: 0 0 0 2px rgba(74, 222, 128, 0.45);
+      }
+      .illumination-pill.is-active .illumination-slider input[type="range"]::-moz-range-thumb {
+        background: var(--success);
+        box-shadow: 0 0 0 2px rgba(74, 222, 128, 0.45);
       }
       .illumination-slider,
       .illumination-colour {
@@ -301,6 +397,10 @@
         gap: var(--space-xs);
         font-size: 0.9rem;
         color: var(--text-muted);
+      }
+      .illumination-pill.is-active .illumination-slider,
+      .illumination-pill.is-active .illumination-colour {
+        color: inherit;
       }
       .illumination-slider input[type="range"] {
         appearance: none;
@@ -401,9 +501,6 @@
       .status-pill.is-busy {
         color: var(--info);
       }
-      .status-pill.is-charging {
-        box-shadow: var(--glow-success);
-      }
       .status-copy {
         display: flex;
         flex-direction: column;
@@ -435,32 +532,27 @@
       #status-subtext:not(:empty) {
         animation: status-reveal var(--transition) ease;
       }
-      #status-subtext::before {
-        content: "⚡";
-        font-size: 0.8rem;
-      }
       #battery-indicator {
         align-items: center;
       }
       .battery-pill {
         font-weight: 600;
         color: var(--text-primary);
+        flex: 1 1 clamp(8.95rem, 12.9vw, 12.3rem);
       }
       .battery-pill.low {
         color: var(--danger);
-        box-shadow: var(--glow-danger);
       }
       .battery-pill.charging {
         color: var(--success);
-        box-shadow: var(--glow-success);
       }
       .battery-pill.unavailable {
         color: var(--text-muted);
         box-shadow: none;
       }
       .battery-icon {
-        width: 2.6rem;
-        height: 1.5rem;
+        width: 3.9rem;
+        height: 2.25rem;
         flex: 0 0 auto;
       }
       .battery-outline {
@@ -501,6 +593,13 @@
         font-size: 0.72rem;
         color: var(--text-muted);
         white-space: nowrap;
+      }
+      .battery-pill.charging #battery-details::before {
+        content: "⚡";
+        display: inline-block;
+        margin-right: 0.35rem;
+        font-size: 0.75rem;
+        vertical-align: middle;
       }
       @keyframes status-busy-track {
         0% {
@@ -544,8 +643,12 @@
         footer {
           align-items: stretch;
         }
-        .status-pill,
-        .battery-pill {
+        .header-panels {
+          width: 100%;
+          justify-content: center;
+          margin-left: 0;
+        }
+        .header-panels > .pill {
           width: 100%;
         }
         #status,
@@ -571,101 +674,128 @@
   <body>
     <header>
       <strong class="brand">RevCam</strong>
-      <div class="pill status-pill is-busy" id="status-pill" role="status" aria-live="polite">
-        <svg class="status-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-          <g class="icon icon-live">
-            <path
-              d="M4 10a8 8 0 0 1 16 0"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.8"
-              stroke-linecap="round"
-            ></path>
-            <path
-              d="M7.5 13a4.5 4.5 0 0 1 9 0"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.8"
-              stroke-linecap="round"
-            ></path>
-            <circle cx="12" cy="16" r="2.2" fill="currentColor"></circle>
-          </g>
-          <g class="icon icon-paused">
-            <rect x="7" y="6.5" width="3.5" height="11" rx="1" fill="currentColor"></rect>
-            <rect x="13.5" y="6.5" width="3.5" height="11" rx="1" fill="currentColor"></rect>
-          </g>
-          <g class="icon icon-busy">
-            <circle
-              cx="12"
-              cy="12"
-              r="7"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.8"
-              stroke-linecap="round"
-              stroke-dasharray="32"
-              stroke-dashoffset="8"
-            ></circle>
-            <circle cx="12" cy="4.5" r="1.6" fill="currentColor"></circle>
-          </g>
-          <g class="icon icon-error">
-            <path d="M12 5l7 12H5z" fill="currentColor"></path>
-          </g>
-        </svg>
-        <div class="status-copy">
-          <span id="status">Initialising…</span>
-          <span id="status-subtext"></span>
+      <div class="header-panels">
+        <div class="pill status-pill is-busy" id="status-pill" role="status" aria-live="polite">
+          <svg class="status-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <g class="icon icon-live">
+              <path
+                d="M4 10a8 8 0 0 1 16 0"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.8"
+                stroke-linecap="round"
+              ></path>
+              <path
+                d="M7.5 13a4.5 4.5 0 0 1 9 0"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.8"
+                stroke-linecap="round"
+              ></path>
+              <circle cx="12" cy="16" r="2.2" fill="currentColor"></circle>
+            </g>
+            <g class="icon icon-paused">
+              <rect x="7" y="6.5" width="3.5" height="11" rx="1" fill="currentColor"></rect>
+              <rect x="13.5" y="6.5" width="3.5" height="11" rx="1" fill="currentColor"></rect>
+            </g>
+            <g class="icon icon-busy">
+              <circle
+                cx="12"
+                cy="12"
+                r="7"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.8"
+                stroke-linecap="round"
+                stroke-dasharray="32"
+                stroke-dashoffset="8"
+              ></circle>
+              <circle cx="12" cy="4.5" r="1.6" fill="currentColor"></circle>
+            </g>
+            <g class="icon icon-error">
+              <path d="M12 5l7 12H5z" fill="currentColor"></path>
+            </g>
+          </svg>
+          <div class="status-copy">
+            <span id="status">Initialising…</span>
+            <span id="status-subtext"></span>
+          </div>
         </div>
-      </div>
-      <div
-        id="battery-indicator"
-        class="pill battery-pill unavailable"
-        aria-live="polite"
-        aria-label="Battery unavailable"
-      >
-        <svg
-          class="battery-icon"
-          id="battery-icon"
-          viewBox="0 0 52 28"
-          aria-hidden="true"
-          focusable="false"
+        <div
+          id="battery-indicator"
+          class="pill battery-pill unavailable"
+          aria-live="polite"
+          aria-label="Battery unavailable"
         >
-          <rect class="battery-outline" x="2" y="6" width="36" height="16" rx="4" ry="4"></rect>
-          <rect class="battery-fill" id="battery-level" x="4" y="8" width="0" height="12" rx="3" ry="3"></rect>
-          <rect class="battery-terminal" x="38" y="11" width="8" height="6" rx="1.5" ry="1.5"></rect>
-          <path class="battery-bolt" d="M27 9l-4 6h3l-1 6 4-7h-3l1-5z"></path>
-        </svg>
-        <div class="battery-copy">
-          <span id="battery-text">—%</span>
-          <span id="battery-details">Battery unavailable</span>
+          <svg
+            class="battery-icon"
+            id="battery-icon"
+            viewBox="0 0 52 28"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <rect class="battery-outline" x="2" y="6" width="36" height="16" rx="4" ry="4"></rect>
+            <rect class="battery-fill" id="battery-level" x="4" y="8" width="0" height="12" rx="3" ry="3"></rect>
+            <rect class="battery-terminal" x="38" y="11" width="8" height="6" rx="1.5" ry="1.5"></rect>
+            <path class="battery-bolt" d="M27 9l-4 6h3l-1 6 4-7h-3l1-5z"></path>
+          </svg>
+          <div class="battery-copy">
+            <span id="battery-text">—%</span>
+            <span id="battery-details">Battery unavailable</span>
+          </div>
         </div>
-      </div>
-      <div class="illumination-pill" id="illumination-controls" aria-live="polite">
-        <button
-          id="toggle-illumination"
-          type="button"
-          aria-pressed="false"
-          aria-label="Enable illumination"
-          title="Enable illumination"
-        >
-          <span class="illumination-toggle-icon" aria-hidden="true">💡</span>
-        </button>
-        <label class="illumination-slider" for="illumination-intensity">
-          <span>Intensity</span>
-          <input
-            id="illumination-intensity"
-            type="range"
-            min="0"
-            max="100"
-            step="1"
-            value="100"
-          />
-          <span class="illumination-slider-value" id="illumination-intensity-display">100%</span>
-        </label>
-        <label class="illumination-colour" for="illumination-colour">
-          <span>Colour</span>
-          <input id="illumination-colour" type="color" value="#FFFFFF" />
-        </label>
+        <div class="pill illumination-pill" id="illumination-controls" aria-live="polite">
+          <button
+            id="toggle-illumination"
+            type="button"
+            aria-pressed="false"
+            aria-label="Enable illumination"
+            title="Enable illumination"
+          >
+            <svg
+              class="illumination-toggle-icon"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+              focusable="false"
+            >
+              <path
+                class="bulb-glass"
+                d="M12 3.2a6.3 6.3 0 0 0-3.85 11.32c.18.14.28.36.28.59V17a1 1 0 0 0 1 1h5.14a1 1 0 0 0 1-1v-1.89c0-.23.1-.45.28-.59A6.3 6.3 0 0 0 12 3.2Z"
+              ></path>
+              <path
+                class="bulb-filament"
+                d="M10 13.25h4"
+              ></path>
+              <path
+                class="bulb-base"
+                d="M9.75 17h4.5v1.75a1.25 1.25 0 0 1-1.25 1.25h-2a1.25 1.25 0 0 1-1.25-1.25Z"
+              ></path>
+              <g class="bulb-rays">
+                <path d="M12 2v1.4"></path>
+                <path d="M6.6 4.6l1 1"></path>
+                <path d="M4.5 10.2h1.4"></path>
+                <path d="M17.4 5.6l-1 1"></path>
+                <path d="M18.1 10.2h1.4"></path>
+              </g>
+            </svg>
+          </button>
+          <label class="illumination-slider" for="illumination-intensity">
+            <span>Intensity</span>
+            <input
+              id="illumination-intensity"
+              type="range"
+              min="0"
+              max="100"
+              step="1"
+              value="100"
+            />
+            <span class="illumination-slider-value" id="illumination-intensity-display">100%</span>
+          </label>
+          <label class="illumination-colour" for="illumination-colour">
+            <span>Colour</span>
+            <input id="illumination-colour" type="color" value="#FFFFFF" />
+          </label>
+        </div>
       </div>
     </header>
     <main>
@@ -842,6 +972,7 @@
         }
         const descriptor = typeof reference === "string" ? reference.toLowerCase() : "";
         statusPill.classList.remove(...STATUS_CLASSES);
+        statusPill.classList.remove("has-success-glow", "has-danger-glow");
         let targetClass = "is-busy";
         if (descriptor.includes("error") || descriptor.includes("fail") || descriptor.includes("lost")) {
           targetClass = "is-error";
@@ -851,23 +982,20 @@
           targetClass = "is-live";
         }
         statusPill.classList.add(targetClass);
+        if (targetClass === "is-live") {
+          statusPill.classList.add("has-success-glow");
+        } else if (targetClass === "is-error") {
+          statusPill.classList.add("has-danger-glow");
+        }
       }
 
       let statusModeText = "";
-      let statusChargingText = "";
 
       function renderStatusSubtext() {
         if (!statusSubtext) {
           return;
         }
-        const parts = [];
-        if (statusModeText) {
-          parts.push(statusModeText);
-        }
-        if (statusChargingText) {
-          parts.push(statusChargingText);
-        }
-        statusSubtext.textContent = parts.join(" · ");
+        statusSubtext.textContent = statusModeText;
       }
 
       function setStatus(message, stateHint) {
@@ -888,13 +1016,10 @@
         renderStatusSubtext();
       }
 
-      function setChargingState(isCharging) {
-        const charging = Boolean(isCharging);
+      function setChargingState() {
         if (statusPill) {
-          statusPill.classList.toggle("is-charging", charging);
+          statusPill.classList.remove("is-charging");
         }
-        statusChargingText = charging ? "Charging" : "";
-        renderStatusSubtext();
       }
 
       let reconnectTimer = null;
@@ -1094,7 +1219,13 @@
         ) {
           return;
         }
-        batteryIndicator.classList.remove("low", "charging", "unavailable");
+        batteryIndicator.classList.remove(
+          "low",
+          "charging",
+          "unavailable",
+          "has-success-glow",
+          "has-danger-glow",
+        );
         batteryIcon.classList.remove("low", "charging", "unavailable");
 
         if (!data || data.available !== true || typeof data.percentage !== "number") {
@@ -1108,7 +1239,7 @@
               : "Battery unavailable";
           batteryDetails.textContent = fallback;
           batteryIndicator.setAttribute("aria-label", fallback);
-          setChargingState(false);
+          setChargingState();
           return;
         }
 
@@ -1120,7 +1251,7 @@
           batteryText.textContent = "—%";
           batteryDetails.textContent = "Battery unavailable";
           batteryIndicator.setAttribute("aria-label", "Battery unavailable");
-          setChargingState(false);
+          setChargingState();
           return;
         }
 
@@ -1133,10 +1264,10 @@
         batteryText.textContent = `${rounded}%`;
 
         if (data.charging === true) {
-          batteryIndicator.classList.add("charging");
+          batteryIndicator.classList.add("charging", "has-success-glow");
           batteryIcon.classList.add("charging");
         } else if (percentage <= 20) {
-          batteryIndicator.classList.add("low");
+          batteryIndicator.classList.add("low", "has-danger-glow");
           batteryIcon.classList.add("low");
         }
 
@@ -1148,18 +1279,18 @@
           const magnitude = Math.abs(data.current_ma);
           const decimals = magnitude >= 100 ? 0 : magnitude >= 10 ? 1 : 2;
           const formatted = magnitude.toFixed(decimals);
-          const suffix = data.charging === true ? "charging" : "draw";
-          detailParts.push(`${formatted} mA ${suffix}`);
-        } else if (data.charging === true) {
-          detailParts.push("Charging");
+          const suffix = data.charging === true ? "" : " draw";
+          detailParts.push(`${formatted} mA${suffix}`.trim());
         }
         const detailText = detailParts.join(" · ") || "Battery OK";
         batteryDetails.textContent = detailText;
-        batteryIndicator.setAttribute(
-          "aria-label",
-          `Battery ${rounded}%, ${detailParts.join(", ") || "status"}`,
-        );
-        setChargingState(data.charging === true);
+        const detailDescription = detailParts.join(", ") || "status";
+        const ariaParts = [`Battery ${rounded}%`, detailDescription];
+        if (data.charging === true) {
+          ariaParts.push("charging");
+        }
+        batteryIndicator.setAttribute("aria-label", ariaParts.join(", "));
+        setChargingState();
       }
 
       async function refreshBattery() {
@@ -1303,6 +1434,14 @@
 
         if (illuminationControls) {
           illuminationControls.classList.toggle("unavailable", !available);
+          illuminationControls.classList.toggle(
+            "is-active",
+            available && active,
+          );
+          illuminationControls.classList.toggle(
+            "has-success-glow",
+            available && active,
+          );
         }
 
         if (illuminationToggle instanceof HTMLButtonElement) {
@@ -1311,6 +1450,7 @@
           illuminationToggle.setAttribute("aria-label", toggleLabel);
           illuminationToggle.title = toggleLabel;
           illuminationToggle.setAttribute("aria-pressed", active ? "true" : "false");
+          illuminationToggle.classList.toggle("is-active", available && active);
         }
 
         if (illuminationIntensityInput instanceof HTMLInputElement) {

--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -1804,37 +1804,6 @@
             </div>
           </section>
 
-          <section class="card">
-            <div class="toggle-row">
-              <div class="toggle-text" id="distance-overlay-text">
-                <h3 id="distance-overlay-heading">Distance overlay</h3>
-                <p id="distance-overlay-description" class="muted helper-text">
-                  Display the live distance measurement on the camera feed.
-                </p>
-              </div>
-              <label
-                class="switch-control"
-                aria-labelledby="distance-overlay-heading"
-                aria-describedby="distance-overlay-description"
-              >
-                <input
-                  type="checkbox"
-                  id="distance-overlay-toggle"
-                  aria-describedby="distance-overlay-description"
-                />
-                <span class="switch-track" aria-hidden="true">
-                  <span class="switch-thumb"></span>
-                </span>
-              </label>
-            </div>
-            <p
-              id="distance-overlay-status"
-              class="muted helper-text status-text"
-              role="status"
-              aria-live="polite"
-            ></p>
-          </section>
-
           <section class="card distance-geometry-card">
             <h2>Mounting geometry</h2>
             <p class="muted helper-text">
@@ -2406,6 +2375,91 @@
             ></p>
           </section>
 
+          <section id="development-overlays-card" class="card" hidden>
+            <h3>Overlay controls</h3>
+            <p class="muted helper-text">
+              Enable or disable each overlay while testing latency. Turning off the master switch bypasses all
+              overlays for a direct video pipeline.
+            </p>
+            <div class="toggle-row">
+              <div class="toggle-text" id="overlay-master-text">
+                <h3 id="overlay-master-heading">Overlay pipeline</h3>
+                <p id="overlay-master-description" class="muted helper-text">
+                  Master switch that enables or bypasses every overlay.
+                </p>
+              </div>
+              <label
+                class="switch-control"
+                aria-labelledby="overlay-master-heading"
+                aria-describedby="overlay-master-description"
+              >
+                <input type="checkbox" id="overlay-master-toggle" aria-describedby="overlay-master-description" />
+                <span class="switch-track" aria-hidden="true">
+                  <span class="switch-thumb"></span>
+                </span>
+              </label>
+            </div>
+            <div class="toggle-row">
+              <div class="toggle-text" id="battery-overlay-text">
+                <h3 id="battery-overlay-heading">Battery overlay</h3>
+                <p id="battery-overlay-description" class="muted helper-text">
+                  Render pack status, charging state, and wireless connectivity on the stream.
+                </p>
+              </div>
+              <label
+                class="switch-control"
+                aria-labelledby="battery-overlay-heading"
+                aria-describedby="battery-overlay-description"
+              >
+                <input type="checkbox" id="battery-overlay-toggle" aria-describedby="battery-overlay-description" />
+                <span class="switch-track" aria-hidden="true">
+                  <span class="switch-thumb"></span>
+                </span>
+              </label>
+            </div>
+            <div class="toggle-row">
+              <div class="toggle-text" id="distance-overlay-text">
+                <h3 id="distance-overlay-heading">Distance overlay</h3>
+                <p id="distance-overlay-description" class="muted helper-text">
+                  Display live sensor readings and projected distance.
+                </p>
+              </div>
+              <label
+                class="switch-control"
+                aria-labelledby="distance-overlay-heading"
+                aria-describedby="distance-overlay-description"
+              >
+                <input type="checkbox" id="distance-overlay-toggle" aria-describedby="distance-overlay-description" />
+                <span class="switch-track" aria-hidden="true">
+                  <span class="switch-thumb"></span>
+                </span>
+              </label>
+            </div>
+            <div class="toggle-row">
+              <div class="toggle-text" id="reversing-overlay-text">
+                <h3 id="reversing-overlay-heading">Reversing aids overlay</h3>
+                <p id="reversing-overlay-description" class="muted helper-text">
+                  Show reversing guide lines and zones on the stream.
+                </p>
+              </div>
+              <label
+                class="switch-control"
+                aria-labelledby="reversing-overlay-heading"
+                aria-describedby="reversing-overlay-description"
+              >
+                <input
+                  type="checkbox"
+                  id="reversing-overlay-toggle"
+                  aria-describedby="reversing-overlay-description"
+                />
+                <span class="switch-track" aria-hidden="true">
+                  <span class="switch-thumb"></span>
+                </span>
+              </label>
+            </div>
+            <p id="overlay-status" class="muted helper-text status-text" role="status" aria-live="polite"></p>
+          </section>
+
           <section id="diagnostics-card" class="card" hidden>
             <h3>Camera and WebRTC diagnostics</h3>
             <p class="muted helper-text">
@@ -2647,8 +2701,12 @@
       const distanceProjectedReadingValue = document.getElementById("distance-projected-reading");
       const distanceError = document.getElementById("distance-error");
       const distanceRefreshButton = document.getElementById("distance-refresh");
+      const overlayCard = document.getElementById("development-overlays-card");
+      const overlayMasterToggle = document.getElementById("overlay-master-toggle");
+      const batteryOverlayToggle = document.getElementById("battery-overlay-toggle");
       const distanceOverlayToggle = document.getElementById("distance-overlay-toggle");
-      const distanceOverlayStatus = document.getElementById("distance-overlay-status");
+      const reversingOverlayToggle = document.getElementById("reversing-overlay-toggle");
+      const overlayStatus = document.getElementById("overlay-status");
       const distanceDisplayToggle = document.getElementById("distance-display-toggle");
       const distanceDisplayStatus = document.getElementById("distance-display-status");
       const distanceDisplayMode = document.getElementById("distance-display-mode");
@@ -2684,7 +2742,8 @@
         : null;
       let distanceLoading = false;
       let distanceCalibrationStatusTimer = null;
-      let distanceOverlayStatusTimer = null;
+      let overlayStatusTimer = null;
+      let overlayState = null;
       let distanceDisplayStatusTimer = null;
       let distanceGeometryStatusTimer = null;
       let distanceGeometrySaving = false;
@@ -3973,26 +4032,157 @@
         }
       }
 
-      function setDistanceOverlayStatus(message, options = {}) {
-        if (!distanceOverlayStatus) {
+      function setOverlayStatus(message, options = {}) {
+        if (!overlayStatus) {
           return;
         }
-        if (distanceOverlayStatusTimer) {
-          window.clearTimeout(distanceOverlayStatusTimer);
-          distanceOverlayStatusTimer = null;
+        if (overlayStatusTimer) {
+          window.clearTimeout(overlayStatusTimer);
+          overlayStatusTimer = null;
         }
-        distanceOverlayStatus.textContent = message || "";
+        overlayStatus.textContent = message || "";
         if (message && options.persistent !== true) {
-          distanceOverlayStatusTimer = window.setTimeout(() => {
-            if (
-              distanceOverlayStatus &&
-              distanceOverlayStatus.textContent === message
-            ) {
-              distanceOverlayStatus.textContent = "";
+          overlayStatusTimer = window.setTimeout(() => {
+            if (overlayStatus && overlayStatus.textContent === message) {
+              overlayStatus.textContent = "";
             }
-            distanceOverlayStatusTimer = null;
+            overlayStatusTimer = null;
           }, 4000);
         }
+      }
+
+      function describeOverlayEffectiveState(summary) {
+        if (!summary || !summary.effective) {
+          return "";
+        }
+        const effective = summary.effective;
+        if (effective.master !== true) {
+          return "All overlays bypassed for direct video pipeline.";
+        }
+        const disabled = [];
+        if (effective.battery !== true) {
+          disabled.push("Battery");
+        }
+        if (effective.distance !== true) {
+          disabled.push("Distance");
+        }
+        if (effective.reversing_aids !== true) {
+          const configured = Boolean(
+            summary.sources && summary.sources.reversing_aids_configured === true,
+          );
+          if (!configured && summary.settings && summary.settings.reversing_aids_enabled === true) {
+            disabled.push("Reversing aids (disabled in configuration)");
+          } else {
+            disabled.push("Reversing aids");
+          }
+        }
+        if (disabled.length === 0) {
+          return "All overlays active.";
+        }
+        if (disabled.length === 1) {
+          return `${disabled[0]} overlay inactive.`;
+        }
+        if (disabled.length === 2) {
+          return `${disabled[0]} and ${disabled[1]} overlays inactive.`;
+        }
+        const parts = disabled.slice(0, -1);
+        const last = disabled[disabled.length - 1];
+        return `${parts.join(", ")}, and ${last} overlays inactive.`;
+      }
+
+      function updateOverlayToggle(toggle, value, options = {}) {
+        if (!(toggle instanceof HTMLInputElement)) {
+          return;
+        }
+        if (options.forceUpdate === true || toggle.dataset.userToggled !== "true") {
+          const desired = value === true;
+          toggle.checked = desired;
+          toggle.dataset.serverValue = desired ? "true" : "false";
+        }
+      }
+
+      function updateOverlayControlsAvailability() {
+        const toggles = [
+          overlayMasterToggle,
+          batteryOverlayToggle,
+          distanceOverlayToggle,
+          reversingOverlayToggle,
+        ];
+        const masterUpdating =
+          overlayMasterToggle instanceof HTMLInputElement &&
+          overlayMasterToggle.dataset.updating === "true";
+        toggles.forEach((toggle) => {
+          if (!(toggle instanceof HTMLInputElement)) {
+            return;
+          }
+          const updating = toggle.dataset.updating === "true";
+          const disabled =
+            !developmentEnabled ||
+            updating ||
+            (masterUpdating && toggle !== overlayMasterToggle);
+          toggle.disabled = disabled;
+        });
+        if (overlayCard) {
+          overlayCard.hidden = !developmentEnabled;
+        }
+      }
+
+      function applyOverlayState(summary, options = {}) {
+        overlayState = summary || null;
+        const settings = summary && summary.settings ? summary.settings : null;
+        const forceUpdate = options.forceUpdate === true;
+        if (settings) {
+          updateOverlayToggle(overlayMasterToggle, settings.master_enabled, { forceUpdate });
+          updateOverlayToggle(batteryOverlayToggle, settings.battery_enabled, { forceUpdate });
+          updateOverlayToggle(distanceOverlayToggle, settings.distance_enabled, { forceUpdate });
+          updateOverlayToggle(reversingOverlayToggle, settings.reversing_aids_enabled, { forceUpdate });
+        }
+        updateOverlayControlsAvailability();
+        if (summary && summary.effective) {
+          const message = describeOverlayEffectiveState(summary);
+          if (message) {
+            setOverlayStatus(message, { persistent: true });
+          } else {
+            setOverlayStatus("", { persistent: true });
+          }
+        } else if (options.clear === true) {
+          setOverlayStatus("");
+        }
+      }
+
+      async function refreshOverlaySettings(options = {}) {
+        try {
+          const response = await fetch("/api/overlays", { cache: "no-store" });
+          if (!response.ok) {
+            throw new Error(`Overlays request failed with status ${response.status}`);
+          }
+          const payload = await response.json();
+          applyOverlayState(payload, { forceUpdate: options.forceUpdate === true });
+        } catch (error) {
+          console.error("Overlay settings fetch failed", error);
+          setOverlayStatus("Unable to load overlay settings.", { persistent: true });
+        }
+      }
+
+      async function updateOverlaySettingsRequest(changes) {
+        const response = await fetch("/api/overlays", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(changes),
+        });
+        if (!response.ok) {
+          let detail = "Unable to update overlay settings.";
+          try {
+            const payload = await response.json();
+            if (payload && typeof payload.detail === "string") {
+              detail = payload.detail;
+            }
+          } catch (err) {
+            console.error(err);
+          }
+          throw new Error(detail);
+        }
+        return response.json();
       }
 
       function setDistanceDisplayStatus(message, options = {}) {
@@ -4269,19 +4459,6 @@
         distanceSummary.textContent = parts.join(" • ");
       }
 
-      function updateDistanceOverlayToggle(enabled, options = {}) {
-        if (!(distanceOverlayToggle instanceof HTMLInputElement)) {
-          return;
-        }
-        const shouldForce = options.forceUpdate === true;
-        if (!shouldForce && distanceOverlayToggle.dataset.userToggled === "true") {
-          return;
-        }
-        const desired = enabled === true;
-        distanceOverlayToggle.checked = desired;
-        distanceOverlayToggle.dataset.serverValue = desired ? "true" : "false";
-      }
-
       function applyDistanceData(data, options = {}) {
         const displayValue = getDisplayDistance(data);
         const useProjected = data && data.use_projected_distance === true;
@@ -4331,10 +4508,10 @@
             options.updateCalibration === true ||
             options.updateGeometry === true,
         });
-        if (distanceOverlayToggle) {
-          const enabled = data && data.overlay_enabled === true;
-          const forceUpdate = options.updateInputs === true || options.updateCalibration === true;
-          updateDistanceOverlayToggle(enabled, { forceUpdate });
+        if (data && data.overlay_settings) {
+          const forceUpdate =
+            options.updateInputs === true || options.updateCalibration === true;
+          applyOverlayState(data.overlay_settings, { forceUpdate });
         }
         recordDevelopmentDistanceReading(data);
       }
@@ -4602,6 +4779,10 @@
         document.body.classList.toggle("development-enabled", developmentEnabled);
         if (!developmentEnabled) {
           diagnosticsLoading = false;
+        }
+        updateOverlayControlsAvailability();
+        if (overlayState) {
+          applyOverlayState(overlayState, { forceUpdate: true });
         }
         if (developmentSystemCard) {
           developmentSystemCard.hidden = !developmentEnabled;
@@ -5540,57 +5721,49 @@
         });
       }
 
-      if (distanceOverlayToggle instanceof HTMLInputElement) {
-        distanceOverlayToggle.dataset.serverValue = distanceOverlayToggle.checked
-          ? "true"
-          : "false";
-        distanceOverlayToggle.addEventListener("change", async () => {
-          if (!(distanceOverlayToggle instanceof HTMLInputElement)) {
+      function registerOverlayToggle(toggle, changeKey) {
+        if (!(toggle instanceof HTMLInputElement)) {
+          return;
+        }
+        toggle.addEventListener("change", async () => {
+          if (!(toggle instanceof HTMLInputElement)) {
             return;
           }
-          const previous = distanceOverlayToggle.dataset.serverValue === "true";
-          const desired = distanceOverlayToggle.checked;
-          distanceOverlayToggle.dataset.userToggled = "true";
-          distanceOverlayToggle.dataset.updating = "true";
-          distanceOverlayToggle.disabled = true;
-          setDistanceOverlayStatus("Saving…", { persistent: true });
+          const previous =
+            toggle.dataset.serverValue === "true"
+              ? true
+              : toggle.dataset.serverValue === "false"
+              ? false
+              : toggle.checked;
+          const desired = toggle.checked;
+          toggle.dataset.userToggled = "true";
+          toggle.dataset.updating = "true";
+          updateOverlayControlsAvailability();
+          setOverlayStatus("Saving overlay settings…", { persistent: true });
           try {
-            const response = await fetch("/api/distance/overlay", {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ enabled: desired }),
-            });
-            if (!response.ok) {
-              let errorDetail = "Unable to update distance overlay.";
-              try {
-                const errorData = await response.json();
-                if (errorData && typeof errorData.detail === "string") {
-                  errorDetail = errorData.detail;
-                }
-              } catch (err) {
-                console.error(err);
-              }
-              throw new Error(errorDetail);
-            }
-            const result = await response.json();
-            const saved = result && result.overlay_enabled === true;
-            updateDistanceOverlayToggle(saved, { forceUpdate: true });
-            setDistanceOverlayStatus(saved ? "Overlay enabled" : "Overlay disabled");
+            const summary = await updateOverlaySettingsRequest({ [changeKey]: desired });
+            applyOverlayState(summary, { forceUpdate: true });
           } catch (error) {
             console.error(error);
-            updateDistanceOverlayToggle(previous, { forceUpdate: true });
+            toggle.checked = previous;
+            toggle.dataset.serverValue = previous ? "true" : "false";
             const message =
-              error && typeof error.message === "string" && error.message
+              error instanceof Error && error.message
                 ? error.message
-                : "Unable to update distance overlay.";
-            setDistanceOverlayStatus(message, { persistent: true });
+                : "Unable to update overlay settings.";
+            setOverlayStatus(message, { persistent: true });
           } finally {
-            distanceOverlayToggle.disabled = false;
-            delete distanceOverlayToggle.dataset.userToggled;
-            delete distanceOverlayToggle.dataset.updating;
+            delete toggle.dataset.userToggled;
+            delete toggle.dataset.updating;
+            updateOverlayControlsAvailability();
           }
         });
       }
+
+      registerOverlayToggle(overlayMasterToggle, "master_enabled");
+      registerOverlayToggle(batteryOverlayToggle, "battery_enabled");
+      registerOverlayToggle(distanceOverlayToggle, "distance_enabled");
+      registerOverlayToggle(reversingOverlayToggle, "reversing_aids_enabled");
 
       if (distanceCalibrationForm) {
         distanceCalibrationForm.addEventListener("submit", async (event) => {
@@ -6147,6 +6320,8 @@
       }
 
       initializeDevelopmentState();
+
+      refreshOverlaySettings({ forceUpdate: true }).catch((err) => console.error(err));
 
       if (availableTabs.length) {
         const initialTab = getTabFromHash(window.location.hash) || availableTabs[0];

--- a/src/rev_cam/version.py
+++ b/src/rev_cam/version.py
@@ -1,6 +1,6 @@
 """Application version metadata."""
 
-APP_VERSION = "0.2.12"
+APP_VERSION = "1.0.0"
 """Human readable application version displayed in the UI."""
 
 __all__ = ["APP_VERSION"]


### PR DESCRIPTION
## Summary
- add overlay configuration storage with a master switch and persist the new flags alongside existing distance overlay data
- gate video pipeline overlays behind the new config and expose overlay APIs for the development UI
- introduce a development overlay control panel with synchronized toggles and bump the app version to 1.0.0

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d98f4b831883328fadfbe759af42d7