### PR TITLE
Disconnect when forgetting active Wi-Fi network

### DIFF
--- a/src/rev_cam/wifi.py
+++ b/src/rev_cam/wifi.py
@@ -2376,6 +2376,7 @@ class WiFiManager:
 
 
 __all__ = [
+    "WiFiCredentialStore",
     "WiFiError",
     "WiFiNetwork",
     "WiFiStatus",

--- a/tests/test_wifi_nmcli.py
+++ b/tests/test_wifi_nmcli.py
@@ -485,3 +485,18 @@ def test_nmcli_forget_surfaces_other_errors(monkeypatch: pytest.MonkeyPatch) -> 
         backend.forget("Cafe")
 
     assert "nmcli failure" in str(excinfo.value)
+
+
+def test_nmcli_disconnect_uses_device_disconnect(monkeypatch: pytest.MonkeyPatch) -> None:
+    backend = NMCLIBackend(interface="wlan0")
+    commands: list[list[str]] = []
+
+    def fake_run(args: list[str]) -> str:
+        commands.append(list(args))
+        return ""
+
+    monkeypatch.setattr(backend, "_run", fake_run)
+
+    backend.disconnect()
+
+    assert commands == [["nmcli", "device", "disconnect", "wlan0"]]


### PR DESCRIPTION
## Summary
- add a disconnect hook to the Wi-Fi backend and implement it for the nmcli backend
- ensure the Wi-Fi manager disconnects when forgetting the currently active network
- extend tests to cover the disconnect behaviour and nmcli command usage

## Testing
- pytest tests/test_wifi_nmcli.py::test_nmcli_disconnect_uses_device_disconnect

------
https://chatgpt.com/codex/tasks/task_e_68dee74384448332a963e3948c0ffdd0