### PR TITLE
Allow loading surveillance recordings without active manager

### DIFF
--- a/src/rev_cam/recording.py
+++ b/src/rev_cam/recording.py
@@ -1,0 +1,353 @@
+"""Recording helpers for surveillance mode."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import time
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import AsyncGenerator
+
+from .camera import BaseCamera
+from .pipeline import FramePipeline
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _safe_recording_name(name: str) -> str:
+    safe_name = Path(name).name
+    if not safe_name:
+        raise FileNotFoundError("Recording not found")
+    return safe_name
+
+
+def load_recording_metadata(directory: Path) -> list[dict[str, object]]:
+    """Load recording metadata files from ``directory`` synchronously."""
+
+    items: list[dict[str, object]] = []
+    for path in sorted(directory.glob("*.meta.json"), reverse=True):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:  # pragma: no cover - best-effort parsing
+            continue
+        if isinstance(data, dict):
+            data.setdefault("name", path.stem.replace(".meta", ""))
+            items.append(data)
+    return items
+
+
+def load_recording_payload(directory: Path, name: str) -> dict[str, object]:
+    """Load a recording payload by ``name`` from ``directory`` synchronously."""
+
+    safe_name = _safe_recording_name(name)
+    path = directory / f"{safe_name}.json"
+    if not path.exists() or not path.is_file():
+        raise FileNotFoundError("Recording not found")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+@dataclass
+class RecordingManager:
+    """Capture frames for surveillance recordings with MJPEG preview support."""
+
+    camera: BaseCamera
+    pipeline: FramePipeline
+    directory: Path
+    fps: int = 10
+    jpeg_quality: int = 80
+    boundary: str = "recording"
+    max_frames: int | None = None
+    _subscribers: set[asyncio.Queue[bytes]] = field(init=False, default_factory=set)
+    _producer_task: asyncio.Task[None] | None = field(init=False, default=None)
+    _lock: asyncio.Lock = field(init=False, default_factory=asyncio.Lock)
+    _state_lock: asyncio.Lock = field(init=False, default_factory=asyncio.Lock)
+    _frame_interval: float = field(init=False)
+    _recording_active: bool = field(init=False, default=False)
+    _recording_frames: list[dict[str, object]] = field(init=False, default_factory=list)
+    _recording_started_at: datetime | None = field(init=False, default=None)
+    _recording_started_monotonic: float | None = field(init=False, default=None)
+    _recording_name: str | None = field(init=False, default=None)
+    _thumbnail: str | None = field(init=False, default=None)
+
+    def __post_init__(self) -> None:
+        if self.fps <= 0:
+            raise ValueError("fps must be positive")
+        if not (1 <= self.jpeg_quality <= 100):
+            raise ValueError("jpeg_quality must be between 1 and 100")
+        self.directory.mkdir(parents=True, exist_ok=True)
+        self._frame_interval = 1.0 / float(self.fps)
+
+    @property
+    def media_type(self) -> str:
+        return f"multipart/x-mixed-replace; boundary={self.boundary}"
+
+    @property
+    def is_recording(self) -> bool:
+        return self._recording_active
+
+    async def stream(self) -> AsyncGenerator[bytes, None]:
+        queue: asyncio.Queue[bytes] = asyncio.Queue(maxsize=1)
+        async with self._subscriber(queue):
+            while True:
+                chunk = await queue.get()
+                yield self._render_chunk(chunk)
+
+    async def start_recording(self) -> dict[str, object]:
+        async with self._state_lock:
+            if self._recording_active:
+                raise RuntimeError("Recording already in progress")
+            started_at = _utcnow()
+            monotonic = time.perf_counter()
+            name = started_at.strftime("%Y%m%d-%H%M%S")
+            self._recording_active = True
+            self._recording_frames = []
+            self._recording_started_at = started_at
+            self._recording_started_monotonic = monotonic
+            self._recording_name = name
+            self._thumbnail = None
+
+        await self._ensure_producer_running()
+        return {"name": name, "started_at": started_at.isoformat()}
+
+    async def stop_recording(self) -> dict[str, object]:
+        async with self._state_lock:
+            if not self._recording_active:
+                raise RuntimeError("No recording in progress")
+            name = self._recording_name or _utcnow().strftime("%Y%m%d-%H%M%S")
+            started_at = self._recording_started_at or _utcnow()
+            frames = list(self._recording_frames)
+            thumbnail = self._thumbnail
+            self._recording_active = False
+            self._recording_frames = []
+            self._recording_started_at = None
+            self._recording_started_monotonic = None
+            self._recording_name = None
+            self._thumbnail = None
+
+        finished_at = _utcnow()
+        duration = max(0.0, (finished_at - started_at).total_seconds())
+        metadata = {
+            "name": name,
+            "started_at": started_at.isoformat(),
+            "ended_at": finished_at.isoformat(),
+            "duration_seconds": duration,
+            "fps": self.fps,
+            "frame_count": len(frames),
+            "thumbnail": thumbnail,
+        }
+        payload = dict(metadata)
+        payload["frames"] = frames
+        data_path = self.directory / f"{name}.json"
+        meta_path = self.directory / f"{name}.meta.json"
+
+        def _write_files() -> None:
+            data_path.write_text(json.dumps(payload), encoding="utf-8")
+            meta_path.write_text(json.dumps(metadata), encoding="utf-8")
+
+        await asyncio.to_thread(_write_files)
+        await self._maybe_stop_producer()
+        return metadata
+
+    async def list_recordings(self) -> list[dict[str, object]]:
+        return await asyncio.to_thread(load_recording_metadata, self.directory)
+
+    async def get_recording(self, name: str) -> dict[str, object]:
+        return await asyncio.to_thread(load_recording_payload, self.directory, name)
+
+    async def remove_recording(self, name: str) -> None:
+        safe_name = Path(name).name
+        paths = [
+            self.directory / f"{safe_name}.json",
+            self.directory / f"{safe_name}.meta.json",
+        ]
+
+        def _remove() -> None:
+            for candidate in paths:
+                try:
+                    candidate.unlink()
+                except FileNotFoundError:
+                    continue
+
+        await asyncio.to_thread(_remove)
+
+    async def apply_settings(
+        self,
+        *,
+        fps: int | None = None,
+        jpeg_quality: int | None = None,
+    ) -> None:
+        async with self._state_lock:
+            if fps is not None and fps > 0 and fps != self.fps:
+                self.fps = int(fps)
+                self._frame_interval = 1.0 / float(self.fps)
+            if jpeg_quality is not None:
+                value = int(jpeg_quality)
+                if value < 1:
+                    value = 1
+                elif value > 100:
+                    value = 100
+                self.jpeg_quality = value
+
+    async def aclose(self) -> None:
+        await self._maybe_stop_producer(force=True)
+        async with self._lock:
+            subscribers = list(self._subscribers)
+            self._subscribers.clear()
+            task = self._producer_task
+            self._producer_task = None
+        for queue in subscribers:
+            self._drain_queue(queue)
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:  # pragma: no cover
+                pass
+
+    async def _maybe_stop_producer(self, force: bool = False) -> None:
+        async with self._lock:
+            if self._producer_task is None:
+                return
+            async with self._state_lock:
+                active = self._recording_active
+            if self._subscribers or active:
+                if not force:
+                    return
+            task = self._producer_task
+            self._producer_task = None
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:  # pragma: no cover
+                pass
+
+    async def _ensure_producer_running(self) -> None:
+        async with self._lock:
+            if self._producer_task is None or self._producer_task.done():
+                self._producer_task = asyncio.create_task(self._produce_frames())
+
+    @asynccontextmanager
+    async def _subscriber(self, queue: asyncio.Queue[bytes]):
+        await self._register(queue)
+        try:
+            yield
+        finally:
+            await self._unregister(queue)
+
+    async def _register(self, queue: asyncio.Queue[bytes]) -> None:
+        should_start = False
+        async with self._lock:
+            self._subscribers.add(queue)
+            should_start = self._producer_task is None or self._producer_task.done()
+        if should_start:
+            await self._ensure_producer_running()
+
+    async def _unregister(self, queue: asyncio.Queue[bytes]) -> None:
+        async with self._lock:
+            self._subscribers.discard(queue)
+            should_stop = not self._subscribers
+        if should_stop:
+            await self._maybe_stop_producer()
+
+    async def _produce_frames(self) -> None:
+        try:
+            while True:
+                iteration_start = time.perf_counter()
+                try:
+                    frame = await self.camera.get_frame()
+                except asyncio.CancelledError:  # pragma: no cover
+                    raise
+                except Exception:  # pragma: no cover
+                    await asyncio.sleep(self._frame_interval)
+                    continue
+
+                try:
+                    processed = self.pipeline.process(frame)
+                    jpeg = await asyncio.to_thread(self._encode_frame, processed)
+                except asyncio.CancelledError:  # pragma: no cover
+                    raise
+                except Exception:  # pragma: no cover
+                    await asyncio.sleep(self._frame_interval)
+                    continue
+
+                await self._record_frame(jpeg, iteration_start)
+                self._broadcast(jpeg)
+
+                elapsed = time.perf_counter() - iteration_start
+                delay = self._frame_interval - elapsed
+                if delay > 0:
+                    try:
+                        await asyncio.sleep(delay)
+                    except asyncio.CancelledError:  # pragma: no cover
+                        raise
+        except asyncio.CancelledError:  # pragma: no cover
+            pass
+
+    async def _record_frame(self, payload: bytes, frame_time: float) -> None:
+        async with self._state_lock:
+            if not self._recording_active:
+                return
+            start = self._recording_started_monotonic
+            if start is None:
+                timestamp = 0.0
+            else:
+                timestamp = max(0.0, frame_time - start)
+            encoded = base64.b64encode(payload).decode("ascii")
+            if self._thumbnail is None:
+                self._thumbnail = encoded
+            frame_entry: dict[str, object] = {
+                "timestamp": round(timestamp, 4),
+                "jpeg": encoded,
+            }
+            self._recording_frames.append(frame_entry)
+            if self.max_frames is not None and len(self._recording_frames) >= self.max_frames:
+                self._recording_active = False
+
+    def _broadcast(self, payload: bytes) -> None:
+        for queue in list(self._subscribers):
+            self._offer(queue, payload)
+
+    def _offer(self, queue: asyncio.Queue[bytes], payload: bytes) -> None:
+        try:
+            queue.put_nowait(payload)
+        except asyncio.QueueFull:  # pragma: no cover
+            self._drain_queue(queue)
+            try:
+                queue.put_nowait(payload)
+            except asyncio.QueueFull:  # pragma: no cover
+                pass
+
+    def _drain_queue(self, queue: asyncio.Queue[bytes]) -> None:
+        try:
+            queue.get_nowait()
+        except asyncio.QueueEmpty:  # pragma: no cover
+            return
+
+    def _encode_frame(self, frame) -> bytes:
+        from .streaming import encode_frame_to_jpeg
+
+        return encode_frame_to_jpeg(frame, quality=self.jpeg_quality)
+
+    def _render_chunk(self, payload: bytes) -> bytes:
+        header = (
+            f"--{self.boundary}\r\n"
+            "Content-Type: image/jpeg\r\n"
+            f"Content-Length: {len(payload)}\r\n"
+            "\r\n"
+        ).encode("ascii")
+        return header + payload + b"\r\n"
+
+
+__all__ = [
+    "RecordingManager",
+    "load_recording_metadata",
+    "load_recording_payload",
+]
+

--- a/src/rev_cam/static/index.html
+++ b/src/rev_cam/static/index.html
@@ -152,7 +152,7 @@
         background-color: black;
         object-fit: contain;
       }
-      button {
+      button:not(.mode-toggle-button) {
         background: linear-gradient(135deg, var(--accent), var(--accent-hover));
         color: var(--text-on-accent);
         border: none;
@@ -164,21 +164,21 @@
         transition: background var(--transition), box-shadow var(--transition),
           transform var(--transition);
       }
-      button:not(:disabled):hover {
+      button:not(.mode-toggle-button):not(:disabled):hover {
         background: linear-gradient(135deg, var(--accent-hover), var(--accent-active));
         box-shadow: 0 12px 26px var(--accent-shadow);
         transform: translateY(-1px);
       }
-      button:not(:disabled):focus-visible {
+      button:not(.mode-toggle-button):not(:disabled):focus-visible {
         background: linear-gradient(135deg, var(--accent-hover), var(--accent-active));
         box-shadow: 0 12px 26px var(--accent-shadow),
           0 0 0 1px var(--accent-active), 0 0 0 4px var(--accent-soft);
         transform: translateY(-1px);
       }
-      button:focus-visible {
+      button:not(.mode-toggle-button):focus-visible {
         outline: none;
       }
-      button:disabled {
+      button:not(.mode-toggle-button):disabled {
         opacity: 0.5;
         cursor: not-allowed;
         box-shadow: none;
@@ -673,7 +673,17 @@
   </head>
   <body>
     <header>
-      <strong class="brand">RevCam</strong>
+      <div class="brand-area">
+        <strong class="brand">RevCam</strong>
+        <div class="mode-toggle" data-mode-toggle role="group" aria-label="Viewing mode">
+          <button class="mode-toggle-button" type="button" data-mode="revcam" aria-pressed="true">
+            RevCam
+          </button>
+          <button class="mode-toggle-button" type="button" data-mode="surveillance" aria-pressed="false">
+            Surveillance
+          </button>
+        </div>
+      </div>
       <div class="header-panels">
         <div class="pill status-pill is-busy" id="status-pill" role="status" aria-live="polite">
           <svg class="status-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
@@ -852,6 +862,11 @@
       const illuminationIntensityDisplay = document.getElementById("illumination-intensity-display");
       const illuminationColourInput = document.getElementById("illumination-colour");
       const illuminationStatusBox = document.getElementById("illumination-status");
+      const modeToggle = document.querySelector("[data-mode-toggle]");
+      const modeButtons = modeToggle
+        ? Array.from(modeToggle.querySelectorAll(".mode-toggle-button"))
+        : [];
+      let currentMode = "revcam";
       const BATTERY_LEVEL_MAX = 32;
       const isFullscreenSupported = () => {
         if (document.fullscreenEnabled || document.webkitFullscreenEnabled) {
@@ -1832,6 +1847,105 @@
         toggleButton.setAttribute("aria-pressed", "false");
       }
 
+      function updateModeButtons(mode) {
+        if (!modeButtons.length) {
+          return;
+        }
+        modeButtons.forEach((button) => {
+          const target = button.dataset.mode || "";
+          button.setAttribute("aria-pressed", String(target === mode));
+        });
+      }
+
+      async function fetchSurveillanceStatus() {
+        try {
+          const response = await fetch("/api/surveillance/status", { cache: "no-store" });
+          if (!response.ok) {
+            return null;
+          }
+          const payload = await response.json();
+          return payload && typeof payload === "object" ? payload : null;
+        } catch (error) {
+          console.error("Surveillance status error", error);
+          return null;
+        }
+      }
+
+      async function changeViewingMode(targetMode) {
+        if (!modeButtons.length) {
+          return;
+        }
+        const desired = targetMode === "surveillance" ? "surveillance" : "revcam";
+        if (desired === currentMode) {
+          if (desired === "surveillance") {
+            window.location.href = "/surveillance";
+          }
+          return;
+        }
+        modeButtons.forEach((button) => {
+          button.disabled = true;
+        });
+        updateModeButtons(desired);
+        if (desired === "surveillance") {
+          stopStream("Switching to surveillance…");
+        }
+        try {
+          const response = await fetch("/api/surveillance/mode", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ mode: desired }),
+          });
+          if (!response.ok) {
+            throw new Error(`Mode switch failed with ${response.status}`);
+          }
+          currentMode = desired;
+          updateModeButtons(currentMode);
+          if (currentMode === "surveillance") {
+            window.location.href = "/surveillance";
+            return;
+          }
+          await startStream({ message: "Connecting to camera…", refreshCapabilities: true });
+        } catch (error) {
+          console.error("Mode switch error", error);
+          updateModeButtons(currentMode);
+          const message =
+            desired === "surveillance"
+              ? "Unable to enable surveillance mode"
+              : "Unable to enable RevCam mode";
+          setStatus(message, "error");
+        } finally {
+          modeButtons.forEach((button) => {
+            button.disabled = false;
+          });
+        }
+      }
+
+      async function initialiseModeToggle() {
+        if (!modeButtons.length) {
+          return "revcam";
+        }
+        updateModeButtons(currentMode);
+        modeButtons.forEach((button) => {
+          button.addEventListener("click", () => {
+            const target = button.dataset.mode || "revcam";
+            changeViewingMode(target).catch((error) =>
+              console.error("Viewing mode toggle error", error),
+            );
+          });
+        });
+        const status = await fetchSurveillanceStatus();
+        if (status && typeof status.mode === "string") {
+          const resolved = status.mode === "surveillance" ? "surveillance" : "revcam";
+          currentMode = resolved;
+          updateModeButtons(currentMode);
+          if (resolved === "surveillance") {
+            window.location.replace("/surveillance");
+            return "surveillance";
+          }
+        }
+        return currentMode;
+      }
+
       async function saveSnapshot() {
         if (!snapshotButton) {
           return;
@@ -2039,9 +2153,20 @@
 
       refreshIlluminationState({ showLoading: true });
       scheduleBatteryUpdates();
-      startStream({ refreshCapabilities: true }).catch((error) =>
-        console.error("Initial stream error", error),
-      );
+      initialiseModeToggle()
+        .then((mode) => {
+          if (mode === "surveillance") {
+            return null;
+          }
+          return startStream({ refreshCapabilities: true });
+        })
+        .catch((error) => {
+          console.error("Mode initialisation error", error);
+          return startStream({ refreshCapabilities: true });
+        })
+        .catch((error) => {
+          console.error("Initial stream error", error);
+        });
     </script>
   </body>
 </html>

--- a/src/rev_cam/static/surveillance.html
+++ b/src/rev_cam/static/surveillance.html
@@ -1,0 +1,528 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>RevCam Surveillance</title>
+    <link rel="icon" type="image/svg+xml" href="images/favicon.svg" />
+    <style>
+      :root {
+        color-scheme: dark;
+        --font-family: "Inter", "Manrope", "Segoe UI", system-ui, -apple-system,
+          BlinkMacSystemFont, sans-serif;
+        --line-height: 1.6;
+        --transition: 200ms ease;
+        --surface-0: rgba(14, 16, 22, 0.9);
+        --surface-1: rgba(26, 28, 36, 0.85);
+        --surface-soft: rgba(255, 255, 255, 0.06);
+        --border-subtle: rgba(255, 255, 255, 0.08);
+        --border-muted: rgba(255, 255, 255, 0.14);
+        --text-primary: #f5f7fb;
+        --text-muted: rgba(245, 247, 250, 0.7);
+        --accent: #0a84ff;
+        --accent-hover: #2f95ff;
+        --accent-active: #55adff;
+        --accent-soft: rgba(10, 132, 255, 0.15);
+        --accent-ring: rgba(10, 132, 255, 0.45);
+        --accent-shadow: rgba(10, 132, 255, 0.35);
+        --success: #34c759;
+        --danger: #ff453a;
+        --radius-md: 0.85rem;
+        --radius-lg: 1.2rem;
+        --radius-pill: 999px;
+        --space-sm: 0.5rem;
+        --space-md: 0.9rem;
+        --space-lg: 1.4rem;
+        --space-xl: 2.1rem;
+        --shadow-sm: 0 12px 24px rgba(0, 0, 0, 0.28);
+        --shadow-md: 0 26px 46px rgba(0, 0, 0, 0.4);
+        --page-gradient: radial-gradient(115% 140% at top, #1b1e26 0%, #0b0d13 60%, #050609 100%);
+      }
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        font-family: var(--font-family);
+        line-height: var(--line-height);
+        background: var(--page-gradient);
+        color: var(--text-primary);
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
+      header,
+      footer {
+        padding: var(--space-md) var(--space-xl);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-lg);
+        background: var(--surface-0);
+        border-bottom: 1px solid var(--border-subtle);
+        backdrop-filter: blur(18px) saturate(130%);
+        -webkit-backdrop-filter: blur(18px) saturate(130%);
+        box-shadow: var(--shadow-md);
+      }
+      footer {
+        border-top: 1px solid var(--border-subtle);
+        border-bottom: none;
+        margin-top: auto;
+        justify-content: center;
+      }
+      .brand-area {
+        display: flex;
+        align-items: center;
+        gap: var(--space-lg);
+        flex-wrap: wrap;
+      }
+      strong.brand {
+        font-size: 1.3rem;
+        letter-spacing: 0.05em;
+        color: var(--success);
+      }
+      .mode-toggle {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-sm);
+        padding: calc(var(--space-sm) * 0.8);
+        border-radius: var(--radius-pill);
+        background: var(--surface-1);
+        border: 1px solid var(--border-muted);
+        box-shadow: var(--shadow-sm);
+      }
+      .mode-toggle-button {
+        appearance: none;
+        border: none;
+        background: transparent;
+        color: var(--text-muted);
+        font-weight: 600;
+        padding: 0.4rem var(--space-lg);
+        border-radius: var(--radius-pill);
+        cursor: pointer;
+        transition: background var(--transition), color var(--transition), box-shadow var(--transition);
+      }
+      .mode-toggle-button[aria-pressed="true"] {
+        background: var(--accent);
+        color: #fff;
+        box-shadow: 0 0 0 1px var(--accent-ring) inset, 0 10px 24px var(--accent-shadow);
+      }
+      .mode-toggle-button:not([aria-pressed="true"]):hover,
+      .mode-toggle-button:not([aria-pressed="true"]):focus-visible {
+        background: var(--surface-soft);
+        color: var(--text-primary);
+      }
+      .mode-toggle-button:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+      }
+      .mode-toggle-button:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+      }
+      .status-message {
+        font-weight: 600;
+        color: var(--text-muted);
+        min-width: 0;
+      }
+      .status-message[data-tone="busy"] {
+        color: var(--accent);
+      }
+      .status-message[data-tone="error"] {
+        color: var(--danger);
+      }
+      main {
+        padding: var(--space-xl);
+        display: grid;
+        grid-template-columns: minmax(280px, 1fr) minmax(260px, 320px);
+        gap: var(--space-xl);
+      }
+      .preview-card {
+        background: var(--surface-1);
+        border-radius: var(--radius-lg);
+        border: 1px solid var(--border-subtle);
+        padding: var(--space-lg);
+        box-shadow: var(--shadow-md);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-md);
+      }
+      .preview-card img {
+        width: 100%;
+        border-radius: var(--radius-md);
+        border: 1px solid var(--border-subtle);
+        background: #000;
+        display: block;
+      }
+      .controls {
+        display: flex;
+        align-items: center;
+        gap: var(--space-sm);
+        flex-wrap: wrap;
+      }
+      button.action {
+        background: linear-gradient(135deg, var(--accent), var(--accent-hover));
+        color: #fff;
+        border: none;
+        padding: 0.65rem 1.5rem;
+        border-radius: var(--radius-pill);
+        font-weight: 600;
+        cursor: pointer;
+        transition: background var(--transition), box-shadow var(--transition), transform var(--transition);
+      }
+      button.action:not(:disabled):hover {
+        background: linear-gradient(135deg, var(--accent-hover), var(--accent-active));
+        transform: translateY(-1px);
+        box-shadow: 0 12px 24px var(--accent-shadow);
+      }
+      button.action:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+      }
+      .recordings-card {
+        background: var(--surface-1);
+        border-radius: var(--radius-lg);
+        border: 1px solid var(--border-subtle);
+        padding: var(--space-lg);
+        box-shadow: var(--shadow-md);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-md);
+        max-height: 70vh;
+        overflow: hidden;
+      }
+      .recordings-header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: var(--space-sm);
+      }
+      .recordings-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        overflow-y: auto;
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-sm);
+      }
+      .recording-item {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-sm);
+        background: var(--surface-soft);
+        border-radius: var(--radius-md);
+        padding: var(--space-sm) var(--space-md);
+        border: 1px solid var(--border-subtle);
+      }
+      .recording-meta {
+        display: flex;
+        flex-direction: column;
+        gap: 0.2rem;
+      }
+      .recording-name {
+        font-weight: 600;
+      }
+      .recording-details {
+        color: var(--text-muted);
+        font-size: 0.85rem;
+      }
+      .open-recording {
+        background: transparent;
+        border: 1px solid var(--border-muted);
+        color: var(--text-primary);
+        border-radius: var(--radius-pill);
+        padding: 0.35rem 1rem;
+        cursor: pointer;
+        transition: border-color var(--transition), color var(--transition);
+      }
+      .open-recording:hover,
+      .open-recording:focus-visible {
+        border-color: var(--accent);
+        color: var(--accent);
+        outline: none;
+      }
+      .muted {
+        color: var(--text-muted);
+      }
+      a.link {
+        color: var(--accent);
+        text-decoration: none;
+        font-weight: 600;
+      }
+      a.link:hover,
+      a.link:focus-visible {
+        text-decoration: underline;
+      }
+      @media (max-width: 960px) {
+        main {
+          grid-template-columns: 1fr;
+        }
+        .recordings-card {
+          max-height: none;
+        }
+      }
+      @media (max-width: 640px) {
+        header,
+        footer {
+          flex-direction: column;
+          align-items: stretch;
+          text-align: center;
+        }
+        .brand-area {
+          justify-content: center;
+        }
+        main {
+          padding: var(--space-lg);
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div class="brand-area">
+        <strong class="brand">RevCam</strong>
+        <div class="mode-toggle" data-mode-toggle role="group" aria-label="Viewing mode">
+          <button class="mode-toggle-button" type="button" data-mode="revcam" aria-pressed="false">
+            RevCam
+          </button>
+          <button class="mode-toggle-button" type="button" data-mode="surveillance" aria-pressed="true">
+            Surveillance
+          </button>
+        </div>
+      </div>
+      <div class="status-message" id="status-message" data-tone="busy">Initialising…</div>
+    </header>
+    <main>
+      <section class="preview-card">
+        <h1>Surveillance preview</h1>
+        <img id="surveillance-preview" alt="Surveillance preview" hidden />
+        <p class="muted" id="preview-message">Preparing surveillance stream…</p>
+        <div class="controls">
+          <button class="action" type="button" id="record-button" aria-pressed="false">
+            Start recording
+          </button>
+        </div>
+      </section>
+      <section class="recordings-card">
+        <div class="recordings-header">
+          <h2>Recordings</h2>
+          <button class="open-recording" type="button" id="refresh-recordings">Refresh</button>
+        </div>
+        <p class="muted" id="recordings-empty">No recordings available yet.</p>
+        <ul class="recordings-list" id="recordings-list" aria-live="polite"></ul>
+      </section>
+    </main>
+    <footer>
+      <a class="link" href="/">Back to live view</a>
+    </footer>
+    <script>
+      const statusMessage = document.getElementById("status-message");
+      const previewImage = document.getElementById("surveillance-preview");
+      const previewMessage = document.getElementById("preview-message");
+      const recordButton = document.getElementById("record-button");
+      const recordingsList = document.getElementById("recordings-list");
+      const recordingsEmpty = document.getElementById("recordings-empty");
+      const refreshButton = document.getElementById("refresh-recordings");
+      const modeToggle = document.querySelector("[data-mode-toggle]");
+      const modeButtons = modeToggle
+        ? Array.from(modeToggle.querySelectorAll(".mode-toggle-button"))
+        : [];
+      let currentMode = "surveillance";
+      let isRecording = false;
+      let previewUrl = null;
+
+      function setStatus(message, tone = "info") {
+        if (!statusMessage) {
+          return;
+        }
+        statusMessage.textContent = message;
+        statusMessage.dataset.tone = tone;
+      }
+
+      function updateModeButtons(mode) {
+        modeButtons.forEach((button) => {
+          const target = button.dataset.mode || "";
+          button.setAttribute("aria-pressed", String(target === mode));
+        });
+      }
+
+      async function changeMode(target) {
+        const desired = target === "revcam" ? "revcam" : "surveillance";
+        if (desired === currentMode) {
+          if (desired === "revcam") {
+            window.location.href = "/";
+          }
+          return;
+        }
+        modeButtons.forEach((button) => {
+          button.disabled = true;
+        });
+        updateModeButtons(desired);
+        try {
+          const response = await fetch("/api/surveillance/mode", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ mode: desired }),
+          });
+          if (!response.ok) {
+            throw new Error(`Mode update failed with ${response.status}`);
+          }
+          if (desired === "revcam") {
+            window.location.href = "/";
+            return;
+          }
+          currentMode = desired;
+          setStatus("Surveillance mode ready", "busy");
+          await loadStatus();
+        } catch (error) {
+          console.error("Viewing mode toggle error", error);
+          updateModeButtons(currentMode);
+          setStatus("Unable to update viewing mode", "error");
+        } finally {
+          modeButtons.forEach((button) => {
+            button.disabled = false;
+          });
+        }
+      }
+
+      function updatePreview(preview) {
+        if (!preview || !preview.endpoint) {
+          if (previewImage) {
+            previewImage.hidden = true;
+            previewImage.removeAttribute("src");
+          }
+          previewUrl = null;
+          previewMessage.textContent = "Preview unavailable.";
+          return;
+        }
+        const nextUrl = `${preview.endpoint}?v=${Date.now()}`;
+        if (previewUrl !== nextUrl && previewImage) {
+          previewUrl = nextUrl;
+          previewImage.src = nextUrl;
+          previewImage.hidden = false;
+        }
+        previewMessage.textContent = "Live surveillance preview.";
+      }
+
+      function updateRecordButton() {
+        if (!recordButton) {
+          return;
+        }
+        recordButton.textContent = isRecording ? "Stop recording" : "Start recording";
+        recordButton.setAttribute("aria-pressed", String(isRecording));
+      }
+
+      function renderRecordings(records) {
+        recordingsList.innerHTML = "";
+        if (!Array.isArray(records) || records.length === 0) {
+          recordingsEmpty.hidden = false;
+          return;
+        }
+        recordingsEmpty.hidden = true;
+        records.forEach((record) => {
+          const item = document.createElement("li");
+          item.className = "recording-item";
+          const meta = document.createElement("div");
+          meta.className = "recording-meta";
+          const name = document.createElement("span");
+          name.className = "recording-name";
+          name.textContent = record.name || "Recording";
+          const details = document.createElement("span");
+          details.className = "recording-details";
+          const started = record.started_at ? new Date(record.started_at) : null;
+          const durationSeconds = typeof record.duration_seconds === "number" ? record.duration_seconds : null;
+          const formatted = [
+            started ? started.toLocaleString() : null,
+            durationSeconds != null ? `${durationSeconds.toFixed(1)}s` : null,
+          ].filter(Boolean);
+          details.textContent = formatted.join(" • ") || "Pending metadata";
+          meta.appendChild(name);
+          meta.appendChild(details);
+          const open = document.createElement("button");
+          open.type = "button";
+          open.className = "open-recording";
+          open.textContent = "Open";
+          open.addEventListener("click", () => {
+            const href = `/surveillance/player?name=${encodeURIComponent(record.name)}`;
+            window.open(href, "_blank", "noopener");
+          });
+          item.appendChild(meta);
+          item.appendChild(open);
+          recordingsList.appendChild(item);
+        });
+      }
+
+      async function loadStatus() {
+        try {
+          setStatus("Loading surveillance status…", "busy");
+          const response = await fetch("/api/surveillance/status", { cache: "no-store" });
+          if (!response.ok) {
+            throw new Error(`Status request failed with ${response.status}`);
+          }
+          const payload = await response.json();
+          if (payload && typeof payload.mode === "string") {
+            currentMode = payload.mode === "surveillance" ? "surveillance" : "revcam";
+            updateModeButtons(currentMode);
+            if (currentMode !== "surveillance") {
+              window.location.replace("/");
+              return;
+            }
+          }
+          isRecording = Boolean(payload && payload.recording);
+          updateRecordButton();
+          updatePreview(payload ? payload.preview : null);
+          renderRecordings(payload && Array.isArray(payload.recordings) ? payload.recordings : []);
+          setStatus(isRecording ? "Recording" : "Surveillance ready", isRecording ? "busy" : "info");
+        } catch (error) {
+          console.error("Failed to load surveillance status", error);
+          setStatus("Unable to load surveillance status", "error");
+        }
+      }
+
+      if (recordButton) {
+        recordButton.addEventListener("click", async () => {
+          recordButton.disabled = true;
+          try {
+            const endpoint = isRecording
+              ? "/api/surveillance/recordings/stop"
+              : "/api/surveillance/recordings/start";
+            const response = await fetch(endpoint, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+            });
+            if (!response.ok) {
+              throw new Error(`Recording request failed with ${response.status}`);
+            }
+            await loadStatus();
+          } catch (error) {
+            console.error("Recording control error", error);
+            setStatus("Recording request failed", "error");
+          } finally {
+            recordButton.disabled = false;
+          }
+        });
+      }
+
+      if (refreshButton) {
+        refreshButton.addEventListener("click", () => {
+          loadStatus();
+        });
+      }
+
+      modeButtons.forEach((button) => {
+        button.addEventListener("click", () => {
+          const target = button.dataset.mode || "revcam";
+          changeMode(target).catch((error) =>
+            console.error("Viewing mode change failure", error),
+          );
+        });
+      });
+
+      loadStatus();
+    </script>
+  </body>
+</html>

--- a/src/rev_cam/static/surveillance_player.html
+++ b/src/rev_cam/static/surveillance_player.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Surveillance Recording Playback</title>
+    <link rel="icon" type="image/svg+xml" href="images/favicon.svg" />
+    <style>
+      :root {
+        color-scheme: dark;
+        --font-family: "Inter", "Manrope", "Segoe UI", system-ui, -apple-system,
+          BlinkMacSystemFont, sans-serif;
+        --surface-0: rgba(14, 16, 22, 0.9);
+        --surface-1: rgba(26, 28, 36, 0.85);
+        --border-subtle: rgba(255, 255, 255, 0.12);
+        --text-primary: #f5f7fb;
+        --text-muted: rgba(245, 247, 250, 0.7);
+        --accent: #0a84ff;
+        --danger: #ff453a;
+        --radius-lg: 1.2rem;
+        --space-md: 1rem;
+        --space-lg: 1.6rem;
+        --page-gradient: radial-gradient(120% 140% at top, #1b1e26 0%, #0b0d13 60%, #050609 100%);
+      }
+      body {
+        margin: 0;
+        background: var(--page-gradient);
+        font-family: var(--font-family);
+        color: var(--text-primary);
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: var(--space-lg);
+      }
+      .player-card {
+        width: min(960px, 100%);
+        background: var(--surface-1);
+        border-radius: var(--radius-lg);
+        border: 1px solid var(--border-subtle);
+        box-shadow: 0 24px 48px rgba(0, 0, 0, 0.45);
+        padding: var(--space-lg);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-md);
+      }
+      .player-card header {
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+      }
+      .muted {
+        color: var(--text-muted);
+      }
+      .playback-frame {
+        width: 100%;
+        border-radius: 0.9rem;
+        border: 1px solid var(--border-subtle);
+        background: #000;
+        min-height: 260px;
+      }
+      .meta-list {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        color: var(--text-muted);
+        font-size: 0.95rem;
+      }
+      .error {
+        color: var(--danger);
+        font-weight: 600;
+      }
+      a.link {
+        color: var(--accent);
+        text-decoration: none;
+      }
+      a.link:hover,
+      a.link:focus-visible {
+        text-decoration: underline;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="player-card" role="document">
+      <header>
+        <h1 id="recording-title">Loading recording…</h1>
+        <div class="meta-list" id="recording-meta"></div>
+        <p class="muted" id="status-text">Preparing playback…</p>
+      </header>
+      <img id="playback-frame" class="playback-frame" alt="Recording playback" hidden />
+      <p class="muted">
+        <a class="link" href="/surveillance">Back to surveillance</a>
+      </p>
+    </div>
+    <script>
+      const params = new URLSearchParams(window.location.search);
+      const recordingName = params.get("name");
+      const title = document.getElementById("recording-title");
+      const metaList = document.getElementById("recording-meta");
+      const statusText = document.getElementById("status-text");
+      const playbackFrame = document.getElementById("playback-frame");
+      let playbackTimer = null;
+
+      function setStatus(message, tone = "info") {
+        if (tone === "error") {
+          statusText.classList.add("error");
+        } else {
+          statusText.classList.remove("error");
+        }
+        statusText.textContent = message;
+      }
+
+      function renderMeta(data) {
+        metaList.innerHTML = "";
+        const entries = [];
+        if (data.started_at) {
+          entries.push(`Started: ${new Date(data.started_at).toLocaleString()}`);
+        }
+        if (data.ended_at) {
+          entries.push(`Finished: ${new Date(data.ended_at).toLocaleString()}`);
+        }
+        if (typeof data.duration_seconds === "number") {
+          entries.push(`Duration: ${data.duration_seconds.toFixed(1)}s`);
+        }
+        if (typeof data.frame_count === "number") {
+          entries.push(`Frames: ${data.frame_count}`);
+        }
+        if (typeof data.fps === "number") {
+          entries.push(`Recorded at ${data.fps} fps`);
+        }
+        if (!entries.length) {
+          metaList.textContent = "No metadata available.";
+          return;
+        }
+        entries.forEach((text) => {
+          const span = document.createElement("span");
+          span.textContent = text;
+          metaList.appendChild(span);
+        });
+      }
+
+      function playFrames(frames, fps) {
+        if (!playbackFrame) {
+          return;
+        }
+        if (!Array.isArray(frames) || frames.length === 0) {
+          setStatus("Recording does not contain any frames.", "error");
+          playbackFrame.hidden = true;
+          return;
+        }
+        let index = 0;
+        const interval = fps && fps > 0 ? Math.max(40, Math.round(1000 / fps)) : 200;
+        playbackFrame.hidden = false;
+
+        const advance = () => {
+          const frame = frames[index];
+          playbackFrame.src = `data:image/jpeg;base64,${frame.jpeg}`;
+          index = (index + 1) % frames.length;
+          playbackTimer = window.setTimeout(advance, interval);
+        };
+
+        advance();
+      }
+
+      async function loadRecording() {
+        if (!recordingName) {
+          setStatus("Missing recording identifier.", "error");
+          return;
+        }
+        title.textContent = recordingName;
+        try {
+          const response = await fetch(
+            `/api/surveillance/recordings/${encodeURIComponent(recordingName)}`,
+            { cache: "no-store" },
+          );
+          if (!response.ok) {
+            throw new Error(`Request failed with ${response.status}`);
+          }
+          const payload = await response.json();
+          if (!payload || typeof payload !== "object") {
+            throw new Error("Invalid recording payload");
+          }
+          renderMeta(payload);
+          setStatus("Playing recording…");
+          playFrames(payload.frames, payload.fps);
+        } catch (error) {
+          console.error("Failed to load recording", error);
+          setStatus("Unable to load recording", "error");
+        }
+      }
+
+      window.addEventListener("beforeunload", () => {
+        if (playbackTimer) {
+          window.clearTimeout(playbackTimer);
+        }
+      });
+
+      loadRecording();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- load surveillance recording metadata from disk when the recording manager is not running
- expose stored recording payloads even when the live surveillance pipeline is inactive
- factor synchronous helpers in `recording.py` so both the backend and manager share the same file IO logic

## Testing
- pytest tests/test_app_camera.py -k surveillance *(skipped: no matching tests)*
- pytest *(fails: wifi watchdog test flakes waiting for hotspot trigger)*

------
https://chatgpt.com/codex/tasks/task_e_68def1c0a7608332a0c02dd653f7a840