### PR TITLE
Add overlay management controls and master bypass

### DIFF
--- a/src/rev_cam/app.py
+++ b/src/rev_cam/app.py
@@ -163,6 +163,13 @@ class ReversingAidsPayload(BaseModel):
     right: list[ReversingAidSegmentPayload] | None = None
 
 
+class OverlaySettingsPayload(BaseModel):
+    master_enabled: bool | None = Field(default=None)
+    battery_enabled: bool | None = Field(default=None)
+    distance_enabled: bool | None = Field(default=None)
+    reversing_aids_enabled: bool | None = Field(default=None)
+
+
 class LedSettingsPayload(BaseModel):
     pattern: str | None = None
     error: bool | None = None
@@ -237,12 +244,16 @@ def create_app(
         credentials_path = config_path.with_name("wifi_credentials.json")
         wifi_manager = WiFiManager(credential_store=WiFiCredentialStore(credentials_path))
 
-    pipeline = FramePipeline(lambda: config_manager.get_orientation())
+    pipeline = FramePipeline(
+        lambda: config_manager.get_orientation(),
+        overlay_enabled_provider=config_manager.get_overlay_master_enabled,
+    )
     pipeline.add_overlay(
         create_battery_overlay(
             battery_monitor,
             config_manager.get_battery_limits,
             wifi_manager.get_status,
+            enabled_provider=config_manager.get_battery_overlay_enabled,
         )
     )
     pipeline.add_overlay(
@@ -254,7 +265,12 @@ def create_app(
             display_mode_provider=config_manager.get_distance_use_projected,
         )
     )
-    pipeline.add_overlay(create_reversing_aids_overlay(config_manager.get_reversing_aids))
+    pipeline.add_overlay(
+        create_reversing_aids_overlay(
+            config_manager.get_reversing_aids,
+            enabled_provider=config_manager.get_reversing_overlay_enabled,
+        )
+    )
     camera: BaseCamera | None = None
     streamer: MJPEGStreamer | None = None
     webrtc_manager: WebRTCManager | None = None
@@ -935,6 +951,30 @@ def create_app(
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         return {"overlay_enabled": enabled}
+
+    @app.get("/api/overlays")
+    def get_overlay_settings() -> dict[str, bool]:
+        return {
+            "master_enabled": config_manager.get_overlay_master_enabled(),
+            "battery_enabled": config_manager.get_battery_overlay_enabled(),
+            "distance_enabled": config_manager.get_distance_overlay_enabled(),
+            "reversing_aids_enabled": config_manager.get_reversing_overlay_enabled(),
+        }
+
+    @app.post("/api/overlays")
+    def update_overlay_settings(payload: OverlaySettingsPayload) -> dict[str, bool]:
+        try:
+            if payload.master_enabled is not None:
+                config_manager.set_overlay_master_enabled(payload.master_enabled)
+            if payload.battery_enabled is not None:
+                config_manager.set_battery_overlay_enabled(payload.battery_enabled)
+            if payload.distance_enabled is not None:
+                config_manager.set_distance_overlay_enabled(payload.distance_enabled)
+            if payload.reversing_aids_enabled is not None:
+                config_manager.set_reversing_overlay_enabled(payload.reversing_aids_enabled)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return get_overlay_settings()
 
     @app.get("/api/reversing-aids")
     def get_reversing_aids() -> dict[str, object]:

--- a/src/rev_cam/battery.py
+++ b/src/rev_cam/battery.py
@@ -740,7 +740,6 @@ _BATTERY_COLOURS = {
 def create_battery_overlay(
     monitor: BatteryMonitor,
     limits_provider: Callable[[], BatteryLimits],
-    wifi_status_provider: Callable[[], "WiFiStatus | None"] | None = None,
     *,
     enabled_provider: Callable[[], bool] | None = None,
 ):
@@ -764,14 +763,7 @@ def create_battery_overlay(
             limits = limits_provider()
         except Exception:  # pragma: no cover - defensive guard
             limits = DEFAULT_BATTERY_LIMITS
-        wifi_status = None
-        if wifi_status_provider is not None:
-            try:
-                wifi_status = wifi_status_provider()
-            except Exception:  # pragma: no cover - best effort logging
-                logger.debug("Wi-Fi status provider failed", exc_info=True)
-                wifi_status = None
-        return _render_battery_overlay(frame, reading, limits, wifi_status)
+        return _render_battery_overlay(frame, reading, limits)
 
     return _overlay
 
@@ -780,7 +772,6 @@ def _render_battery_overlay(
     frame,
     reading: BatteryReading,
     limits: BatteryLimits,
-    wifi_status: "WiFiStatus | None" = None,
 ):
     if _np is None or not isinstance(frame, _np.ndarray):  # pragma: no cover - optional guard
         return frame
@@ -798,8 +789,6 @@ def _render_battery_overlay(
     voltage = reading.voltage if reading.available else None
     if voltage is not None and not math.isfinite(voltage):
         voltage = None
-
-    wifi_level, wifi_text = _prepare_wifi_display(wifi_status)
 
     if percentage is not None:
         percentage_text = f"{percentage:.0f}%"
@@ -823,20 +812,14 @@ def _render_battery_overlay(
     padding = 4 * scale
     text_gap = 2 * scale
 
-    wifi_icon_width, wifi_icon_height = _wifi_icon_dimensions(scale)
     battery_icon_width, battery_icon_height = _battery_icon_dimensions(scale)
 
     bar_height = max(
         glyph_height + padding * 2,
-        wifi_icon_height + padding * 2,
         battery_icon_height + padding * 2,
     )
 
     text_y = max(0, (bar_height - glyph_height) // 2)
-
-    wifi_icon_x = padding
-    wifi_icon_y = max(0, (bar_height - wifi_icon_height) // 2)
-    _draw_wifi_icon(frame, wifi_icon_x, wifi_icon_y, scale, wifi_level)
 
     battery_text_width = _measure_text(battery_text, glyph_width, char_spacing)
     if battery_text_width:
@@ -850,9 +833,74 @@ def _render_battery_overlay(
 
     battery_text_x = battery_icon_x + battery_icon_width + (text_gap if battery_text_width else 0)
 
+    text_colour = (255, 255, 255)
+
+    if battery_text_width:
+        _draw_text(frame, battery_text, battery_text_x, text_y, scale, text_colour)
+
+    return frame
+
+
+def create_wifi_overlay(
+    wifi_status_provider: Callable[[], "WiFiStatus | None"],
+    *,
+    enabled_provider: Callable[[], bool] | None = None,
+):
+    """Return an overlay function that renders the current Wi-Fi status."""
+
+    def _overlay(frame):
+        if enabled_provider is not None:
+            try:
+                if not enabled_provider():
+                    return frame
+            except Exception:  # pragma: no cover - best effort guard
+                logger.debug("Wi-Fi overlay enabled provider failed", exc_info=True)
+        if _np is None or not isinstance(frame, _np.ndarray):  # pragma: no cover - optional path
+            return frame
+
+        try:
+            status = wifi_status_provider()
+        except Exception:  # pragma: no cover - best effort logging
+            logger.debug("Wi-Fi status provider failed", exc_info=True)
+            status = None
+        return _render_wifi_overlay(frame, status)
+
+    return _overlay
+
+
+def _render_wifi_overlay(frame, status: "WiFiStatus | None"):
+    if _np is None or not isinstance(frame, _np.ndarray):  # pragma: no cover - optional guard
+        return frame
+
+    height, width = frame.shape[:2]
+    if height < 24 or width < 60:
+        return frame
+
+    wifi_level, wifi_text = _prepare_wifi_display(status)
+
+    scale = max(2, min(width, height) // 200)
+    glyph_width = _FONT_WIDTH * scale
+    glyph_height = _FONT_HEIGHT * scale
+    char_spacing = 1 * scale
+    padding = 4 * scale
+    text_gap = 2 * scale
+
+    wifi_icon_width, wifi_icon_height = _wifi_icon_dimensions(scale)
+
+    bar_height = max(
+        glyph_height + padding * 2,
+        wifi_icon_height + padding * 2,
+    )
+
+    text_y = max(0, (bar_height - glyph_height) // 2)
+
+    wifi_icon_x = padding
+    wifi_icon_y = max(0, (bar_height - wifi_icon_height) // 2)
+    _draw_wifi_icon(frame, wifi_icon_x, wifi_icon_y, scale, wifi_level)
+
     wifi_text_x = wifi_icon_x + wifi_icon_width + text_gap
     wifi_text_width = _measure_text(wifi_text, glyph_width, char_spacing)
-    max_wifi_width = max(0, battery_icon_x - text_gap - wifi_text_x)
+    max_wifi_width = max(0, width - padding - wifi_text_x)
     if wifi_text_width > max_wifi_width:
         if max_wifi_width >= glyph_width:
             wifi_text = "---"
@@ -862,12 +910,9 @@ def _render_battery_overlay(
             wifi_text_width = 0
 
     text_colour = (255, 255, 255)
-    wifi_colour = text_colour
 
     if wifi_text_width:
-        _draw_text(frame, wifi_text, wifi_text_x, text_y, scale, wifi_colour)
-    if battery_text_width:
-        _draw_text(frame, battery_text, battery_text_x, text_y, scale, text_colour)
+        _draw_text(frame, wifi_text, wifi_text_x, text_y, scale, text_colour)
 
     return frame
 
@@ -1092,4 +1137,5 @@ __all__ = [
     "DEFAULT_BATTERY_LIMITS",
     "BatterySupervisor",
     "create_battery_overlay",
+    "create_wifi_overlay",
 ]

--- a/src/rev_cam/config.py
+++ b/src/rev_cam/config.py
@@ -33,6 +33,7 @@ DEFAULT_DISTANCE_USE_PROJECTED = False
 
 DEFAULT_OVERLAY_MASTER_ENABLED = True
 DEFAULT_BATTERY_OVERLAY_ENABLED = True
+DEFAULT_WIFI_OVERLAY_ENABLED = True
 DEFAULT_REVERSING_OVERLAY_ENABLED = True
 
 
@@ -656,6 +657,7 @@ class ConfigManager:
             self._reversing_aids,
             self._overlays_master_enabled,
             self._battery_overlay_enabled,
+            self._wifi_overlay_enabled,
             self._reversing_overlay_enabled,
         ) = self._load()
 
@@ -677,6 +679,10 @@ class ConfigManager:
         int,
         StreamSettings,
         ReversingAidsConfig,
+        bool,
+        bool,
+        bool,
+        bool,
     ]:
         if not self._path.exists():
             return (
@@ -694,6 +700,7 @@ class ConfigManager:
                 DEFAULT_REVERSING_AIDS,
                 DEFAULT_OVERLAY_MASTER_ENABLED,
                 DEFAULT_BATTERY_OVERLAY_ENABLED,
+                DEFAULT_WIFI_OVERLAY_ENABLED,
                 DEFAULT_REVERSING_OVERLAY_ENABLED,
             )
         try:
@@ -751,6 +758,7 @@ class ConfigManager:
             overlays_payload = payload.get("overlays")
             overlay_master_enabled = DEFAULT_OVERLAY_MASTER_ENABLED
             battery_overlay_enabled = DEFAULT_BATTERY_OVERLAY_ENABLED
+            wifi_overlay_enabled = DEFAULT_WIFI_OVERLAY_ENABLED
             reversing_overlay_enabled = (
                 reversing_aids.enabled if isinstance(reversing_aids, ReversingAidsConfig) else DEFAULT_REVERSING_OVERLAY_ENABLED
             )
@@ -760,6 +768,9 @@ class ConfigManager:
                 )
                 battery_overlay_enabled = _parse_overlay_flag(
                     overlays_payload.get("battery"), default=DEFAULT_BATTERY_OVERLAY_ENABLED
+                )
+                wifi_overlay_enabled = _parse_overlay_flag(
+                    overlays_payload.get("wifi"), default=DEFAULT_WIFI_OVERLAY_ENABLED
                 )
                 if "distance" in overlays_payload:
                     distance_overlay_enabled = _parse_overlay_flag(
@@ -784,6 +795,7 @@ class ConfigManager:
                 reversing_aids,
                 overlay_master_enabled,
                 battery_overlay_enabled,
+                wifi_overlay_enabled,
                 reversing_overlay_enabled,
             )
         except (OSError, ValueError) as exc:
@@ -810,6 +822,7 @@ class ConfigManager:
             "overlays": {
                 "master": self._overlays_master_enabled,
                 "battery": self._battery_overlay_enabled,
+                "wifi": self._wifi_overlay_enabled,
                 "distance": self._distance_overlay_enabled,
                 "reversing_aids": self._reversing_overlay_enabled,
             },
@@ -910,6 +923,17 @@ class ConfigManager:
         enabled = _parse_overlay_flag(value, default=self._battery_overlay_enabled)
         with self._lock:
             self._battery_overlay_enabled = enabled
+            self._save()
+        return enabled
+
+    def get_wifi_overlay_enabled(self) -> bool:
+        with self._lock:
+            return self._wifi_overlay_enabled
+
+    def set_wifi_overlay_enabled(self, value: Any) -> bool:
+        enabled = _parse_overlay_flag(value, default=self._wifi_overlay_enabled)
+        with self._lock:
+            self._wifi_overlay_enabled = enabled
             self._save()
         return enabled
 

--- a/src/rev_cam/config.py
+++ b/src/rev_cam/config.py
@@ -31,6 +31,10 @@ from .distance import (
 DEFAULT_DISTANCE_OVERLAY_ENABLED = True
 DEFAULT_DISTANCE_USE_PROJECTED = False
 
+DEFAULT_OVERLAY_MASTER_ENABLED = True
+DEFAULT_BATTERY_OVERLAY_ENABLED = True
+DEFAULT_REVERSING_OVERLAY_ENABLED = True
+
 
 @dataclass(frozen=True, slots=True)
 class DistanceMounting:
@@ -239,6 +243,26 @@ def _parse_orientation(data: Mapping[str, Any]) -> Orientation:
     except Exception as exc:
         raise ValueError(str(exc)) from exc
     return Orientation(rotation=rotation, flip_horizontal=flip_horizontal, flip_vertical=flip_vertical)
+
+
+def _parse_overlay_flag(value: Any, *, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        if math.isnan(float(value)):
+            raise ValueError("Overlay flags must be boolean values")
+        return bool(value)
+    if isinstance(value, str):
+        text = value.strip().lower()
+        if not text:
+            return default
+        if text in {"true", "1", "yes", "on", "enabled"}:
+            return True
+        if text in {"false", "0", "no", "off", "disabled"}:
+            return False
+    raise ValueError("Overlay flags must be boolean values")
 
 
 def _parse_resolution(value: Any, *, default: Resolution) -> Resolution:
@@ -630,6 +654,9 @@ class ConfigManager:
             self._battery_capacity,
             self._stream_settings,
             self._reversing_aids,
+            self._overlays_master_enabled,
+            self._battery_overlay_enabled,
+            self._reversing_overlay_enabled,
         ) = self._load()
 
     def _ensure_parent(self) -> None:
@@ -665,6 +692,9 @@ class ConfigManager:
                 DEFAULT_BATTERY_CAPACITY_MAH,
                 DEFAULT_STREAM_SETTINGS,
                 DEFAULT_REVERSING_AIDS,
+                DEFAULT_OVERLAY_MASTER_ENABLED,
+                DEFAULT_BATTERY_OVERLAY_ENABLED,
+                DEFAULT_REVERSING_OVERLAY_ENABLED,
             )
         try:
             payload = json.loads(self._path.read_text())
@@ -718,6 +748,27 @@ class ConfigManager:
                 reversing_payload, default=DEFAULT_REVERSING_AIDS
             )
 
+            overlays_payload = payload.get("overlays")
+            overlay_master_enabled = DEFAULT_OVERLAY_MASTER_ENABLED
+            battery_overlay_enabled = DEFAULT_BATTERY_OVERLAY_ENABLED
+            reversing_overlay_enabled = (
+                reversing_aids.enabled if isinstance(reversing_aids, ReversingAidsConfig) else DEFAULT_REVERSING_OVERLAY_ENABLED
+            )
+            if isinstance(overlays_payload, Mapping):
+                overlay_master_enabled = _parse_overlay_flag(
+                    overlays_payload.get("master"), default=DEFAULT_OVERLAY_MASTER_ENABLED
+                )
+                battery_overlay_enabled = _parse_overlay_flag(
+                    overlays_payload.get("battery"), default=DEFAULT_BATTERY_OVERLAY_ENABLED
+                )
+                if "distance" in overlays_payload:
+                    distance_overlay_enabled = _parse_overlay_flag(
+                        overlays_payload.get("distance"), default=distance_overlay_enabled
+                    )
+                reversing_overlay_enabled = _parse_overlay_flag(
+                    overlays_payload.get("reversing_aids"), default=reversing_overlay_enabled
+                )
+
             return (
                 orientation,
                 camera,
@@ -731,6 +782,9 @@ class ConfigManager:
                 battery_capacity,
                 stream_settings,
                 reversing_aids,
+                overlay_master_enabled,
+                battery_overlay_enabled,
+                reversing_overlay_enabled,
             )
         except (OSError, ValueError) as exc:
             raise RuntimeError(f"Failed to load configuration: {exc}") from exc
@@ -753,6 +807,12 @@ class ConfigManager:
             },
             "stream": self._stream_settings.to_dict(),
             "reversing_aids": self._reversing_aids.to_dict(),
+            "overlays": {
+                "master": self._overlays_master_enabled,
+                "battery": self._battery_overlay_enabled,
+                "distance": self._distance_overlay_enabled,
+                "reversing_aids": self._reversing_overlay_enabled,
+            },
         }
         self._path.write_text(json.dumps(payload, indent=2))
 
@@ -831,6 +891,45 @@ class ConfigManager:
             self._save()
         return enabled
 
+    def get_overlay_master_enabled(self) -> bool:
+        with self._lock:
+            return self._overlays_master_enabled
+
+    def set_overlay_master_enabled(self, value: Any) -> bool:
+        enabled = _parse_overlay_flag(value, default=self._overlays_master_enabled)
+        with self._lock:
+            self._overlays_master_enabled = enabled
+            self._save()
+        return enabled
+
+    def get_battery_overlay_enabled(self) -> bool:
+        with self._lock:
+            return self._battery_overlay_enabled
+
+    def set_battery_overlay_enabled(self, value: Any) -> bool:
+        enabled = _parse_overlay_flag(value, default=self._battery_overlay_enabled)
+        with self._lock:
+            self._battery_overlay_enabled = enabled
+            self._save()
+        return enabled
+
+    def get_reversing_overlay_enabled(self) -> bool:
+        with self._lock:
+            return self._reversing_overlay_enabled
+
+    def set_reversing_overlay_enabled(self, value: Any) -> bool:
+        enabled = _parse_overlay_flag(value, default=self._reversing_overlay_enabled)
+        with self._lock:
+            self._reversing_overlay_enabled = enabled
+            if self._reversing_aids.enabled != enabled:
+                self._reversing_aids = ReversingAidsConfig(
+                    enabled=enabled,
+                    left=self._reversing_aids.left,
+                    right=self._reversing_aids.right,
+                )
+            self._save()
+        return enabled
+
     def get_distance_mounting(self) -> DistanceMounting:
         with self._lock:
             return self._distance_mounting
@@ -898,6 +997,7 @@ class ConfigManager:
         aids = _parse_reversing_aids(data, default=self._reversing_aids)
         with self._lock:
             self._reversing_aids = aids
+            self._reversing_overlay_enabled = aids.enabled
             self._save()
         return aids
 

--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -2434,7 +2434,7 @@
               <div class="toggle-text">
                 <h4 id="overlay-battery-heading">Battery overlay</h4>
                 <p id="overlay-battery-description" class="muted helper-text">
-                  Show current battery status and wireless signal strength on the preview.
+                  Show current battery status on the preview.
                 </p>
               </div>
               <label
@@ -2443,6 +2443,24 @@
                 aria-describedby="overlay-battery-description"
               >
                 <input type="checkbox" id="overlay-battery-toggle" />
+                <span class="switch-track" aria-hidden="true">
+                  <span class="switch-thumb"></span>
+                </span>
+              </label>
+            </div>
+            <div class="toggle-row">
+              <div class="toggle-text">
+                <h4 id="overlay-wifi-heading">Wi-Fi overlay</h4>
+                <p id="overlay-wifi-description" class="muted helper-text">
+                  Display wireless connection status and signal quality on the preview.
+                </p>
+              </div>
+              <label
+                class="switch-control"
+                aria-labelledby="overlay-wifi-heading"
+                aria-describedby="overlay-wifi-description"
+              >
+                <input type="checkbox" id="overlay-wifi-toggle" />
                 <span class="switch-track" aria-hidden="true">
                   <span class="switch-thumb"></span>
                 </span>
@@ -2929,6 +2947,7 @@
       const developmentOverlaysCard = document.getElementById("development-overlays-card");
       const overlayMasterToggle = document.getElementById("overlay-master-toggle");
       const overlayBatteryToggle = document.getElementById("overlay-battery-toggle");
+      const overlayWifiToggle = document.getElementById("overlay-wifi-toggle");
       const overlayDistanceToggle = document.getElementById("overlay-distance-toggle");
       const overlayReversingToggle = document.getElementById("overlay-reversing-toggle");
       const overlaysStatus = document.getElementById("overlays-status");
@@ -4392,6 +4411,7 @@
         const toggles = [
           overlayMasterToggle,
           overlayBatteryToggle,
+          overlayWifiToggle,
           overlayDistanceToggle,
           overlayReversingToggle,
         ];
@@ -4418,6 +4438,7 @@
       const overlayToggleMessages = new Map([
         ["master_enabled", { enabled: "All overlays enabled.", disabled: "Overlay pipeline bypassed." }],
         ["battery_enabled", { enabled: "Battery overlay enabled.", disabled: "Battery overlay disabled." }],
+        ["wifi_enabled", { enabled: "Wi-Fi overlay enabled.", disabled: "Wi-Fi overlay disabled." }],
         ["distance_enabled", { enabled: "Distance overlay enabled.", disabled: "Distance overlay disabled." }],
         [
           "reversing_aids_enabled",
@@ -4440,6 +4461,9 @@
         }
         if (payload && typeof payload.battery_enabled === "boolean") {
           updateOverlayToggle(overlayBatteryToggle, payload.battery_enabled, { forceUpdate });
+        }
+        if (payload && typeof payload.wifi_enabled === "boolean") {
+          updateOverlayToggle(overlayWifiToggle, payload.wifi_enabled, { forceUpdate });
         }
         if (payload && typeof payload.distance_enabled === "boolean") {
           updateOverlayToggle(overlayDistanceToggle, payload.distance_enabled, { forceUpdate });
@@ -5761,6 +5785,7 @@
 
       bindOverlayToggle(overlayMasterToggle, "master_enabled");
       bindOverlayToggle(overlayBatteryToggle, "battery_enabled");
+      bindOverlayToggle(overlayWifiToggle, "wifi_enabled");
       bindOverlayToggle(overlayDistanceToggle, "distance_enabled");
       bindOverlayToggle(overlayReversingToggle, "reversing_aids_enabled");
 

--- a/src/rev_cam/static/settings.html
+++ b/src/rev_cam/static/settings.html
@@ -2406,6 +2406,92 @@
             ></p>
           </section>
 
+          <section id="development-overlays-card" class="card" hidden>
+            <h3>Overlay controls</h3>
+            <p class="muted helper-text">
+              Manage the overlays applied to the live camera feed. Disable the master switch to bypass overlay rendering
+              entirely for the lowest latency preview.
+            </p>
+            <div class="toggle-row">
+              <div class="toggle-text">
+                <h4 id="overlay-master-heading">Master overlay switch</h4>
+                <p id="overlay-master-description" class="muted helper-text">
+                  Stream the raw camera output without any overlays when disabled.
+                </p>
+              </div>
+              <label
+                class="switch-control"
+                aria-labelledby="overlay-master-heading"
+                aria-describedby="overlay-master-description"
+              >
+                <input type="checkbox" id="overlay-master-toggle" />
+                <span class="switch-track" aria-hidden="true">
+                  <span class="switch-thumb"></span>
+                </span>
+              </label>
+            </div>
+            <div class="toggle-row">
+              <div class="toggle-text">
+                <h4 id="overlay-battery-heading">Battery overlay</h4>
+                <p id="overlay-battery-description" class="muted helper-text">
+                  Show current battery status and wireless signal strength on the preview.
+                </p>
+              </div>
+              <label
+                class="switch-control"
+                aria-labelledby="overlay-battery-heading"
+                aria-describedby="overlay-battery-description"
+              >
+                <input type="checkbox" id="overlay-battery-toggle" />
+                <span class="switch-track" aria-hidden="true">
+                  <span class="switch-thumb"></span>
+                </span>
+              </label>
+            </div>
+            <div class="toggle-row">
+              <div class="toggle-text">
+                <h4 id="overlay-distance-heading">Distance overlay</h4>
+                <p id="overlay-distance-description" class="muted helper-text">
+                  Toggle the distance sensor readout banner without changing warning zone settings.
+                </p>
+              </div>
+              <label
+                class="switch-control"
+                aria-labelledby="overlay-distance-heading"
+                aria-describedby="overlay-distance-description"
+              >
+                <input type="checkbox" id="overlay-distance-toggle" />
+                <span class="switch-track" aria-hidden="true">
+                  <span class="switch-thumb"></span>
+                </span>
+              </label>
+            </div>
+            <div class="toggle-row">
+              <div class="toggle-text">
+                <h4 id="overlay-reversing-heading">Reversing aids overlay</h4>
+                <p id="overlay-reversing-description" class="muted helper-text">
+                  Enable the alignment guides drawn over the preview while preserving your calibration.
+                </p>
+              </div>
+              <label
+                class="switch-control"
+                aria-labelledby="overlay-reversing-heading"
+                aria-describedby="overlay-reversing-description"
+              >
+                <input type="checkbox" id="overlay-reversing-toggle" />
+                <span class="switch-track" aria-hidden="true">
+                  <span class="switch-thumb"></span>
+                </span>
+              </label>
+            </div>
+            <p
+              id="overlays-status"
+              class="muted helper-text status-text"
+              role="status"
+              aria-live="polite"
+            ></p>
+          </section>
+
           <section id="diagnostics-card" class="card" hidden>
             <h3>Camera and WebRTC diagnostics</h3>
             <p class="muted helper-text">
@@ -2840,6 +2926,15 @@
       );
       const diagnosticsWebrtcHints = document.getElementById("diagnostics-webrtc-hints");
       const diagnosticsError = document.getElementById("diagnostics-error");
+      const developmentOverlaysCard = document.getElementById("development-overlays-card");
+      const overlayMasterToggle = document.getElementById("overlay-master-toggle");
+      const overlayBatteryToggle = document.getElementById("overlay-battery-toggle");
+      const overlayDistanceToggle = document.getElementById("overlay-distance-toggle");
+      const overlayReversingToggle = document.getElementById("overlay-reversing-toggle");
+      const overlaysStatus = document.getElementById("overlays-status");
+      let overlaysStatusTimer = null;
+      let overlaysLoading = false;
+      let overlaysLoaded = false;
       const DIAGNOSTICS_DISABLED_MESSAGE = "Enable development features to run diagnostics.";
       let diagnosticsLoading = false;
       let diagnosticsStatusTimer = null;
@@ -3645,6 +3740,7 @@
         reversingAidsEnabledInput.checked = enabled;
         setReversingInputsDisabled(!enabled);
         updateReversingAidsStatus(config);
+        updateOverlayToggle(overlayReversingToggle, enabled, { forceUpdate: true });
         updateReversingAidsInputs(config, forceUpdate);
         drawReversingPreviewOverlay();
       }
@@ -4269,6 +4365,184 @@
         distanceSummary.textContent = parts.join(" • ");
       }
 
+      function clearOverlaysStatusTimer() {
+        if (overlaysStatusTimer) {
+          window.clearTimeout(overlaysStatusTimer);
+          overlaysStatusTimer = null;
+        }
+      }
+
+      function setOverlaysStatus(message, options = {}) {
+        if (!overlaysStatus) {
+          return;
+        }
+        clearOverlaysStatusTimer();
+        overlaysStatus.textContent = message || "";
+        if (message && options.persistent !== true) {
+          overlaysStatusTimer = window.setTimeout(() => {
+            if (overlaysStatus && overlaysStatus.textContent === message) {
+              overlaysStatus.textContent = "";
+            }
+            overlaysStatusTimer = null;
+          }, 4000);
+        }
+      }
+
+      function setOverlayControlsDisabled(disabled) {
+        const toggles = [
+          overlayMasterToggle,
+          overlayBatteryToggle,
+          overlayDistanceToggle,
+          overlayReversingToggle,
+        ];
+        for (const toggle of toggles) {
+          if (toggle instanceof HTMLInputElement) {
+            toggle.disabled = disabled;
+          }
+        }
+      }
+
+      function updateOverlayToggle(element, enabled, options = {}) {
+        if (!(element instanceof HTMLInputElement)) {
+          return;
+        }
+        const shouldForce = options.forceUpdate === true;
+        if (!shouldForce && element.dataset.userToggled === "true") {
+          return;
+        }
+        const desired = enabled === true;
+        element.checked = desired;
+        element.dataset.serverValue = desired ? "true" : "false";
+      }
+
+      const overlayToggleMessages = new Map([
+        ["master_enabled", { enabled: "All overlays enabled.", disabled: "Overlay pipeline bypassed." }],
+        ["battery_enabled", { enabled: "Battery overlay enabled.", disabled: "Battery overlay disabled." }],
+        ["distance_enabled", { enabled: "Distance overlay enabled.", disabled: "Distance overlay disabled." }],
+        [
+          "reversing_aids_enabled",
+          { enabled: "Reversing aids overlay enabled.", disabled: "Reversing aids overlay disabled." },
+        ],
+      ]);
+
+      function getOverlayStatusMessage(key, enabled) {
+        const entry = overlayToggleMessages.get(key);
+        if (!entry) {
+          return enabled ? "Overlay enabled." : "Overlay disabled.";
+        }
+        return enabled ? entry.enabled : entry.disabled;
+      }
+
+      function applyOverlaySettings(payload, options = {}) {
+        const forceUpdate = options.forceUpdate === true;
+        if (payload && typeof payload.master_enabled === "boolean") {
+          updateOverlayToggle(overlayMasterToggle, payload.master_enabled, { forceUpdate });
+        }
+        if (payload && typeof payload.battery_enabled === "boolean") {
+          updateOverlayToggle(overlayBatteryToggle, payload.battery_enabled, { forceUpdate });
+        }
+        if (payload && typeof payload.distance_enabled === "boolean") {
+          updateOverlayToggle(overlayDistanceToggle, payload.distance_enabled, { forceUpdate });
+          updateDistanceOverlayToggle(payload.distance_enabled, { forceUpdate: true });
+        }
+        if (payload && typeof payload.reversing_aids_enabled === "boolean") {
+          updateOverlayToggle(overlayReversingToggle, payload.reversing_aids_enabled, { forceUpdate });
+          applyReversingAids({ enabled: payload.reversing_aids_enabled }, { forceUpdate: false });
+        }
+        overlaysLoaded = true;
+      }
+
+      async function refreshOverlaySettings(options = {}) {
+        if (overlaysLoading) {
+          return;
+        }
+        overlaysLoading = true;
+        if (options.disableControls !== false) {
+          setOverlayControlsDisabled(true);
+        }
+        if (options.suppressStatus !== true) {
+          setOverlaysStatus("Loading overlay settings…", { persistent: true });
+        }
+        try {
+          const response = await fetch("/api/overlays", { cache: "no-store" });
+          if (!response.ok) {
+            throw new Error(`Overlay request failed with status ${response.status}`);
+          }
+          const payload = await response.json();
+          applyOverlaySettings(payload, { forceUpdate: true });
+          if (developmentEnabled) {
+            setOverlayControlsDisabled(false);
+          }
+          if (options.suppressStatus !== true) {
+            setOverlaysStatus("", { persistent: true });
+          }
+        } catch (error) {
+          console.error("Overlay settings load failed", error);
+          if (options.suppressStatus !== true) {
+            setOverlaysStatus("Unable to load overlay settings.", { persistent: true });
+          }
+        } finally {
+          overlaysLoading = false;
+          if (developmentEnabled) {
+            setOverlayControlsDisabled(false);
+          }
+        }
+      }
+
+      function bindOverlayToggle(element, payloadKey) {
+        if (!(element instanceof HTMLInputElement)) {
+          return;
+        }
+        element.addEventListener("change", async () => {
+          if (!(element instanceof HTMLInputElement)) {
+            return;
+          }
+          if (!developmentEnabled) {
+            updateOverlayToggle(element, element.dataset.serverValue === "true", { forceUpdate: true });
+            return;
+          }
+          const previous = element.dataset.serverValue === "true";
+          const desired = element.checked;
+          element.dataset.userToggled = "true";
+          element.disabled = true;
+          setOverlaysStatus("Saving…", { persistent: true });
+          try {
+            const response = await fetch("/api/overlays", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ [payloadKey]: desired }),
+            });
+            if (!response.ok) {
+              let detail = "Unable to update overlay settings.";
+              try {
+                const errorData = await response.json();
+                if (errorData && typeof errorData.detail === "string") {
+                  detail = errorData.detail;
+                }
+              } catch (err) {
+                console.error(err);
+              }
+              throw new Error(detail);
+            }
+            const payload = await response.json();
+            applyOverlaySettings(payload, { forceUpdate: true });
+            const saved = payload && payload[payloadKey] === true;
+            setOverlaysStatus(getOverlayStatusMessage(payloadKey, saved));
+          } catch (error) {
+            console.error("Overlay update error", error);
+            updateOverlayToggle(element, previous, { forceUpdate: true });
+            const message =
+              error instanceof Error && typeof error.message === "string" && error.message
+                ? error.message
+                : "Unable to update overlay settings.";
+            setOverlaysStatus(message, { persistent: true });
+          } finally {
+            element.disabled = !developmentEnabled;
+            delete element.dataset.userToggled;
+          }
+        });
+      }
+
       function updateDistanceOverlayToggle(enabled, options = {}) {
         if (!(distanceOverlayToggle instanceof HTMLInputElement)) {
           return;
@@ -4335,6 +4609,7 @@
           const enabled = data && data.overlay_enabled === true;
           const forceUpdate = options.updateInputs === true || options.updateCalibration === true;
           updateDistanceOverlayToggle(enabled, { forceUpdate });
+          updateOverlayToggle(overlayDistanceToggle, enabled, { forceUpdate: true });
         }
         recordDevelopmentDistanceReading(data);
       }
@@ -4593,7 +4868,10 @@
         }
       }
 
-      function applyDevelopmentEnabled(enabled, { persist = true, announce = false } = {}) {
+      function applyDevelopmentEnabled(
+        enabled,
+        { persist = true, announce = false, forceRefresh = false } = {},
+      ) {
         developmentEnabled = enabled === true;
         if (developmentToggle instanceof HTMLInputElement) {
           developmentToggle.checked = developmentEnabled;
@@ -4602,6 +4880,20 @@
         document.body.classList.toggle("development-enabled", developmentEnabled);
         if (!developmentEnabled) {
           diagnosticsLoading = false;
+        }
+        if (developmentOverlaysCard) {
+          developmentOverlaysCard.hidden = !developmentEnabled;
+        }
+        if (developmentEnabled) {
+          setOverlayControlsDisabled(overlaysLoading);
+          if (!overlaysLoading && (forceRefresh || !overlaysLoaded)) {
+            refreshOverlaySettings({ suppressStatus: overlaysLoaded })
+              .catch((err) => console.error(err));
+          }
+        } else {
+          setOverlayControlsDisabled(true);
+          setOverlaysStatus("");
+          overlaysLoaded = false;
         }
         if (developmentSystemCard) {
           developmentSystemCard.hidden = !developmentEnabled;
@@ -5467,6 +5759,11 @@
         });
       }
 
+      bindOverlayToggle(overlayMasterToggle, "master_enabled");
+      bindOverlayToggle(overlayBatteryToggle, "battery_enabled");
+      bindOverlayToggle(overlayDistanceToggle, "distance_enabled");
+      bindOverlayToggle(overlayReversingToggle, "reversing_aids_enabled");
+
       if (developmentToggle) {
         developmentToggle.addEventListener("change", () => {
           applyDevelopmentEnabled(developmentToggle.checked, { announce: true });
@@ -5575,10 +5872,13 @@
             const result = await response.json();
             const saved = result && result.overlay_enabled === true;
             updateDistanceOverlayToggle(saved, { forceUpdate: true });
+            updateOverlayToggle(overlayDistanceToggle, saved, { forceUpdate: true });
+            overlaysLoaded = true;
             setDistanceOverlayStatus(saved ? "Overlay enabled" : "Overlay disabled");
           } catch (error) {
             console.error(error);
             updateDistanceOverlayToggle(previous, { forceUpdate: true });
+            updateOverlayToggle(overlayDistanceToggle, previous, { forceUpdate: true });
             const message =
               error && typeof error.message === "string" && error.message
                 ? error.message

--- a/src/rev_cam/version.py
+++ b/src/rev_cam/version.py
@@ -1,6 +1,6 @@
 """Application version metadata."""
 
-APP_VERSION = "0.2.16"
+APP_VERSION = "1.0.0"
 """Human readable application version displayed in the UI."""
 
 __all__ = ["APP_VERSION"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,6 +14,7 @@ from rev_cam.config import (
     StreamSettings,
     generate_reversing_segments,
     DEFAULT_DISTANCE_OVERLAY_ENABLED,
+    DEFAULT_WIFI_OVERLAY_ENABLED,
     DEFAULT_BATTERY_CAPACITY_MAH,
     DEFAULT_CAMERA_CHOICE,
     DEFAULT_REVERSING_AIDS,
@@ -270,6 +271,7 @@ def test_default_overlay_settings(tmp_path: Path) -> None:
     manager = ConfigManager(tmp_path / "config.json")
     assert manager.get_overlay_master_enabled() is True
     assert manager.get_battery_overlay_enabled() is True
+    assert manager.get_wifi_overlay_enabled() is DEFAULT_WIFI_OVERLAY_ENABLED
     assert manager.get_distance_overlay_enabled() is DEFAULT_DISTANCE_OVERLAY_ENABLED
     assert manager.get_reversing_overlay_enabled() is DEFAULT_REVERSING_AIDS.enabled
 
@@ -279,10 +281,12 @@ def test_overlay_settings_persist(tmp_path: Path) -> None:
     manager = ConfigManager(config_file)
     manager.set_overlay_master_enabled(False)
     manager.set_battery_overlay_enabled(False)
+    manager.set_wifi_overlay_enabled(False)
     manager.set_distance_overlay_enabled(False)
     manager.set_reversing_overlay_enabled(False)
     reloaded = ConfigManager(config_file)
     assert reloaded.get_overlay_master_enabled() is False
     assert reloaded.get_battery_overlay_enabled() is False
+    assert reloaded.get_wifi_overlay_enabled() is False
     assert reloaded.get_distance_overlay_enabled() is False
     assert reloaded.get_reversing_overlay_enabled() is False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,6 +13,7 @@ from rev_cam.config import (
     ReversingAidsConfig,
     StreamSettings,
     generate_reversing_segments,
+    DEFAULT_DISTANCE_OVERLAY_ENABLED,
     DEFAULT_BATTERY_CAPACITY_MAH,
     DEFAULT_CAMERA_CHOICE,
     DEFAULT_REVERSING_AIDS,
@@ -263,3 +264,25 @@ def test_reversing_aids_validation(tmp_path: Path) -> None:
                 ],
             }
         )
+
+
+def test_default_overlay_settings(tmp_path: Path) -> None:
+    manager = ConfigManager(tmp_path / "config.json")
+    assert manager.get_overlay_master_enabled() is True
+    assert manager.get_battery_overlay_enabled() is True
+    assert manager.get_distance_overlay_enabled() is DEFAULT_DISTANCE_OVERLAY_ENABLED
+    assert manager.get_reversing_overlay_enabled() is DEFAULT_REVERSING_AIDS.enabled
+
+
+def test_overlay_settings_persist(tmp_path: Path) -> None:
+    config_file = tmp_path / "config.json"
+    manager = ConfigManager(config_file)
+    manager.set_overlay_master_enabled(False)
+    manager.set_battery_overlay_enabled(False)
+    manager.set_distance_overlay_enabled(False)
+    manager.set_reversing_overlay_enabled(False)
+    reloaded = ConfigManager(config_file)
+    assert reloaded.get_overlay_master_enabled() is False
+    assert reloaded.get_battery_overlay_enabled() is False
+    assert reloaded.get_distance_overlay_enabled() is False
+    assert reloaded.get_reversing_overlay_enabled() is False

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -49,3 +49,18 @@ def test_overlay_composition():
     pipeline.add_overlay(increment)
     processed = pipeline.process(frame)
     assert processed == increment(frame)
+
+
+def test_master_toggle_disables_overlays():
+    frame = make_frame()
+    pipeline = FramePipeline(lambda: orientation_provider(), overlay_enabled_provider=lambda: False)
+
+    def increment(data):
+        return [
+            [[min(channel + 1, 255) for channel in pixel] for pixel in row]
+            for row in data
+        ]
+
+    pipeline.add_overlay(increment)
+    processed = pipeline.process(frame)
+    assert processed == frame

--- a/tests/test_reversing_aids.py
+++ b/tests/test_reversing_aids.py
@@ -32,6 +32,18 @@ def test_reversing_aids_overlay_disabled() -> None:
     assert not np.any(result)
 
 
+def test_reversing_aids_overlay_respects_enabled_provider() -> None:
+    overlay = create_reversing_aids_overlay(
+        lambda: DEFAULT_REVERSING_AIDS,
+        enabled_provider=lambda: False,
+    )
+    frame = np.zeros((160, 240, 3), dtype=np.uint8)
+
+    result = overlay(frame.copy())
+
+    assert np.array_equal(result, frame)
+
+
 def test_reversing_aids_overlay_handles_non_numpy() -> None:
     overlay = create_reversing_aids_overlay(lambda: DEFAULT_REVERSING_AIDS)
     frame = [[0, 0, 0], [0, 0, 0]]


### PR DESCRIPTION
## Summary
- add persistent overlay settings with a master toggle and per-overlay switches in the configuration and API
- bypass overlay rendering in the pipeline when disabled and update overlay renderers and UI to honour the new controls
- cover the new behaviour with tests and bump the application version to 1.0.0

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9a3170dfc8332bb8763c0d474f417