### PR TITLE
Add surveillance settings UI and improve playback timing

### DIFF
--- a/src/rev_cam/app.py
+++ b/src/rev_cam/app.py
@@ -597,6 +597,7 @@ def create_app(
                 storage_threshold_percent=surveillance_settings.storage_threshold_percent,
                 motion_detection_enabled=surveillance_settings.motion_detection_enabled,
                 motion_sensitivity=surveillance_settings.motion_sensitivity,
+                motion_frame_decimation=surveillance_settings.motion_frame_decimation,
                 on_stop=_handle_recording_stopped,
             )
         else:
@@ -608,6 +609,7 @@ def create_app(
                 storage_threshold_percent=surveillance_settings.storage_threshold_percent,
                 motion_detection_enabled=surveillance_settings.motion_detection_enabled,
                 motion_sensitivity=surveillance_settings.motion_sensitivity,
+                motion_frame_decimation=surveillance_settings.motion_frame_decimation,
             )
         return recording_manager
 

--- a/src/rev_cam/app.py
+++ b/src/rev_cam/app.py
@@ -613,6 +613,7 @@ def create_app(
                 motion_detection_enabled=surveillance_settings.motion_detection_enabled,
                 motion_sensitivity=surveillance_settings.motion_sensitivity,
                 motion_frame_decimation=surveillance_settings.motion_frame_decimation,
+                motion_post_event_seconds=surveillance_settings.motion_post_event_seconds,
                 on_stop=_handle_recording_stopped,
             )
         else:
@@ -625,6 +626,7 @@ def create_app(
                 motion_detection_enabled=surveillance_settings.motion_detection_enabled,
                 motion_sensitivity=surveillance_settings.motion_sensitivity,
                 motion_frame_decimation=surveillance_settings.motion_frame_decimation,
+                motion_post_event_seconds=surveillance_settings.motion_post_event_seconds,
             )
         return recording_manager
 

--- a/src/rev_cam/app.py
+++ b/src/rev_cam/app.py
@@ -1083,6 +1083,10 @@ def create_app(
     async def surveillance_settings_page() -> str:
         return _load_static("surveillance_settings.html")
 
+    @app.get("/surveillance/timeline", response_class=HTMLResponse)
+    async def surveillance_timeline_page() -> str:
+        return _load_static("surveillance_timeline.html")
+
     @app.get("/images/{asset}")
     async def get_image(asset: str):
         safe_name = Path(asset).name

--- a/src/rev_cam/app.py
+++ b/src/rev_cam/app.py
@@ -564,6 +564,9 @@ def create_app(
         await _apply_auto_purge(settings_obj)
         surveillance_settings = settings_obj.serialise()
         storage_status = _build_storage_status(settings_obj)
+        motion_state = (
+            recording_manager.get_motion_status() if recording_manager is not None else None
+        )
         state = config_manager.get_surveillance_state().to_dict()
         return {
             "mode": current_mode.value,
@@ -572,6 +575,7 @@ def create_app(
             "preview": preview,
             "settings": surveillance_settings,
             "storage": storage_status,
+            "motion": motion_state,
             "resume_state": state,
         }
 
@@ -591,6 +595,8 @@ def create_app(
                 directory=RECORDINGS_DIR,
                 chunk_duration_seconds=surveillance_settings.chunk_duration_seconds,
                 storage_threshold_percent=surveillance_settings.storage_threshold_percent,
+                motion_detection_enabled=surveillance_settings.motion_detection_enabled,
+                motion_sensitivity=surveillance_settings.motion_sensitivity,
                 on_stop=_handle_recording_stopped,
             )
         else:
@@ -600,6 +606,8 @@ def create_app(
                 jpeg_quality=jpeg_quality,
                 chunk_duration_seconds=surveillance_settings.chunk_duration_seconds,
                 storage_threshold_percent=surveillance_settings.storage_threshold_percent,
+                motion_detection_enabled=surveillance_settings.motion_detection_enabled,
+                motion_sensitivity=surveillance_settings.motion_sensitivity,
             )
         return recording_manager
 
@@ -1783,6 +1791,8 @@ def create_app(
                     jpeg_quality=settings.resolved_jpeg_quality,
                     chunk_duration_seconds=settings.chunk_duration_seconds,
                     storage_threshold_percent=settings.storage_threshold_percent,
+                    motion_detection_enabled=settings.motion_detection_enabled,
+                    motion_sensitivity=settings.motion_sensitivity,
                 )
             except Exception as exc:  # pragma: no cover - defensive logging
                 logger.exception("Failed to apply surveillance recording settings")

--- a/src/rev_cam/app.py
+++ b/src/rev_cam/app.py
@@ -177,6 +177,8 @@ class SurveillanceSettingsPayload(BaseModel):
     remember_recording_state: bool | None = None
     motion_detection_enabled: bool | None = None
     motion_sensitivity: int | None = None
+    motion_frame_decimation: int | None = None
+    motion_post_event_seconds: float | None = None
     auto_purge_days: int | None = None
     storage_threshold_percent: float | None = None
 
@@ -1812,6 +1814,8 @@ def create_app(
                     storage_threshold_percent=settings.storage_threshold_percent,
                     motion_detection_enabled=settings.motion_detection_enabled,
                     motion_sensitivity=settings.motion_sensitivity,
+                    motion_frame_decimation=settings.motion_frame_decimation,
+                    motion_post_event_seconds=settings.motion_post_event_seconds,
                 )
             except Exception as exc:  # pragma: no cover - defensive logging
                 logger.exception("Failed to apply surveillance recording settings")

--- a/src/rev_cam/app.py
+++ b/src/rev_cam/app.py
@@ -1863,7 +1863,7 @@ def create_app(
         ):
             raise HTTPException(status_code=507, detail="Insufficient storage available")
         try:
-            details = await manager.start_recording()
+            details = await manager.start_recording(motion_mode=False)
         except RuntimeError as exc:
             raise HTTPException(status_code=409, detail=str(exc)) from exc
         _persist_surveillance_state(True)

--- a/src/rev_cam/app.py
+++ b/src/rev_cam/app.py
@@ -1869,7 +1869,10 @@ def create_app(
         ):
             raise HTTPException(status_code=507, detail="Insufficient storage available")
         try:
-            details = await manager.start_recording(motion_mode=False)
+            details = await asyncio.shield(manager.start_recording(motion_mode=False))
+        except asyncio.CancelledError:
+            _persist_surveillance_state(True)
+            raise
         except RuntimeError as exc:
             raise HTTPException(status_code=409, detail=str(exc)) from exc
         _persist_surveillance_state(True)
@@ -1895,7 +1898,10 @@ def create_app(
         ):
             raise HTTPException(status_code=507, detail="Insufficient storage available")
         try:
-            details = await manager.start_recording(motion_mode=True)
+            details = await asyncio.shield(manager.start_recording(motion_mode=True))
+        except asyncio.CancelledError:
+            _persist_surveillance_state(True)
+            raise
         except RuntimeError as exc:
             raise HTTPException(status_code=409, detail=str(exc)) from exc
         _persist_surveillance_state(True)
@@ -1908,7 +1914,10 @@ def create_app(
         if recording_manager is None:
             raise HTTPException(status_code=409, detail="No recording in progress")
         try:
-            details = await recording_manager.stop_recording()
+            details = await asyncio.shield(recording_manager.stop_recording())
+        except asyncio.CancelledError:
+            _persist_surveillance_state(False)
+            raise
         except RuntimeError as exc:
             raise HTTPException(status_code=409, detail=str(exc)) from exc
         _persist_surveillance_state(False)

--- a/src/rev_cam/app.py
+++ b/src/rev_cam/app.py
@@ -580,12 +580,18 @@ def create_app(
         recording_mode = (
             recording_manager.recording_mode if recording_manager is not None else "idle"
         )
+        started_at_iso: str | None = None
+        if recording_manager is not None:
+            started_at_value = recording_manager.recording_started_at
+            if started_at_value is not None:
+                started_at_iso = started_at_value.isoformat()
         is_recording_flag = recording_manager.is_recording if recording_manager else False
         state = config_manager.get_surveillance_state().to_dict()
         return {
             "mode": current_mode.value,
             "recording": is_recording_flag,
             "recording_mode": recording_mode,
+            "recording_started_at": started_at_iso,
             "recordings": recordings,
             "preview": preview,
             "settings": surveillance_settings,

--- a/src/rev_cam/config.py
+++ b/src/rev_cam/config.py
@@ -145,6 +145,7 @@ class SurveillanceSettings:
     remember_recording_state: bool = False
     motion_detection_enabled: bool = False
     motion_sensitivity: int = 50
+    motion_frame_decimation: int = 1
     auto_purge_days: int | None = None
     storage_threshold_percent: float = 10.0
 
@@ -194,6 +195,15 @@ class SurveillanceSettings:
         elif sensitivity > 100:
             sensitivity = 100
 
+        try:
+            decimation = int(float(self.motion_frame_decimation))
+        except (TypeError, ValueError) as exc:  # pragma: no cover - defensive branch
+            raise ValueError("Motion frame decimation must be numeric") from exc
+        if decimation < 1:
+            decimation = 1
+        elif decimation > 30:
+            decimation = 30
+
         auto_purge: int | None
         if self.auto_purge_days in (None, "", 0):
             auto_purge = None
@@ -220,6 +230,7 @@ class SurveillanceSettings:
         object.__setattr__(self, "expert_jpeg_quality", quality)
         object.__setattr__(self, "chunk_duration_seconds", chunk_duration)
         object.__setattr__(self, "motion_sensitivity", sensitivity)
+        object.__setattr__(self, "motion_frame_decimation", decimation)
         object.__setattr__(self, "auto_purge_days", auto_purge)
         object.__setattr__(self, "storage_threshold_percent", threshold_percent)
 
@@ -249,6 +260,7 @@ class SurveillanceSettings:
             "remember_recording_state": bool(self.remember_recording_state),
             "motion_detection_enabled": bool(self.motion_detection_enabled),
             "motion_sensitivity": int(self.motion_sensitivity),
+            "motion_frame_decimation": int(self.motion_frame_decimation),
             "auto_purge_days": self.auto_purge_days,
             "storage_threshold_percent": float(self.storage_threshold_percent),
         }
@@ -536,6 +548,9 @@ def _parse_surveillance_settings(
     remember_raw = value.get("remember_recording_state", current.remember_recording_state)
     motion_enabled_raw = value.get("motion_detection_enabled", current.motion_detection_enabled)
     motion_sensitivity_raw = value.get("motion_sensitivity", current.motion_sensitivity)
+    motion_decimation_raw = value.get(
+        "motion_frame_decimation", current.motion_frame_decimation
+    )
     chunk_duration_raw = value.get("chunk_duration_seconds", current.chunk_duration_seconds)
     purge_days_raw = value.get("auto_purge_days", current.auto_purge_days)
     threshold_raw = value.get("storage_threshold_percent", current.storage_threshold_percent)
@@ -563,6 +578,7 @@ def _parse_surveillance_settings(
         motion_detection_enabled=motion_detection_enabled,
         motion_sensitivity=motion_sensitivity_raw,
         chunk_duration_seconds=chunk_duration_raw,
+        motion_frame_decimation=motion_decimation_raw,
         auto_purge_days=purge_days_raw,
         storage_threshold_percent=threshold_raw,
     )

--- a/src/rev_cam/config.py
+++ b/src/rev_cam/config.py
@@ -146,6 +146,7 @@ class SurveillanceSettings:
     motion_detection_enabled: bool = False
     motion_sensitivity: int = 50
     motion_frame_decimation: int = 1
+    motion_post_event_seconds: float = 2.0
     auto_purge_days: int | None = None
     storage_threshold_percent: float = 10.0
 
@@ -204,6 +205,15 @@ class SurveillanceSettings:
         elif decimation > 30:
             decimation = 30
 
+        try:
+            post_seconds = float(self.motion_post_event_seconds)
+        except (TypeError, ValueError) as exc:  # pragma: no cover - defensive branch
+            raise ValueError("Motion post-event duration must be numeric") from exc
+        if post_seconds < 0.0:
+            post_seconds = 0.0
+        elif post_seconds > 60.0:
+            post_seconds = 60.0
+
         auto_purge: int | None
         if self.auto_purge_days in (None, "", 0):
             auto_purge = None
@@ -231,6 +241,7 @@ class SurveillanceSettings:
         object.__setattr__(self, "chunk_duration_seconds", chunk_duration)
         object.__setattr__(self, "motion_sensitivity", sensitivity)
         object.__setattr__(self, "motion_frame_decimation", decimation)
+        object.__setattr__(self, "motion_post_event_seconds", float(post_seconds))
         object.__setattr__(self, "auto_purge_days", auto_purge)
         object.__setattr__(self, "storage_threshold_percent", threshold_percent)
 
@@ -261,6 +272,7 @@ class SurveillanceSettings:
             "motion_detection_enabled": bool(self.motion_detection_enabled),
             "motion_sensitivity": int(self.motion_sensitivity),
             "motion_frame_decimation": int(self.motion_frame_decimation),
+            "motion_post_event_seconds": float(self.motion_post_event_seconds),
             "auto_purge_days": self.auto_purge_days,
             "storage_threshold_percent": float(self.storage_threshold_percent),
         }
@@ -551,6 +563,9 @@ def _parse_surveillance_settings(
     motion_decimation_raw = value.get(
         "motion_frame_decimation", current.motion_frame_decimation
     )
+    motion_post_event_raw = value.get(
+        "motion_post_event_seconds", current.motion_post_event_seconds
+    )
     chunk_duration_raw = value.get("chunk_duration_seconds", current.chunk_duration_seconds)
     purge_days_raw = value.get("auto_purge_days", current.auto_purge_days)
     threshold_raw = value.get("storage_threshold_percent", current.storage_threshold_percent)
@@ -579,6 +594,7 @@ def _parse_surveillance_settings(
         motion_sensitivity=motion_sensitivity_raw,
         chunk_duration_seconds=chunk_duration_raw,
         motion_frame_decimation=motion_decimation_raw,
+        motion_post_event_seconds=motion_post_event_raw,
         auto_purge_days=purge_days_raw,
         storage_threshold_percent=threshold_raw,
     )

--- a/src/rev_cam/recording.py
+++ b/src/rev_cam/recording.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+import shutil
 import time
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import AsyncGenerator
+from typing import AsyncGenerator, Awaitable, Callable, Mapping
 
 from .camera import BaseCamera
 from .pipeline import FramePipeline
@@ -38,6 +39,16 @@ def load_recording_metadata(directory: Path) -> list[dict[str, object]]:
             continue
         if isinstance(data, dict):
             data.setdefault("name", path.stem.replace(".meta", ""))
+            chunks = data.get("chunks")
+            if isinstance(chunks, list):
+                total = 0
+                for entry in chunks:
+                    if isinstance(entry, Mapping):
+                        size = entry.get("size_bytes")
+                        if isinstance(size, (int, float)):
+                            total += int(size)
+                if total and "size_bytes" not in data:
+                    data["size_bytes"] = total
             items.append(data)
     return items
 
@@ -46,10 +57,123 @@ def load_recording_payload(directory: Path, name: str) -> dict[str, object]:
     """Load a recording payload by ``name`` from ``directory`` synchronously."""
 
     safe_name = _safe_recording_name(name)
-    path = directory / f"{safe_name}.json"
-    if not path.exists() or not path.is_file():
-        raise FileNotFoundError("Recording not found")
-    return json.loads(path.read_text(encoding="utf-8"))
+    metadata: dict[str, object] | None = None
+    meta_path = directory / f"{safe_name}.meta.json"
+    if meta_path.exists() and meta_path.is_file():
+        try:
+            candidate = json.loads(meta_path.read_text(encoding="utf-8"))
+        except Exception:  # pragma: no cover - best-effort parsing
+            metadata = None
+        else:
+            metadata = candidate if isinstance(candidate, dict) else None
+    frames: list[dict[str, object]] = []
+    chunk_files: list[Path] = []
+    if metadata and isinstance(metadata.get("chunks"), list):
+        for entry in metadata["chunks"]:  # type: ignore[index]
+            if isinstance(entry, Mapping):
+                filename = entry.get("file")
+                if isinstance(filename, str):
+                    chunk_path = directory / filename
+                    chunk_files.append(chunk_path)
+    if chunk_files:
+        for chunk_path in chunk_files:
+            if not chunk_path.exists() or not chunk_path.is_file():
+                continue
+            try:
+                chunk_payload = json.loads(chunk_path.read_text(encoding="utf-8"))
+            except Exception:  # pragma: no cover - best-effort parsing
+                continue
+            if isinstance(chunk_payload, Mapping):
+                chunk_frames = chunk_payload.get("frames")
+            else:
+                chunk_frames = chunk_payload
+            if isinstance(chunk_frames, list):
+                frames.extend(
+                    [frame for frame in chunk_frames if isinstance(frame, Mapping)]
+                )
+    else:
+        data_path = directory / f"{safe_name}.json"
+        if not data_path.exists() or not data_path.is_file():
+            raise FileNotFoundError("Recording not found")
+        payload = json.loads(data_path.read_text(encoding="utf-8"))
+        if isinstance(payload, Mapping):
+            raw_frames = payload.get("frames")
+            if isinstance(raw_frames, list):
+                frames = [frame for frame in raw_frames if isinstance(frame, Mapping)]
+            else:
+                frames = []
+            if metadata is None:
+                metadata = {key: value for key, value in payload.items() if key != "frames"}
+        elif isinstance(payload, list):
+            frames = [frame for frame in payload if isinstance(frame, Mapping)]
+        else:
+            frames = []
+    payload: dict[str, object]
+    if metadata is not None:
+        payload = dict(metadata)
+    else:
+        payload = {"name": safe_name}
+    payload.setdefault("name", safe_name)
+    payload["frames"] = frames
+    return payload
+
+
+def remove_recording_files(directory: Path, name: str) -> None:
+    """Delete recording data and metadata for ``name``."""
+
+    safe_name = _safe_recording_name(name)
+    paths = [
+        directory / f"{safe_name}.json",
+        directory / f"{safe_name}.meta.json",
+    ]
+    metadata: dict[str, object] | None = None
+    meta_path = paths[1]
+    if meta_path.exists():
+        try:
+            metadata = json.loads(meta_path.read_text(encoding="utf-8"))
+        except Exception:  # pragma: no cover - defensive parsing
+            metadata = None
+    if isinstance(metadata, Mapping):
+        chunks = metadata.get("chunks")
+        if isinstance(chunks, list):
+            for entry in chunks:
+                if isinstance(entry, Mapping):
+                    filename = entry.get("file")
+                    if isinstance(filename, str):
+                        paths.append(directory / filename)
+    for candidate in paths:
+        try:
+            candidate.unlink()
+        except FileNotFoundError:
+            continue
+
+
+def purge_recordings(directory: Path, older_than: datetime) -> list[str]:
+    """Remove recordings that finished before ``older_than``."""
+
+    removed: list[str] = []
+    for meta_path in list(directory.glob("*.meta.json")):
+        try:
+            metadata = json.loads(meta_path.read_text(encoding="utf-8"))
+        except Exception:  # pragma: no cover - defensive parsing
+            continue
+        if not isinstance(metadata, Mapping):
+            continue
+        ended_at_raw = metadata.get("ended_at")
+        if not isinstance(ended_at_raw, str):
+            continue
+        try:
+            ended_at = datetime.fromisoformat(ended_at_raw)
+        except ValueError:
+            continue
+        if ended_at.tzinfo is None:
+            ended_at = ended_at.replace(tzinfo=timezone.utc)
+        if ended_at >= older_than:
+            continue
+        name = metadata.get("name") or meta_path.stem.replace(".meta", "")
+        remove_recording_files(directory, str(name))
+        removed.append(str(name))
+    return removed
 
 
 @dataclass
@@ -63,6 +187,9 @@ class RecordingManager:
     jpeg_quality: int = 80
     boundary: str = "recording"
     max_frames: int | None = None
+    chunk_duration_seconds: int | None = None
+    storage_threshold_percent: float = 10.0
+    on_stop: Callable[[dict[str, object]], Awaitable[None]] | None = None
     _subscribers: set[asyncio.Queue[bytes]] = field(init=False, default_factory=set)
     _producer_task: asyncio.Task[None] | None = field(init=False, default=None)
     _lock: asyncio.Lock = field(init=False, default_factory=asyncio.Lock)
@@ -74,6 +201,9 @@ class RecordingManager:
     _recording_started_monotonic: float | None = field(init=False, default=None)
     _recording_name: str | None = field(init=False, default=None)
     _thumbnail: str | None = field(init=False, default=None)
+    _next_stop_reason: str | None = field(init=False, default=None)
+    _auto_stop_task: asyncio.Task[None] | None = field(init=False, default=None)
+    _last_storage_status: dict[str, float | int] | None = field(init=False, default=None)
 
     def __post_init__(self) -> None:
         if self.fps <= 0:
@@ -82,6 +212,8 @@ class RecordingManager:
             raise ValueError("jpeg_quality must be between 1 and 100")
         self.directory.mkdir(parents=True, exist_ok=True)
         self._frame_interval = 1.0 / float(self.fps)
+        self.chunk_duration_seconds = self._normalise_chunk_duration(self.chunk_duration_seconds)
+        self.storage_threshold_percent = self._normalise_storage_threshold(self.storage_threshold_percent)
 
     @property
     def media_type(self) -> str:
@@ -111,6 +243,8 @@ class RecordingManager:
             self._recording_started_monotonic = monotonic
             self._recording_name = name
             self._thumbnail = None
+            self._next_stop_reason = None
+            self._cancel_auto_stop_task()
 
         await self._ensure_producer_running()
         return {"name": name, "started_at": started_at.isoformat()}
@@ -129,6 +263,9 @@ class RecordingManager:
             self._recording_started_monotonic = None
             self._recording_name = None
             self._thumbnail = None
+            stop_reason = self._next_stop_reason
+            self._next_stop_reason = None
+            self._cancel_auto_stop_task()
 
         finished_at = _utcnow()
         duration = max(0.0, (finished_at - started_at).total_seconds())
@@ -141,17 +278,61 @@ class RecordingManager:
             "frame_count": len(frames),
             "thumbnail": thumbnail,
         }
-        payload = dict(metadata)
-        payload["frames"] = frames
-        data_path = self.directory / f"{name}.json"
         meta_path = self.directory / f"{name}.meta.json"
 
-        def _write_files() -> None:
-            data_path.write_text(json.dumps(payload), encoding="utf-8")
+        chunks = self._chunk_frames(frames, self.fps)
+        chunk_entries: list[dict[str, object]] = []
+        total_size = 0
+
+        async def _write_chunk(filename: str, payload: dict[str, object]) -> int:
+            def _write() -> int:
+                path = self.directory / filename
+                path.write_text(json.dumps(payload), encoding="utf-8")
+                return path.stat().st_size
+
+            return await asyncio.to_thread(_write)
+
+        if not chunks:
+            chunks = [frames]
+
+        if len(chunks) == 1:
+            chunk_filename = f"{name}.json"
+            payload = {"frames": chunks[0]}
+            size = await _write_chunk(chunk_filename, payload)
+            chunk_entries.append(
+                {"file": chunk_filename, "frame_count": len(chunks[0]), "size_bytes": size}
+            )
+            total_size = size
+        else:
+            for index, group in enumerate(chunks, start=1):
+                chunk_filename = f"{name}.chunk{index:03d}.json"
+                payload = {"frames": group}
+                size = await _write_chunk(chunk_filename, payload)
+                chunk_entries.append(
+                    {"file": chunk_filename, "frame_count": len(group), "size_bytes": size}
+                )
+                total_size += size
+
+        if stop_reason:
+            metadata["stop_reason"] = stop_reason
+        if self.chunk_duration_seconds:
+            metadata["chunk_duration_seconds"] = self.chunk_duration_seconds
+        metadata["chunk_count"] = len(chunks)
+        metadata["chunks"] = chunk_entries
+        metadata["size_bytes"] = total_size
+        if self._last_storage_status:
+            metadata["storage_status"] = self._last_storage_status
+
+        def _write_metadata() -> None:
             meta_path.write_text(json.dumps(metadata), encoding="utf-8")
 
-        await asyncio.to_thread(_write_files)
+        await asyncio.to_thread(_write_metadata)
         await self._maybe_stop_producer()
+        if callable(self.on_stop):
+            try:
+                await self.on_stop(metadata)
+            except Exception:  # pragma: no cover - defensive callback guard
+                pass
         return metadata
 
     async def list_recordings(self) -> list[dict[str, object]]:
@@ -161,26 +342,15 @@ class RecordingManager:
         return await asyncio.to_thread(load_recording_payload, self.directory, name)
 
     async def remove_recording(self, name: str) -> None:
-        safe_name = Path(name).name
-        paths = [
-            self.directory / f"{safe_name}.json",
-            self.directory / f"{safe_name}.meta.json",
-        ]
-
-        def _remove() -> None:
-            for candidate in paths:
-                try:
-                    candidate.unlink()
-                except FileNotFoundError:
-                    continue
-
-        await asyncio.to_thread(_remove)
+        await asyncio.to_thread(remove_recording_files, self.directory, name)
 
     async def apply_settings(
         self,
         *,
         fps: int | None = None,
         jpeg_quality: int | None = None,
+        chunk_duration_seconds: int | None = None,
+        storage_threshold_percent: float | int | None = None,
     ) -> None:
         async with self._state_lock:
             if fps is not None and fps > 0 and fps != self.fps:
@@ -193,6 +363,10 @@ class RecordingManager:
                 elif value > 100:
                     value = 100
                 self.jpeg_quality = value
+            if chunk_duration_seconds is not None:
+                self.chunk_duration_seconds = self._normalise_chunk_duration(chunk_duration_seconds)
+            if storage_threshold_percent is not None:
+                self.storage_threshold_percent = self._normalise_storage_threshold(storage_threshold_percent)
 
     async def aclose(self) -> None:
         await self._maybe_stop_producer(force=True)
@@ -291,6 +465,8 @@ class RecordingManager:
             pass
 
     async def _record_frame(self, payload: bytes, frame_time: float) -> None:
+        storage_limit_reached = False
+        storage_status: dict[str, float | int] | None = None
         async with self._state_lock:
             if not self._recording_active:
                 return
@@ -309,6 +485,15 @@ class RecordingManager:
             self._recording_frames.append(frame_entry)
             if self.max_frames is not None and len(self._recording_frames) >= self.max_frames:
                 self._recording_active = False
+            storage_status = self._compute_storage_status()
+            if self.storage_threshold_percent > 0:
+                free_percent = float(storage_status.get("free_percent", 100.0))
+                if free_percent <= self.storage_threshold_percent:
+                    storage_limit_reached = True
+        if storage_status is None:
+            storage_status = self._compute_storage_status()
+        if storage_limit_reached:
+            self._schedule_auto_stop("storage_low")
 
     def _broadcast(self, payload: bytes) -> None:
         for queue in list(self._subscribers):
@@ -344,10 +529,89 @@ class RecordingManager:
         ).encode("ascii")
         return header + payload + b"\r\n"
 
+    def _normalise_chunk_duration(self, value: int | float | None) -> int | None:
+        if value in (None, "", 0):
+            return None
+        try:
+            duration = int(float(value))
+        except (TypeError, ValueError):  # pragma: no cover - defensive branch
+            return None
+        if duration <= 0:
+            return None
+        if duration > 24 * 60 * 60:
+            return 24 * 60 * 60
+        return duration
+
+    def _normalise_storage_threshold(self, value: float | int | None) -> float:
+        if value is None:
+            return 0.0
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError):  # pragma: no cover - defensive branch
+            return self.storage_threshold_percent
+        if numeric < 0:
+            numeric = 0.0
+        if numeric > 90:
+            numeric = 90.0
+        return numeric
+
+    def _chunk_frames(self, frames: list[dict[str, object]], fps: int) -> list[list[dict[str, object]]]:
+        duration = self.chunk_duration_seconds
+        if not frames:
+            return []
+        if duration is None or duration <= 0 or fps <= 0:
+            return [frames]
+        chunk_size = max(1, int(round(fps * duration)))
+        return [frames[index : index + chunk_size] for index in range(0, len(frames), chunk_size)]
+
+    def _compute_storage_status(self) -> dict[str, float | int]:
+        usage = shutil.disk_usage(self.directory)
+        total = int(getattr(usage, "total", 0))
+        free = int(getattr(usage, "free", 0))
+        used = int(getattr(usage, "used", total - free))
+        free_percent = 100.0 if total <= 0 else max(0.0, min(100.0, (free / total) * 100.0))
+        status = {
+            "total_bytes": total,
+            "free_bytes": free,
+            "used_bytes": used,
+            "free_percent": round(free_percent, 3),
+        }
+        self._last_storage_status = status
+        return status
+
+    def get_storage_status(self) -> dict[str, float | int]:
+        if self._last_storage_status is None:
+            return self._compute_storage_status()
+        return dict(self._last_storage_status)
+
+    def _schedule_auto_stop(self, reason: str) -> None:
+        if self._next_stop_reason is None:
+            self._next_stop_reason = reason
+        if self._auto_stop_task is None or self._auto_stop_task.done():
+            self._auto_stop_task = asyncio.create_task(self._auto_stop())
+
+    async def _auto_stop(self) -> None:
+        try:
+            await self.stop_recording()
+        except RuntimeError:
+            pass
+        except Exception:  # pragma: no cover - defensive logging
+            pass
+        finally:
+            self._auto_stop_task = None
+
+    def _cancel_auto_stop_task(self) -> None:
+        task = self._auto_stop_task
+        if task is not None and not task.done():
+            task.cancel()
+        self._auto_stop_task = None
+
 
 __all__ = [
     "RecordingManager",
     "load_recording_metadata",
     "load_recording_payload",
+    "remove_recording_files",
+    "purge_recordings",
 ]
 

--- a/src/rev_cam/recording.py
+++ b/src/rev_cam/recording.py
@@ -572,6 +572,10 @@ class RecordingManager:
             return "idle"
         return "motion" if self._active_motion_enabled else "continuous"
 
+    @property
+    def recording_started_at(self) -> datetime | None:
+        return self._recording_started_at
+
     async def stream(self) -> AsyncGenerator[bytes, None]:
         queue: asyncio.Queue[bytes] = asyncio.Queue(maxsize=1)
         async with self._subscriber(queue):

--- a/src/rev_cam/static/surveillance.html
+++ b/src/rev_cam/static/surveillance.html
@@ -338,6 +338,9 @@
           <button class="action" type="button" id="record-button" aria-pressed="false">
             Start recording
           </button>
+          <button class="action" type="button" id="motion-record-button" aria-pressed="false">
+            Start motion recording
+          </button>
         </div>
         <p class="muted storage-status" id="storage-status">Storage: —</p>
       </section>
@@ -359,6 +362,7 @@
       const previewImage = document.getElementById("surveillance-preview");
       const previewMessage = document.getElementById("preview-message");
       const recordButton = document.getElementById("record-button");
+      const motionRecordButton = document.getElementById("motion-record-button");
       const recordingsList = document.getElementById("recordings-list");
       const recordingsEmpty = document.getElementById("recordings-empty");
       const refreshButton = document.getElementById("refresh-recordings");
@@ -369,6 +373,7 @@
         : [];
       let currentMode = "surveillance";
       let isRecording = false;
+      let recordingMode = "idle";
       let previewUrl = null;
 
       function setStatus(message, tone = "info") {
@@ -444,12 +449,21 @@
         previewMessage.textContent = "Live surveillance preview.";
       }
 
-      function updateRecordButton() {
-        if (!recordButton) {
-          return;
+      function updateControlButtons() {
+        const isContinuous = recordingMode === "continuous";
+        const isMotion = recordingMode === "motion";
+        if (recordButton) {
+          recordButton.textContent = isContinuous ? "Stop recording" : "Start recording";
+          recordButton.setAttribute("aria-pressed", String(isContinuous));
+          recordButton.disabled = isMotion;
         }
-        recordButton.textContent = isRecording ? "Stop recording" : "Start recording";
-        recordButton.setAttribute("aria-pressed", String(isRecording));
+        if (motionRecordButton) {
+          motionRecordButton.textContent = isMotion
+            ? "Stop motion recording"
+            : "Start motion recording";
+          motionRecordButton.setAttribute("aria-pressed", String(isMotion));
+          motionRecordButton.disabled = isContinuous;
+        }
       }
 
       function formatBytes(bytes) {
@@ -644,12 +658,24 @@
               return;
             }
           }
-          isRecording = Boolean(payload && payload.recording);
-          updateRecordButton();
+          let nextRecordingMode = "idle";
+          if (payload && typeof payload.recording_mode === "string") {
+            const candidate = payload.recording_mode;
+            if (candidate === "motion" || candidate === "continuous") {
+              nextRecordingMode = candidate;
+            }
+          }
+          if (nextRecordingMode === "idle" && payload && payload.recording) {
+            nextRecordingMode = "continuous";
+          }
+          recordingMode = nextRecordingMode;
+          isRecording = recordingMode !== "idle";
+          updateControlButtons();
           updatePreview(payload ? payload.preview : null);
           renderRecordings(payload && Array.isArray(payload.recordings) ? payload.recordings : []);
           const storage = payload ? payload.storage : null;
           updateStorage(storage);
+          const motionSnapshot = payload ? payload.motion : null;
           const processingRecord = payload ? payload.processing_recording : null;
           const isProcessing = Boolean(payload && payload.processing);
           const processingError =
@@ -657,7 +683,20 @@
             typeof processingRecord.processing_error === "string" &&
             processingRecord.processing_error.length > 0;
           if (isRecording) {
-            setStatus("Recording", "busy");
+            if (
+              recordingMode === "motion" &&
+              motionSnapshot &&
+              motionSnapshot.session_active
+            ) {
+              const sessionState = motionSnapshot.session_state;
+              if (sessionState === "monitoring" || motionSnapshot.active === false) {
+                setStatus("Monitoring for motion", "busy");
+              } else {
+                setStatus("Motion recording", "busy");
+              }
+            } else {
+              setStatus("Recording", "busy");
+            }
           } else if (isProcessing) {
             setStatus("Processing video clip…", "busy");
           } else if (processingError) {
@@ -682,9 +721,13 @@
 
       if (recordButton) {
         recordButton.addEventListener("click", async () => {
-          recordButton.disabled = true;
+          const buttons = [recordButton, motionRecordButton].filter(Boolean);
+          buttons.forEach((button) => {
+            button.disabled = true;
+          });
           try {
-            const endpoint = isRecording
+            const stopMode = recordingMode === "continuous";
+            const endpoint = stopMode
               ? "/api/surveillance/recordings/stop"
               : "/api/surveillance/recordings/start";
             const response = await fetch(endpoint, {
@@ -699,7 +742,39 @@
             console.error("Recording control error", error);
             setStatus("Recording request failed", "error");
           } finally {
-            recordButton.disabled = false;
+            buttons.forEach((button) => {
+              button.disabled = false;
+            });
+          }
+        });
+      }
+
+      if (motionRecordButton) {
+        motionRecordButton.addEventListener("click", async () => {
+          const buttons = [recordButton, motionRecordButton].filter(Boolean);
+          buttons.forEach((button) => {
+            button.disabled = true;
+          });
+          try {
+            const stopMode = recordingMode === "motion";
+            const endpoint = stopMode
+              ? "/api/surveillance/recordings/stop"
+              : "/api/surveillance/recordings/start-motion";
+            const response = await fetch(endpoint, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+            });
+            if (!response.ok) {
+              throw new Error(`Recording request failed with ${response.status}`);
+            }
+            await loadStatus();
+          } catch (error) {
+            console.error("Motion recording control error", error);
+            setStatus("Recording request failed", "error");
+          } finally {
+            buttons.forEach((button) => {
+              button.disabled = false;
+            });
           }
         });
       }

--- a/src/rev_cam/static/surveillance.html
+++ b/src/rev_cam/static/surveillance.html
@@ -27,6 +27,7 @@
         --accent-shadow: rgba(10, 132, 255, 0.35);
         --success: #34c759;
         --danger: #ff453a;
+        --warning: #ffd60a;
         --radius-md: 0.85rem;
         --radius-lg: 1.2rem;
         --radius-pill: 999px;
@@ -133,6 +134,14 @@
       .status-message[data-tone="error"] {
         color: var(--danger);
       }
+      .status-message[data-tone="monitor"] {
+        color: var(--warning);
+        text-shadow: 0 0 12px rgba(255, 214, 10, 0.35);
+      }
+      .status-message[data-tone="alert"] {
+        color: var(--danger);
+        text-shadow: 0 0 16px rgba(255, 69, 58, 0.45);
+      }
       main {
         padding: var(--space-xl);
         display: grid;
@@ -148,6 +157,15 @@
         display: flex;
         flex-direction: column;
         gap: var(--space-md);
+        transition: border-color var(--transition), box-shadow var(--transition);
+      }
+      .preview-card.motion-monitoring {
+        border-color: rgba(255, 214, 10, 0.5);
+        box-shadow: 0 20px 40px rgba(255, 214, 10, 0.16);
+      }
+      .preview-card.motion-alert {
+        border-color: rgba(255, 69, 58, 0.6);
+        box-shadow: 0 22px 46px rgba(255, 69, 58, 0.25);
       }
       .preview-card img {
         width: 100%;
@@ -176,6 +194,31 @@
         background: linear-gradient(135deg, var(--accent-hover), var(--accent-active));
         transform: translateY(-1px);
         box-shadow: 0 12px 24px var(--accent-shadow);
+      }
+      @keyframes motionAlertPulse {
+        0% {
+          box-shadow: 0 0 0 0 rgba(255, 69, 58, 0.35);
+          transform: translateY(0);
+        }
+        50% {
+          box-shadow: 0 0 0 12px rgba(255, 69, 58, 0);
+          transform: translateY(-1px);
+        }
+        100% {
+          box-shadow: 0 0 0 0 rgba(255, 69, 58, 0.35);
+          transform: translateY(0);
+        }
+      }
+      button.action.motion-monitoring {
+        background: linear-gradient(135deg, rgba(255, 214, 10, 0.1), rgba(255, 214, 10, 0.45));
+        color: var(--warning);
+        box-shadow: 0 0 0 1px rgba(255, 214, 10, 0.35) inset, 0 10px 26px rgba(255, 214, 10, 0.25);
+      }
+      button.action.motion-alert {
+        background: linear-gradient(135deg, rgba(255, 69, 58, 0.9), rgba(255, 105, 97, 0.95));
+        color: #fff;
+        box-shadow: 0 0 0 1px rgba(255, 69, 58, 0.45) inset, 0 12px 28px rgba(255, 69, 58, 0.45);
+        animation: motionAlertPulse 1.4s ease-in-out infinite;
       }
       button.action:disabled {
         opacity: 0.6;
@@ -376,6 +419,7 @@
     </footer>
     <script>
       const statusMessage = document.getElementById("status-message");
+      const previewCard = document.querySelector(".preview-card");
       const previewImage = document.getElementById("surveillance-preview");
       const previewMessage = document.getElementById("preview-message");
       const recordButton = document.getElementById("record-button");
@@ -523,6 +567,36 @@
         const threshold = Number(storage.threshold_percent ?? 0);
         if (Number.isFinite(threshold) && threshold > 0 && freePercent <= threshold) {
           storageStatus.classList.add("is-low");
+        }
+      }
+
+      function updateMotionIndicators(motionSnapshot) {
+        if (!motionRecordButton) {
+          return;
+        }
+        motionRecordButton.classList.remove("motion-monitoring", "motion-alert");
+        if (previewCard) {
+          previewCard.classList.remove("motion-monitoring", "motion-alert");
+        }
+        if (!motionSnapshot || motionSnapshot.session_active !== true) {
+          return;
+        }
+        const sessionState = motionSnapshot.session_state;
+        const isMotionSession =
+          recordingMode === "motion" || motionSnapshot.session_override === true;
+        if (!isMotionSession) {
+          return;
+        }
+        if (sessionState === "recording") {
+          motionRecordButton.classList.add("motion-alert");
+          if (previewCard) {
+            previewCard.classList.add("motion-alert");
+          }
+        } else {
+          motionRecordButton.classList.add("motion-monitoring");
+          if (previewCard) {
+            previewCard.classList.add("motion-monitoring");
+          }
         }
       }
 
@@ -693,6 +767,7 @@
           const storage = payload ? payload.storage : null;
           updateStorage(storage);
           const motionSnapshot = payload ? payload.motion : null;
+          updateMotionIndicators(motionSnapshot);
           const processingRecord = payload ? payload.processing_recording : null;
           const isProcessing = Boolean(payload && payload.processing);
           const processingError =
@@ -707,9 +782,9 @@
             ) {
               const sessionState = motionSnapshot.session_state;
               if (sessionState === "monitoring" || motionSnapshot.active === false) {
-                setStatus("Monitoring for motion", "busy");
+                setStatus("Monitoring for motion", "monitor");
               } else {
-                setStatus("Motion recording", "busy");
+                setStatus("Motion recording", "alert");
               }
             } else {
               setStatus("Recording", "busy");

--- a/src/rev_cam/static/surveillance.html
+++ b/src/rev_cam/static/surveillance.html
@@ -180,6 +180,34 @@
         gap: var(--space-sm);
         flex-wrap: wrap;
       }
+      .recording-timer {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.45rem;
+        padding: 0.4rem 1rem;
+        border-radius: var(--radius-pill);
+        background: rgba(10, 132, 255, 0.12);
+        border: 1px solid rgba(10, 132, 255, 0.35);
+        font-weight: 600;
+        font-variant-numeric: tabular-nums;
+        color: var(--accent);
+        box-shadow: 0 10px 28px rgba(10, 132, 255, 0.18);
+      }
+      .recording-timer .recording-timer-icon {
+        font-size: 0.95rem;
+      }
+      .recording-timer .recording-timer-label {
+        text-transform: uppercase;
+        font-size: 0.7rem;
+        letter-spacing: 0.08em;
+        color: var(--text-muted);
+      }
+      .recording-timer .recording-timer-value {
+        color: var(--text-primary);
+        font-size: 0.95rem;
+        min-width: 3.5ch;
+        text-align: right;
+      }
       button.action {
         background: linear-gradient(135deg, var(--accent), var(--accent-hover));
         color: #fff;
@@ -364,6 +392,13 @@
         main {
           padding: var(--space-lg);
         }
+        .controls {
+          justify-content: center;
+        }
+        .recording-timer {
+          width: 100%;
+          justify-content: center;
+        }
       }
     </style>
   </head>
@@ -394,6 +429,11 @@
           <button class="action" type="button" id="motion-record-button" aria-pressed="false">
             Start motion recording
           </button>
+          <div class="recording-timer" id="recording-timer" aria-live="polite" hidden>
+            <span class="recording-timer-icon" aria-hidden="true">⏱</span>
+            <span class="recording-timer-label">Elapsed</span>
+            <span class="recording-timer-value" data-timer-value>00:00</span>
+          </div>
         </div>
         <p class="muted storage-status" id="storage-status">Storage: —</p>
       </section>
@@ -424,6 +464,10 @@
       const previewMessage = document.getElementById("preview-message");
       const recordButton = document.getElementById("record-button");
       const motionRecordButton = document.getElementById("motion-record-button");
+      const recordingTimer = document.getElementById("recording-timer");
+      const recordingTimerValue = recordingTimer
+        ? recordingTimer.querySelector("[data-timer-value]")
+        : null;
       const recordingsList = document.getElementById("recordings-list");
       const recordingsEmpty = document.getElementById("recordings-empty");
       const refreshButton = document.getElementById("refresh-recordings");
@@ -436,6 +480,9 @@
       let isRecording = false;
       let recordingMode = "idle";
       let previewUrl = null;
+      let recordingTimerStartMs = null;
+      let recordingTimerInterval = null;
+      let recordingTimerSource = null;
 
       function setStatus(message, tone = "info") {
         if (!statusMessage) {
@@ -443,6 +490,88 @@
         }
         statusMessage.textContent = message;
         statusMessage.dataset.tone = tone;
+      }
+
+      function renderRecordingTimer() {
+        if (!recordingTimer || !recordingTimerValue) {
+          return;
+        }
+        if (recordingTimerStartMs === null) {
+          recordingTimerValue.textContent = "00:00";
+          recordingTimer.hidden = true;
+          return;
+        }
+        const elapsedSeconds = Math.max(0, Math.floor((Date.now() - recordingTimerStartMs) / 1000));
+        const hours = Math.floor(elapsedSeconds / 3600);
+        const minutes = Math.floor((elapsedSeconds % 3600) / 60);
+        const seconds = elapsedSeconds % 60;
+        const minutesPart = hours > 0 ? String(minutes).padStart(2, "0") : String(minutes);
+        const secondsPart = String(seconds).padStart(2, "0");
+        const prefix = hours > 0 ? `${hours}:${minutesPart}` : minutesPart.padStart(2, "0");
+        const display = `${prefix}:${secondsPart}`;
+        recordingTimerValue.textContent = display;
+        recordingTimer.hidden = false;
+      }
+
+      function stopRecordingTimer() {
+        if (recordingTimerInterval !== null) {
+          window.clearInterval(recordingTimerInterval);
+          recordingTimerInterval = null;
+        }
+        recordingTimerStartMs = null;
+        recordingTimerSource = null;
+        if (recordingTimerValue) {
+          recordingTimerValue.textContent = "00:00";
+        }
+        if (recordingTimer) {
+          recordingTimer.hidden = true;
+        }
+      }
+
+      function startRecordingTimer(startIso) {
+        if (!recordingTimer || !recordingTimerValue) {
+          return;
+        }
+        if (typeof startIso !== "string" || startIso.length === 0) {
+          return;
+        }
+        const parsed = Date.parse(startIso);
+        if (Number.isNaN(parsed)) {
+          return;
+        }
+        if (recordingTimerInterval !== null) {
+          window.clearInterval(recordingTimerInterval);
+          recordingTimerInterval = null;
+        }
+        recordingTimerStartMs = parsed;
+        recordingTimerSource = startIso;
+        renderRecordingTimer();
+        recordingTimerInterval = window.setInterval(renderRecordingTimer, 1000);
+      }
+
+      function syncRecordingTimer(startIso, motionSnapshot) {
+        if (!recordingTimer) {
+          return;
+        }
+        const hasStart = typeof startIso === "string" && startIso.length > 0;
+        const isContinuousRecording = isRecording && recordingMode === "continuous";
+        let isMotionRecording = false;
+        if (recordingMode === "motion" && motionSnapshot && motionSnapshot.session_active) {
+          const sessionRecording = motionSnapshot.session_recording === true;
+          const sessionState = motionSnapshot.session_state;
+          const eventActive = motionSnapshot.event_active === true;
+          isMotionRecording = sessionRecording || eventActive || sessionState === "recording";
+        }
+        const shouldRun = hasStart && (isContinuousRecording || isMotionRecording);
+        if (!shouldRun) {
+          stopRecordingTimer();
+          return;
+        }
+        if (recordingTimerSource === startIso && recordingTimerStartMs !== null) {
+          renderRecordingTimer();
+          return;
+        }
+        startRecordingTimer(startIso);
       }
 
       function updateModeButtons(mode) {
@@ -770,6 +899,11 @@
           updateStorage(storage);
           const motionSnapshot = payload ? payload.motion : null;
           updateMotionIndicators(motionSnapshot);
+          const startedAtIso =
+            payload && typeof payload.recording_started_at === "string"
+              ? payload.recording_started_at
+              : null;
+          syncRecordingTimer(startedAtIso, motionSnapshot);
           const processingRecord = payload ? payload.processing_recording : null;
           const isProcessing = Boolean(payload && payload.processing);
           const processingError =
@@ -883,6 +1017,10 @@
             console.error("Viewing mode change failure", error),
           );
         });
+      });
+
+      window.addEventListener("pagehide", () => {
+        stopRecordingTimer();
       });
 
       loadStatus();

--- a/src/rev_cam/static/surveillance.html
+++ b/src/rev_cam/static/surveillance.html
@@ -230,6 +230,11 @@
         color: var(--text-muted);
         font-size: 0.85rem;
       }
+      .recording-actions {
+        display: flex;
+        align-items: center;
+        gap: var(--space-sm);
+      }
       .open-recording {
         background: transparent;
         border: 1px solid var(--border-muted);
@@ -244,6 +249,29 @@
         border-color: var(--accent);
         color: var(--accent);
         outline: none;
+      }
+      .delete-recording {
+        background: transparent;
+        border: 1px solid rgba(255, 69, 58, 0.5);
+        color: var(--danger);
+        border-radius: var(--radius-pill);
+        padding: 0.35rem 0.9rem;
+        cursor: pointer;
+        transition: border-color var(--transition), color var(--transition);
+      }
+      .delete-recording:hover,
+      .delete-recording:focus-visible {
+        border-color: var(--danger);
+        color: #ff6b61;
+        outline: none;
+      }
+      .storage-status {
+        margin: 0;
+        font-size: 0.9rem;
+      }
+      .storage-status.is-low {
+        color: var(--danger);
+        font-weight: 600;
       }
       .muted {
         color: var(--text-muted);
@@ -306,6 +334,7 @@
             Start recording
           </button>
         </div>
+        <p class="muted storage-status" id="storage-status">Storage: —</p>
       </section>
       <section class="recordings-card">
         <div class="recordings-header">
@@ -328,6 +357,7 @@
       const recordingsList = document.getElementById("recordings-list");
       const recordingsEmpty = document.getElementById("recordings-empty");
       const refreshButton = document.getElementById("refresh-recordings");
+      const storageStatus = document.getElementById("storage-status");
       const modeToggle = document.querySelector("[data-mode-toggle]");
       const modeButtons = modeToggle
         ? Array.from(modeToggle.querySelectorAll(".mode-toggle-button"))
@@ -417,6 +447,81 @@
         recordButton.setAttribute("aria-pressed", String(isRecording));
       }
 
+      function formatBytes(bytes) {
+        if (typeof bytes !== "number" || !Number.isFinite(bytes) || bytes < 0) {
+          return null;
+        }
+        if (bytes === 0) {
+          return "0 B";
+        }
+        const units = ["B", "KB", "MB", "GB", "TB"];
+        const exponent = Math.min(
+          units.length - 1,
+          Math.floor(Math.log(bytes) / Math.log(1024)),
+        );
+        const value = bytes / 1024 ** exponent;
+        return `${value.toFixed(value >= 10 ? 1 : 2)} ${units[exponent]}`;
+      }
+
+      function updateStorage(storage) {
+        if (!storageStatus) {
+          return;
+        }
+        storageStatus.classList.remove("is-low");
+        if (!storage || typeof storage.free_percent !== "number") {
+          storageStatus.textContent = "Storage: —";
+          return;
+        }
+        const freePercent = Number(storage.free_percent) || 0;
+        const freeText = formatBytes(storage.free_bytes);
+        const totalText = formatBytes(storage.total_bytes);
+        const parts = [];
+        if (freeText) {
+          parts.push(`${freeText} free`);
+        }
+        parts.push(`(${freePercent.toFixed(1)}%)`);
+        if (totalText) {
+          parts.push(`of ${totalText}`);
+        }
+        storageStatus.textContent = `Storage: ${parts.join(" ")}`;
+        const threshold = Number(storage.threshold_percent ?? 0);
+        if (Number.isFinite(threshold) && threshold > 0 && freePercent <= threshold) {
+          storageStatus.classList.add("is-low");
+        }
+      }
+
+      function createActionButton(label, className) {
+        const button = document.createElement("button");
+        button.type = "button";
+        button.className = className;
+        button.textContent = label;
+        return button;
+      }
+
+      async function deleteRecording(name) {
+        if (!name) {
+          return;
+        }
+        const confirmed = window.confirm(`Delete recording ${name}?`);
+        if (!confirmed) {
+          return;
+        }
+        try {
+          const response = await fetch(`/api/surveillance/recordings/${encodeURIComponent(name)}`, {
+            method: "DELETE",
+            headers: { "Content-Type": "application/json" },
+          });
+          if (!response.ok) {
+            throw new Error(`Delete failed with ${response.status}`);
+          }
+          await loadStatus();
+          setStatus(`Deleted recording ${name}.`, "info");
+        } catch (error) {
+          console.error("Failed to delete recording", error);
+          setStatus("Unable to delete recording", "error");
+        }
+      }
+
       function renderRecordings(records) {
         recordingsList.innerHTML = "";
         if (!Array.isArray(records) || records.length === 0) {
@@ -436,23 +541,39 @@
           details.className = "recording-details";
           const started = record.started_at ? new Date(record.started_at) : null;
           const durationSeconds = typeof record.duration_seconds === "number" ? record.duration_seconds : null;
+          const sizeBytes = typeof record.size_bytes === "number" ? record.size_bytes : null;
+          const chunkCount = typeof record.chunk_count === "number" ? record.chunk_count : null;
           const formatted = [
             started ? started.toLocaleString() : null,
             durationSeconds != null ? `${durationSeconds.toFixed(1)}s` : null,
+            sizeBytes != null ? formatBytes(sizeBytes) : null,
+            chunkCount && chunkCount > 1 ? `${chunkCount} chunks` : null,
+            record.stop_reason === "storage_low"
+              ? "Stopped due to low storage"
+              : typeof record.stop_reason === "string"
+              ? `Stopped: ${record.stop_reason}`
+              : null,
           ].filter(Boolean);
           details.textContent = formatted.join(" • ") || "Pending metadata";
           meta.appendChild(name);
           meta.appendChild(details);
-          const open = document.createElement("button");
-          open.type = "button";
-          open.className = "open-recording";
-          open.textContent = "Open";
+          const actions = document.createElement("div");
+          actions.className = "recording-actions";
+          const open = createActionButton("Open", "open-recording");
           open.addEventListener("click", () => {
             const href = `/surveillance/player?name=${encodeURIComponent(record.name)}`;
-            window.open(href, "_blank", "noopener");
+            window.location.href = href;
           });
+          actions.appendChild(open);
+          const removeButton = createActionButton("Delete", "delete-recording");
+          removeButton.addEventListener("click", () => {
+            deleteRecording(record.name).catch((error) => {
+              console.error("Delete recording error", error);
+            });
+          });
+          actions.appendChild(removeButton);
           item.appendChild(meta);
-          item.appendChild(open);
+          item.appendChild(actions);
           recordingsList.appendChild(item);
         });
       }
@@ -477,7 +598,18 @@
           updateRecordButton();
           updatePreview(payload ? payload.preview : null);
           renderRecordings(payload && Array.isArray(payload.recordings) ? payload.recordings : []);
+          const storage = payload ? payload.storage : null;
+          updateStorage(storage);
           setStatus(isRecording ? "Recording" : "Surveillance ready", isRecording ? "busy" : "info");
+          if (
+            storage &&
+            typeof storage.free_percent === "number" &&
+            typeof storage.threshold_percent === "number" &&
+            storage.threshold_percent > 0 &&
+            storage.free_percent <= storage.threshold_percent
+          ) {
+            setStatus("Low storage — recordings will pause automatically", "error");
+          }
         } catch (error) {
           console.error("Failed to load surveillance status", error);
           setStatus("Unable to load surveillance status", "error");

--- a/src/rev_cam/static/surveillance.html
+++ b/src/rev_cam/static/surveillance.html
@@ -545,21 +545,34 @@
           const details = document.createElement("span");
           details.className = "recording-details";
           const started = record.started_at ? new Date(record.started_at) : null;
-          const durationSeconds = typeof record.duration_seconds === "number" ? record.duration_seconds : null;
+          const durationSeconds =
+            typeof record.duration_seconds === "number" ? record.duration_seconds : null;
           const sizeBytes = typeof record.size_bytes === "number" ? record.size_bytes : null;
           const chunkCount = typeof record.chunk_count === "number" ? record.chunk_count : null;
-          const formatted = [
-            started ? started.toLocaleString() : null,
-            durationSeconds != null ? `${durationSeconds.toFixed(1)}s` : null,
-            sizeBytes != null ? formatBytes(sizeBytes) : null,
-            chunkCount && chunkCount > 1 ? `${chunkCount} chunks` : null,
-            record.stop_reason === "storage_low"
-              ? "Stopped due to low storage"
-              : typeof record.stop_reason === "string"
-              ? `Stopped: ${record.stop_reason}`
-              : null,
-          ].filter(Boolean);
-          details.textContent = formatted.join(" • ") || "Pending metadata";
+          const isProcessingRecord = Boolean(record.processing);
+          const processingError =
+            typeof record.processing_error === "string" && record.processing_error.length > 0;
+          let summaryText;
+          if (isProcessingRecord) {
+            summaryText = "Processing clip…";
+          } else if (processingError) {
+            summaryText = "Processing failed";
+            details.title = record.processing_error;
+          } else {
+            const formatted = [
+              started ? started.toLocaleString() : null,
+              durationSeconds != null ? `${durationSeconds.toFixed(1)}s` : null,
+              sizeBytes != null ? formatBytes(sizeBytes) : null,
+              chunkCount && chunkCount > 1 ? `${chunkCount} chunks` : null,
+              record.stop_reason === "storage_low"
+                ? "Stopped due to low storage"
+                : typeof record.stop_reason === "string"
+                ? `Stopped: ${record.stop_reason}`
+                : null,
+            ].filter(Boolean);
+            summaryText = formatted.join(" • ") || "Pending metadata";
+          }
+          details.textContent = summaryText;
           meta.appendChild(name);
           meta.appendChild(details);
           if (Array.isArray(record.chunks) && record.chunks.length > 0) {
@@ -589,12 +602,20 @@
           const actions = document.createElement("div");
           actions.className = "recording-actions";
           const open = createActionButton("Open", "open-recording");
+          if (isProcessingRecord) {
+            open.disabled = true;
+            open.title = "Processing clip…";
+          }
           open.addEventListener("click", () => {
             const href = `/surveillance/player?name=${encodeURIComponent(record.name)}`;
             window.location.href = href;
           });
           actions.appendChild(open);
           const removeButton = createActionButton("Delete", "delete-recording");
+          if (isProcessingRecord) {
+            removeButton.disabled = true;
+            removeButton.title = "Processing clip…";
+          }
           removeButton.addEventListener("click", () => {
             deleteRecording(record.name).catch((error) => {
               console.error("Delete recording error", error);
@@ -629,7 +650,21 @@
           renderRecordings(payload && Array.isArray(payload.recordings) ? payload.recordings : []);
           const storage = payload ? payload.storage : null;
           updateStorage(storage);
-          setStatus(isRecording ? "Recording" : "Surveillance ready", isRecording ? "busy" : "info");
+          const processingRecord = payload ? payload.processing_recording : null;
+          const isProcessing = Boolean(payload && payload.processing);
+          const processingError =
+            processingRecord &&
+            typeof processingRecord.processing_error === "string" &&
+            processingRecord.processing_error.length > 0;
+          if (isRecording) {
+            setStatus("Recording", "busy");
+          } else if (isProcessing) {
+            setStatus("Processing video clip…", "busy");
+          } else if (processingError) {
+            setStatus("Recording processing failed", "error");
+          } else {
+            setStatus("Surveillance ready", "info");
+          }
           if (
             storage &&
             typeof storage.free_percent === "number" &&

--- a/src/rev_cam/static/surveillance.html
+++ b/src/rev_cam/static/surveillance.html
@@ -582,12 +582,14 @@
           return;
         }
         const sessionState = motionSnapshot.session_state;
+        const sessionRecording = motionSnapshot.session_recording === true;
+        const eventActive = motionSnapshot.event_active === true;
         const isMotionSession =
           recordingMode === "motion" || motionSnapshot.session_override === true;
         if (!isMotionSession) {
           return;
         }
-        if (sessionState === "recording") {
+        if (sessionRecording || sessionState === "recording" || eventActive) {
           motionRecordButton.classList.add("motion-alert");
           if (previewCard) {
             previewCard.classList.add("motion-alert");
@@ -775,16 +777,13 @@
             typeof processingRecord.processing_error === "string" &&
             processingRecord.processing_error.length > 0;
           if (isRecording) {
-            if (
-              recordingMode === "motion" &&
-              motionSnapshot &&
-              motionSnapshot.session_active
-            ) {
+            if (recordingMode === "motion" && motionSnapshot && motionSnapshot.session_active) {
               const sessionState = motionSnapshot.session_state;
-              if (sessionState === "monitoring" || motionSnapshot.active === false) {
-                setStatus("Monitoring for motion", "monitor");
-              } else {
+              const sessionRecording = motionSnapshot.session_recording === true;
+              if (sessionRecording || sessionState === "recording") {
                 setStatus("Motion recording", "alert");
+              } else {
+                setStatus("Monitoring for motion", "monitor");
               }
             } else {
               setStatus("Recording", "busy");

--- a/src/rev_cam/static/surveillance.html
+++ b/src/rev_cam/static/surveillance.html
@@ -230,6 +230,11 @@
         color: var(--text-muted);
         font-size: 0.85rem;
       }
+      .recording-chunks {
+        font-size: 0.78rem;
+        color: var(--text-muted);
+        margin-top: 0.2rem;
+      }
       .recording-actions {
         display: flex;
         align-items: center;
@@ -557,6 +562,30 @@
           details.textContent = formatted.join(" • ") || "Pending metadata";
           meta.appendChild(name);
           meta.appendChild(details);
+          if (Array.isArray(record.chunks) && record.chunks.length > 0) {
+            const chunkSummaries = record.chunks
+              .map((chunk, idx) => {
+                if (!chunk || typeof chunk !== "object") {
+                  return null;
+                }
+                const label = idx + 1;
+                const chunkSize =
+                  typeof chunk.size_bytes === "number" && Number.isFinite(chunk.size_bytes)
+                    ? formatBytes(chunk.size_bytes)
+                    : null;
+                if (!chunkSize) {
+                  return null;
+                }
+                return `Chunk ${label} (${chunkSize})`;
+              })
+              .filter(Boolean);
+            if (chunkSummaries.length) {
+              const chunkLine = document.createElement("div");
+              chunkLine.className = "recording-chunks";
+              chunkLine.textContent = chunkSummaries.join(", ");
+              meta.appendChild(chunkLine);
+            }
+          }
           const actions = document.createElement("div");
           actions.className = "recording-actions";
           const open = createActionButton("Open", "open-recording");

--- a/src/rev_cam/static/surveillance.html
+++ b/src/rev_cam/static/surveillance.html
@@ -199,6 +199,12 @@
         justify-content: space-between;
         gap: var(--space-sm);
       }
+      .recordings-actions {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-sm);
+        flex-wrap: wrap;
+      }
       .recordings-list {
         list-style: none;
         margin: 0;
@@ -248,6 +254,10 @@
         padding: 0.35rem 1rem;
         cursor: pointer;
         transition: border-color var(--transition), color var(--transition);
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        text-decoration: none;
       }
       .open-recording:hover,
       .open-recording:focus-visible {
@@ -347,7 +357,14 @@
       <section class="recordings-card">
         <div class="recordings-header">
           <h2>Recordings</h2>
-          <button class="open-recording" type="button" id="refresh-recordings">Refresh</button>
+          <div class="recordings-actions">
+            <a class="open-recording" href="/surveillance/timeline" role="button"
+              >Timeline view</a
+            >
+            <button class="open-recording" type="button" id="refresh-recordings">
+              Refresh
+            </button>
+          </div>
         </div>
         <p class="muted" id="recordings-empty">No recordings available yet.</p>
         <ul class="recordings-list" id="recordings-list" aria-live="polite"></ul>

--- a/src/rev_cam/static/surveillance.html
+++ b/src/rev_cam/static/surveillance.html
@@ -317,6 +317,7 @@
       </section>
     </main>
     <footer>
+      <a class="link" href="/surveillance/settings">Surveillance settings</a>
       <a class="link" href="/">Back to live view</a>
     </footer>
     <script>

--- a/src/rev_cam/static/surveillance_player.html
+++ b/src/rev_cam/static/surveillance_player.html
@@ -148,15 +148,89 @@
           playbackFrame.hidden = true;
           return;
         }
+        const playable = frames
+          .map((frame) => ({
+            jpeg: frame && typeof frame.jpeg === "string" ? frame.jpeg : null,
+            timestamp:
+              frame && typeof frame.timestamp === "number" && Number.isFinite(frame.timestamp)
+                ? Number(frame.timestamp)
+                : null,
+          }))
+          .filter((frame) => typeof frame.jpeg === "string" && frame.jpeg.length > 0);
+        if (!playable.length) {
+          setStatus("Recording frames are invalid.", "error");
+          playbackFrame.hidden = true;
+          return;
+        }
+
+        const fallbackInterval = fps && fps > 0 ? Math.max(40, Math.round(1000 / fps)) : 200;
+        const firstTimestamp = playable.find((frame) => frame.timestamp !== null)?.timestamp ?? null;
+        let lastTimestamp = null;
+        for (let idx = playable.length - 1; idx >= 0; idx -= 1) {
+          const candidate = playable[idx].timestamp;
+          if (candidate !== null) {
+            lastTimestamp = candidate;
+            break;
+          }
+        }
+        let cycleDurationMs = fallbackInterval * playable.length;
+        if (
+          firstTimestamp !== null &&
+          lastTimestamp !== null &&
+          lastTimestamp > firstTimestamp &&
+          Number.isFinite(lastTimestamp) &&
+          Number.isFinite(firstTimestamp)
+        ) {
+          cycleDurationMs = Math.max(
+            40,
+            Math.round((lastTimestamp - firstTimestamp) * 1000),
+          );
+        }
+        if (!Number.isFinite(cycleDurationMs) || cycleDurationMs <= 0) {
+          cycleDurationMs = fallbackInterval * playable.length;
+        }
+
+        const intervals = playable.map((frame, idx) => {
+          const nextFrame = playable[(idx + 1) % playable.length];
+          const currentTs = frame.timestamp;
+          const nextTs = nextFrame.timestamp;
+          let delay = fallbackInterval;
+          if (
+            currentTs !== null &&
+            nextTs !== null &&
+            Number.isFinite(currentTs) &&
+            Number.isFinite(nextTs) &&
+            nextTs >= currentTs
+          ) {
+            delay = Math.max(40, Math.round((nextTs - currentTs) * 1000));
+          } else if (
+            currentTs !== null &&
+            Number.isFinite(currentTs) &&
+            firstTimestamp !== null &&
+            Number.isFinite(firstTimestamp) &&
+            cycleDurationMs > 0
+          ) {
+            const elapsed = Math.max(0, Math.round((currentTs - firstTimestamp) * 1000));
+            const remaining = cycleDurationMs - elapsed;
+            if (remaining > 0 && Number.isFinite(remaining)) {
+              delay = Math.max(40, remaining);
+            }
+          }
+          if (!Number.isFinite(delay) || delay <= 0) {
+            delay = fallbackInterval;
+          }
+          return delay;
+        });
+
         let index = 0;
-        const interval = fps && fps > 0 ? Math.max(40, Math.round(1000 / fps)) : 200;
         playbackFrame.hidden = false;
 
         const advance = () => {
-          const frame = frames[index];
+          const frame = playable[index];
           playbackFrame.src = `data:image/jpeg;base64,${frame.jpeg}`;
-          index = (index + 1) % frames.length;
-          playbackTimer = window.setTimeout(advance, interval);
+          const delay = intervals[index] ?? fallbackInterval;
+          index = (index + 1) % playable.length;
+          playbackTimer = window.setTimeout(advance, delay);
         };
 
         advance();

--- a/src/rev_cam/static/surveillance_player.html
+++ b/src/rev_cam/static/surveillance_player.html
@@ -66,6 +66,10 @@
         color: var(--text-muted);
         font-size: 0.95rem;
       }
+      .chunk-summary {
+        font-size: 0.85rem;
+        color: var(--text-muted);
+      }
       .error {
         color: var(--danger);
         font-weight: 600;
@@ -85,6 +89,7 @@
       <header>
         <h1 id="recording-title">Loading recording…</h1>
         <div class="meta-list" id="recording-meta"></div>
+        <div class="chunk-summary" id="chunk-summary"></div>
         <p class="muted" id="status-text">Preparing playback…</p>
       </header>
       <img id="playback-frame" class="playback-frame" alt="Recording playback" hidden />
@@ -97,6 +102,7 @@
       const recordingName = params.get("name");
       const title = document.getElementById("recording-title");
       const metaList = document.getElementById("recording-meta");
+      const chunkSummary = document.getElementById("chunk-summary");
       const statusText = document.getElementById("status-text");
       const playbackFrame = document.getElementById("playback-frame");
       let playbackTimer = null;
@@ -110,8 +116,26 @@
         statusText.textContent = message;
       }
 
+      function formatBytes(bytes) {
+        if (typeof bytes !== "number" || !Number.isFinite(bytes) || bytes < 0) {
+          return null;
+        }
+        const units = ["B", "KB", "MB", "GB", "TB"];
+        let value = bytes;
+        let index = 0;
+        while (value >= 1024 && index < units.length - 1) {
+          value /= 1024;
+          index += 1;
+        }
+        const display = value >= 10 || index === 0 ? value.toFixed(0) : value.toFixed(1);
+        return `${display.replace(/\.0$/, "")} ${units[index]}`;
+      }
+
       function renderMeta(data) {
         metaList.innerHTML = "";
+        if (chunkSummary) {
+          chunkSummary.textContent = "";
+        }
         const entries = [];
         if (data.started_at) {
           entries.push(`Started: ${new Date(data.started_at).toLocaleString()}`);
@@ -128,6 +152,12 @@
         if (typeof data.fps === "number") {
           entries.push(`Recorded at ${data.fps} fps`);
         }
+        if (typeof data.size_bytes === "number") {
+          const sizeLabel = formatBytes(data.size_bytes);
+          if (sizeLabel) {
+            entries.push(`Size: ${sizeLabel}`);
+          }
+        }
         if (!entries.length) {
           metaList.textContent = "No metadata available.";
           return;
@@ -137,6 +167,21 @@
           span.textContent = text;
           metaList.appendChild(span);
         });
+        if (Array.isArray(data.chunks) && data.chunks.length && chunkSummary) {
+          const details = data.chunks
+            .map((chunk, idx) => {
+              if (!chunk || typeof chunk !== "object") {
+                return null;
+              }
+              const label = idx + 1;
+              const sizeLabel = formatBytes(chunk.size_bytes);
+              return sizeLabel ? `Chunk ${label} — ${sizeLabel}` : null;
+            })
+            .filter(Boolean);
+          if (details.length) {
+            chunkSummary.textContent = details.join(" • ");
+          }
+        }
       }
 
       function playFrames(frames, fps) {

--- a/src/rev_cam/static/surveillance_settings.html
+++ b/src/rev_cam/static/surveillance_settings.html
@@ -430,6 +430,14 @@
               <input id="motion-sensitivity" type="range" min="0" max="100" step="1" />
               <span class="muted">Current sensitivity: <span id="motion-sensitivity-value">50</span>%</span>
             </div>
+            <div class="motion-control">
+              <label for="motion-decimation">Record every Nth frame</label>
+              <input id="motion-decimation" type="number" min="1" max="30" step="1" />
+              <span class="muted">
+                Effective motion capture: <span id="motion-effective-fps">—</span> fps.
+                Aim for 8 fps or below to balance performance and detail.
+              </span>
+            </div>
           </section>
           <section class="tab-panel" data-tab-panel="storage" hidden>
             <h2>Storage &amp; maintenance</h2>
@@ -504,6 +512,8 @@
       const motionEnabledInput = document.getElementById("motion-enabled");
       const motionSensitivityInput = document.getElementById("motion-sensitivity");
       const motionSensitivityValue = document.getElementById("motion-sensitivity-value");
+      const motionDecimationInput = document.getElementById("motion-decimation");
+      const motionEffectiveFpsText = document.getElementById("motion-effective-fps");
 
       let currentSettings = null;
 
@@ -533,6 +543,44 @@
         motionSensitivityValue.textContent = String(Math.round(numeric));
       }
 
+      function getMotionDecimation() {
+        if (!motionDecimationInput) {
+          return 1;
+        }
+        const numeric = Number.parseInt(motionDecimationInput.value, 10);
+        if (!Number.isFinite(numeric) || numeric < 1) {
+          return 1;
+        }
+        if (numeric > 30) {
+          return 30;
+        }
+        return numeric;
+      }
+
+      function formatFpsLabel(value) {
+        if (!Number.isFinite(value) || value <= 0) {
+          return "—";
+        }
+        if (value >= 10) {
+          return value.toFixed(0);
+        }
+        if (value >= 1) {
+          return value.toFixed(1).replace(/\.0$/, "");
+        }
+        return value.toFixed(2);
+      }
+
+      function updateMotionGuidance() {
+        if (!motionEffectiveFpsText) {
+          return;
+        }
+        const decimation = getMotionDecimation();
+        const effective = resolveEffectiveSettings();
+        const baseFps = Number.isFinite(effective.fps) ? effective.fps : null;
+        const motionFps = baseFps ? baseFps / Math.max(1, decimation) : null;
+        motionEffectiveFpsText.textContent = formatFpsLabel(motionFps ?? 0);
+      }
+
       tabButtons.forEach((button) => {
         button.addEventListener("click", () => {
           setActiveTab(button.dataset.tab || "recording");
@@ -544,6 +592,17 @@
         motionSensitivityInput.addEventListener("input", () => {
           updateMotionSensitivityLabel(Number(motionSensitivityInput.value));
         });
+      }
+
+      if (motionDecimationInput) {
+        motionDecimationInput.addEventListener("input", () => {
+          updateMotionGuidance();
+          updateSummary();
+        });
+      }
+
+      if (motionEnabledInput) {
+        motionEnabledInput.addEventListener("change", updateSummary);
       }
 
       if (chunkDurationInput) {
@@ -630,7 +689,19 @@
             text += ` • Split every ${minutes} min`;
           }
         }
+        if (motionEnabledInput && motionEnabledInput.checked && effective.fps) {
+          const decimation = getMotionDecimation();
+          const motionFps = effective.fps / Math.max(1, decimation);
+          const motionLabel = formatFpsLabel(motionFps);
+          if (decimation > 1) {
+            text += ` • Motion capture ~${motionLabel} fps`;
+          } else {
+            text += ` • Motion capture ${motionLabel} fps`;
+          }
+          text += " (recommended ≤ 8 fps)";
+        }
         summary.textContent = text;
+        updateMotionGuidance();
       }
 
       function applySettings(settings) {
@@ -670,6 +741,14 @@
           const value = Number(settings.motion_sensitivity ?? 50);
           motionSensitivityInput.value = Number.isFinite(value) ? value : 50;
           updateMotionSensitivityLabel(Number(motionSensitivityInput.value));
+        }
+        if (motionDecimationInput) {
+          const decimation = Number(settings.motion_frame_decimation ?? 1);
+          const normalised =
+            Number.isFinite(decimation) && decimation > 0
+              ? Math.min(30, Math.max(1, Math.round(decimation)))
+              : 1;
+          motionDecimationInput.value = normalised;
         }
         updateSummary();
       }
@@ -736,6 +815,14 @@
         if (motionSensitivityInput) {
           const motionValue = parseInt(motionSensitivityInput.value, 10);
           payload.motion_sensitivity = Number.isFinite(motionValue) ? motionValue : 50;
+        }
+        if (motionDecimationInput) {
+          const decimationValue = parseInt(motionDecimationInput.value, 10);
+          const normalised =
+            Number.isFinite(decimationValue) && decimationValue > 0
+              ? Math.min(30, Math.max(1, decimationValue))
+              : 1;
+          payload.motion_frame_decimation = normalised;
         }
         if (chunkDurationInput) {
           const chunkMinutes = parseInt(chunkDurationInput.value, 10);

--- a/src/rev_cam/static/surveillance_settings.html
+++ b/src/rev_cam/static/surveillance_settings.html
@@ -438,6 +438,13 @@
                 Aim for 8 fps or below to balance performance and detail.
               </span>
             </div>
+            <div class="motion-control">
+              <label for="motion-post-seconds">Continue recording after motion (seconds)</label>
+              <input id="motion-post-seconds" type="number" min="0" max="60" step="0.5" />
+              <span class="muted">
+                Avoids cutting off clips by holding the recording briefly once motion stops.
+              </span>
+            </div>
           </section>
           <section class="tab-panel" data-tab-panel="storage" hidden>
             <h2>Storage &amp; maintenance</h2>
@@ -514,6 +521,7 @@
       const motionSensitivityValue = document.getElementById("motion-sensitivity-value");
       const motionDecimationInput = document.getElementById("motion-decimation");
       const motionEffectiveFpsText = document.getElementById("motion-effective-fps");
+      const motionPostSecondsInput = document.getElementById("motion-post-seconds");
 
       let currentSettings = null;
 
@@ -591,6 +599,7 @@
       if (motionSensitivityInput) {
         motionSensitivityInput.addEventListener("input", () => {
           updateMotionSensitivityLabel(Number(motionSensitivityInput.value));
+          updateSummary();
         });
       }
 
@@ -599,6 +608,10 @@
           updateMotionGuidance();
           updateSummary();
         });
+      }
+
+      if (motionPostSecondsInput) {
+        motionPostSecondsInput.addEventListener("input", updateSummary);
       }
 
       if (motionEnabledInput) {
@@ -699,6 +712,13 @@
             text += ` • Motion capture ${motionLabel} fps`;
           }
           text += " (recommended ≤ 8 fps)";
+          if (motionPostSecondsInput) {
+            const lingerRaw = Number(motionPostSecondsInput.value);
+            if (Number.isFinite(lingerRaw) && lingerRaw > 0) {
+              const display = lingerRaw % 1 === 0 ? lingerRaw.toFixed(0) : lingerRaw.toFixed(1);
+              text += ` • Hold ${display}s post-motion`;
+            }
+          }
         }
         summary.textContent = text;
         updateMotionGuidance();
@@ -749,6 +769,14 @@
               ? Math.min(30, Math.max(1, Math.round(decimation)))
               : 1;
           motionDecimationInput.value = normalised;
+        }
+        if (motionPostSecondsInput) {
+          const linger = Number(settings.motion_post_event_seconds ?? 0);
+          const normalised =
+            Number.isFinite(linger) && linger >= 0
+              ? Math.min(60, Math.max(0, Math.round(linger * 2) / 2))
+              : 0;
+          motionPostSecondsInput.value = normalised;
         }
         updateSummary();
       }
@@ -823,6 +851,22 @@
               ? Math.min(30, Math.max(1, decimationValue))
               : 1;
           payload.motion_frame_decimation = normalised;
+        }
+        if (motionPostSecondsInput) {
+          const lingerValue = parseFloat(motionPostSecondsInput.value);
+          if (
+            Number.isFinite(lingerValue) &&
+            lingerValue >= 0 &&
+            lingerValue <= 60
+          ) {
+            payload.motion_post_event_seconds = lingerValue;
+          } else if (motionPostSecondsInput.value !== "") {
+            statusText.textContent = "Post-motion recording must be between 0 and 60 seconds.";
+            motionPostSecondsInput.focus();
+            return;
+          } else {
+            payload.motion_post_event_seconds = 0;
+          }
         }
         if (chunkDurationInput) {
           const chunkMinutes = parseInt(chunkDurationInput.value, 10);

--- a/src/rev_cam/static/surveillance_settings.html
+++ b/src/rev_cam/static/surveillance_settings.html
@@ -1,0 +1,551 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Surveillance settings</title>
+    <link rel="icon" type="image/svg+xml" href="images/favicon.svg" />
+    <style>
+      :root {
+        color-scheme: dark;
+        --font-family: "Inter", "Manrope", "Segoe UI", system-ui, -apple-system,
+          BlinkMacSystemFont, sans-serif;
+        --surface-0: rgba(14, 16, 22, 0.92);
+        --surface-1: rgba(24, 26, 34, 0.88);
+        --surface-2: rgba(36, 38, 48, 0.82);
+        --border-subtle: rgba(255, 255, 255, 0.14);
+        --border-strong: rgba(255, 255, 255, 0.26);
+        --text-primary: #f5f7fb;
+        --text-muted: rgba(245, 247, 250, 0.72);
+        --text-accent: #0a84ff;
+        --danger: #ff453a;
+        --success: #32d74b;
+        --radius-lg: 1.2rem;
+        --radius-md: 0.9rem;
+        --radius-sm: 0.6rem;
+        --space-xs: 0.4rem;
+        --space-sm: 0.6rem;
+        --space-md: 1rem;
+        --space-lg: 1.6rem;
+        --space-xl: 2.4rem;
+        --line-height: 1.55;
+        --shadow-lg: 0 32px 60px rgba(0, 0, 0, 0.5);
+        --shadow-md: 0 20px 40px rgba(0, 0, 0, 0.35);
+        --page-gradient: radial-gradient(120% 160% at top, #1b1e26 0%, #090b12 60%, #050609 100%);
+      }
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        font-family: var(--font-family);
+        line-height: var(--line-height);
+        background: var(--page-gradient);
+        color: var(--text-primary);
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
+      header,
+      footer {
+        padding: var(--space-md) var(--space-xl);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-lg);
+        background: var(--surface-0);
+        border-bottom: 1px solid var(--border-subtle);
+        backdrop-filter: blur(18px) saturate(130%);
+        -webkit-backdrop-filter: blur(18px) saturate(130%);
+        box-shadow: var(--shadow-md);
+      }
+      footer {
+        border-top: 1px solid var(--border-subtle);
+        border-bottom: none;
+        justify-content: center;
+        margin-top: auto;
+      }
+      main {
+        padding: var(--space-xl);
+        display: flex;
+        justify-content: center;
+      }
+      .brand-area {
+        display: flex;
+        align-items: center;
+        gap: var(--space-lg);
+        flex-wrap: wrap;
+      }
+      .brand {
+        font-size: 1.4rem;
+        font-weight: 700;
+      }
+      .settings-card {
+        width: min(960px, 100%);
+        background: var(--surface-1);
+        border-radius: var(--radius-lg);
+        border: 1px solid var(--border-subtle);
+        padding: var(--space-xl);
+        box-shadow: var(--shadow-lg);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-lg);
+      }
+      .settings-card h1 {
+        margin: 0;
+      }
+      .muted {
+        color: var(--text-muted);
+      }
+      form {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-lg);
+      }
+      fieldset {
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        padding: var(--space-md);
+        margin: 0;
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-sm);
+      }
+      legend {
+        padding: 0 var(--space-xs);
+        font-weight: 600;
+      }
+      label.option {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: var(--space-sm);
+        align-items: center;
+        padding: var(--space-sm);
+        border-radius: var(--radius-sm);
+        transition: background 140ms ease;
+      }
+      label.option:hover,
+      label.option:focus-within {
+        background: var(--surface-2);
+      }
+      label.option strong {
+        display: block;
+        font-weight: 600;
+      }
+      label.option span.helper {
+        font-size: 0.85rem;
+        color: var(--text-muted);
+      }
+      .preset-grid {
+        display: grid;
+        gap: var(--space-sm);
+      }
+      .preset-label {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: var(--space-sm);
+        align-items: start;
+        padding: var(--space-sm);
+        border-radius: var(--radius-sm);
+        border: 1px solid transparent;
+        transition: border-color 160ms ease, background 160ms ease;
+      }
+      .preset-label:hover,
+      .preset-label:focus-within {
+        background: rgba(255, 255, 255, 0.05);
+        border-color: var(--border-subtle);
+      }
+      .preset-label strong {
+        display: block;
+        font-weight: 600;
+      }
+      .preset-label span.meta {
+        display: block;
+        font-size: 0.85rem;
+        color: var(--text-muted);
+      }
+      .expert-grid {
+        display: grid;
+        gap: var(--space-md);
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      }
+      .expert-control {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-xs);
+        padding: var(--space-sm);
+        border-radius: var(--radius-sm);
+        background: rgba(255, 255, 255, 0.04);
+        border: 1px solid rgba(255, 255, 255, 0.1);
+      }
+      .expert-control label {
+        font-weight: 600;
+      }
+      .expert-control input[type="number"] {
+        padding: var(--space-sm);
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border-subtle);
+        background: rgba(0, 0, 0, 0.25);
+        color: var(--text-primary);
+        font-size: 1rem;
+      }
+      .summary {
+        padding: var(--space-md);
+        border-radius: var(--radius-md);
+        background: rgba(10, 132, 255, 0.16);
+        border: 1px solid rgba(10, 132, 255, 0.4);
+        font-weight: 600;
+      }
+      button[type="submit"] {
+        align-self: flex-start;
+        padding: 0.75rem 1.8rem;
+        border-radius: 999px;
+        border: none;
+        background: linear-gradient(135deg, #0a84ff, #54d1ff);
+        color: #041026;
+        font-weight: 700;
+        font-size: 1rem;
+        cursor: pointer;
+        box-shadow: 0 18px 36px rgba(10, 132, 255, 0.35);
+        transition: transform 160ms ease, box-shadow 160ms ease;
+      }
+      button[type="submit"]:hover,
+      button[type="submit"]:focus-visible {
+        transform: translateY(-1px);
+        box-shadow: 0 22px 40px rgba(10, 132, 255, 0.45);
+      }
+      button[type="submit"]:disabled {
+        opacity: 0.6;
+        cursor: wait;
+      }
+      .status {
+        min-height: 1.4rem;
+      }
+      a.link {
+        color: var(--text-accent);
+        text-decoration: none;
+        font-weight: 600;
+      }
+      a.link:hover,
+      a.link:focus-visible {
+        text-decoration: underline;
+      }
+      @media (max-width: 720px) {
+        header,
+        footer {
+          flex-direction: column;
+          align-items: stretch;
+          text-align: center;
+        }
+        main {
+          padding: var(--space-lg);
+        }
+        .settings-card {
+          padding: var(--space-lg);
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div class="brand-area">
+        <strong class="brand">RevCam</strong>
+        <span class="muted">Surveillance mode</span>
+      </div>
+      <a class="link" href="/surveillance">Back to surveillance</a>
+    </header>
+    <main>
+      <section class="settings-card">
+        <header>
+          <h1>Surveillance settings</h1>
+          <p class="muted">
+            Configure recording behaviour for standard deployments or switch to expert
+            mode for full control over frame rate and compression.
+          </p>
+        </header>
+        <form id="surveillance-settings-form">
+          <fieldset>
+            <legend>Configuration mode</legend>
+            <label class="option">
+              <input type="radio" name="profile" value="standard" />
+              <div>
+                <strong>Standard presets</strong>
+                <span class="helper">Pick from tuned combinations for common setups.</span>
+              </div>
+            </label>
+            <label class="option">
+              <input type="radio" name="profile" value="expert" />
+              <div>
+                <strong>Expert controls</strong>
+                <span class="helper">Manually set capture frame rate and JPEG quality.</span>
+              </div>
+            </label>
+          </fieldset>
+          <section id="standard-section" aria-live="polite">
+            <h2>Standard presets</h2>
+            <p class="muted">
+              Choose the preset that best reflects your surveillance needs. Presets adjust
+              both the capture frame rate and recording compression.
+            </p>
+            <div class="preset-grid">
+              <label class="preset-label">
+                <input type="radio" name="preset" value="balanced" />
+                <div>
+                  <strong>Balanced coverage</strong>
+                  <span class="meta">6 fps • JPEG quality 70 — ideal all-round coverage.</span>
+                </div>
+              </label>
+              <label class="preset-label">
+                <input type="radio" name="preset" value="detail" />
+                <div>
+                  <strong>High detail</strong>
+                  <span class="meta">9 fps • JPEG quality 85 — more motion clarity indoors.</span>
+                </div>
+              </label>
+              <label class="preset-label">
+                <input type="radio" name="preset" value="endurance" />
+                <div>
+                  <strong>Extended endurance</strong>
+                  <span class="meta">4 fps • JPEG quality 60 — longer recordings, smaller files.</span>
+                </div>
+              </label>
+            </div>
+          </section>
+          <section id="expert-section" hidden>
+            <h2>Expert controls</h2>
+            <p class="muted">
+              Tune capture parameters precisely. Higher frame rates and JPEG quality increase
+              detail at the cost of storage and bandwidth.
+            </p>
+            <div class="expert-grid">
+              <div class="expert-control">
+                <label for="expert-fps">Frame rate</label>
+                <input id="expert-fps" type="number" min="1" max="30" step="1" />
+                <span class="muted">Frames captured per second.</span>
+              </div>
+              <div class="expert-control">
+                <label for="expert-quality">JPEG quality</label>
+                <input id="expert-quality" type="number" min="30" max="100" step="1" />
+                <span class="muted">Higher values increase detail while using more space.</span>
+              </div>
+            </div>
+          </section>
+          <div class="summary" id="settings-summary" role="status" aria-live="polite">
+            Effective capture: —
+          </div>
+          <button type="submit">Save surveillance settings</button>
+          <p class="muted status" id="settings-status"></p>
+        </form>
+      </section>
+    </main>
+    <footer>
+      <a class="link" href="/surveillance">Back to surveillance</a>
+      <a class="link" href="/">Back to live view</a>
+    </footer>
+    <script>
+      const STANDARD_PRESETS = {
+        balanced: {
+          label: "Balanced coverage",
+          fps: 6,
+          jpeg_quality: 70,
+        },
+        detail: {
+          label: "High detail",
+          fps: 9,
+          jpeg_quality: 85,
+        },
+        endurance: {
+          label: "Extended endurance",
+          fps: 4,
+          jpeg_quality: 60,
+        },
+      };
+
+      const form = document.getElementById("surveillance-settings-form");
+      const profileInputs = Array.from(form.querySelectorAll('input[name="profile"]'));
+      const presetInputs = Array.from(form.querySelectorAll('input[name="preset"]'));
+      const standardSection = document.getElementById("standard-section");
+      const expertSection = document.getElementById("expert-section");
+      const expertFpsInput = document.getElementById("expert-fps");
+      const expertQualityInput = document.getElementById("expert-quality");
+      const statusText = document.getElementById("settings-status");
+      const summary = document.getElementById("settings-summary");
+
+      let currentSettings = null;
+
+      function getSelectedProfile() {
+        const selected = profileInputs.find((input) => input.checked);
+        return selected ? selected.value : "standard";
+      }
+
+      function getSelectedPreset() {
+        const selected = presetInputs.find((input) => input.checked);
+        return selected ? selected.value : "balanced";
+      }
+
+      function setProfile(profile) {
+        profileInputs.forEach((input) => {
+          input.checked = input.value === profile;
+        });
+        updateModeVisibility();
+      }
+
+      function setPreset(preset) {
+        let matched = false;
+        presetInputs.forEach((input) => {
+          const checked = input.value === preset;
+          input.checked = checked;
+          if (checked) {
+            matched = true;
+          }
+        });
+        if (!matched && presetInputs.length) {
+          presetInputs[0].checked = true;
+        }
+      }
+
+      function updateModeVisibility() {
+        const profile = getSelectedProfile();
+        const standard = profile === "standard";
+        standardSection.hidden = !standard;
+        expertSection.hidden = standard;
+        summary.dataset.profile = profile;
+        updateSummary();
+      }
+
+      function resolveEffectiveSettings() {
+        const profile = getSelectedProfile();
+        if (profile === "standard") {
+          const preset = getSelectedPreset();
+          const config = STANDARD_PRESETS[preset] || STANDARD_PRESETS.balanced;
+          return {
+            profile,
+            preset,
+            fps: config.fps,
+            jpeg_quality: config.jpeg_quality,
+          };
+        }
+        const fpsValue = parseInt(expertFpsInput.value, 10);
+        const qualityValue = parseInt(expertQualityInput.value, 10);
+        return {
+          profile,
+          preset: getSelectedPreset(),
+          fps: Number.isFinite(fpsValue) ? fpsValue : null,
+          jpeg_quality: Number.isFinite(qualityValue) ? qualityValue : null,
+        };
+      }
+
+      function updateSummary() {
+        const effective = resolveEffectiveSettings();
+        let text = "Effective capture: ";
+        if (effective.fps && effective.jpeg_quality) {
+          const prefix =
+            effective.profile === "standard"
+              ? `${STANDARD_PRESETS[effective.preset]?.label || "Preset"}: `
+              : "Expert configuration: ";
+          text += `${prefix}${effective.fps} fps, JPEG quality ${effective.jpeg_quality}`;
+        } else {
+          text += "—";
+        }
+        summary.textContent = text;
+      }
+
+      function applySettings(settings) {
+        if (!settings || typeof settings !== "object") {
+          return;
+        }
+        currentSettings = settings;
+        const profile = settings.profile === "expert" ? "expert" : "standard";
+        setProfile(profile);
+        setPreset(settings.preset || "balanced");
+        expertFpsInput.value = settings.expert_fps ?? settings.fps ?? 6;
+        expertQualityInput.value = settings.expert_jpeg_quality ?? settings.jpeg_quality ?? 75;
+        updateModeVisibility();
+      }
+
+      async function loadSettings() {
+        statusText.textContent = "Loading settings…";
+        try {
+          const response = await fetch("/api/surveillance/settings", { cache: "no-store" });
+          if (!response.ok) {
+            throw new Error(`Request failed with ${response.status}`);
+          }
+          const payload = await response.json();
+          if (!payload || typeof payload !== "object") {
+            throw new Error("Invalid response payload");
+          }
+          applySettings(payload.settings);
+          statusText.textContent = "";
+        } catch (error) {
+          console.error("Failed to load surveillance settings", error);
+          statusText.textContent = "Unable to load surveillance settings.";
+        }
+      }
+
+      profileInputs.forEach((input) => {
+        input.addEventListener("change", () => {
+          updateModeVisibility();
+        });
+      });
+      presetInputs.forEach((input) => {
+        input.addEventListener("change", () => {
+          updateSummary();
+        });
+      });
+      expertFpsInput.addEventListener("input", updateSummary);
+      expertQualityInput.addEventListener("input", updateSummary);
+
+      form.addEventListener("submit", async (event) => {
+        event.preventDefault();
+        const profile = getSelectedProfile();
+        const payload = { profile };
+        if (profile === "standard") {
+          payload.preset = getSelectedPreset();
+        } else {
+          const fpsValue = parseInt(expertFpsInput.value, 10);
+          const qualityValue = parseInt(expertQualityInput.value, 10);
+          if (!Number.isFinite(fpsValue) || fpsValue < 1 || fpsValue > 30) {
+            statusText.textContent = "Enter a frame rate between 1 and 30 fps.";
+            expertFpsInput.focus();
+            return;
+          }
+          if (!Number.isFinite(qualityValue) || qualityValue < 30 || qualityValue > 100) {
+            statusText.textContent = "JPEG quality must be between 30 and 100.";
+            expertQualityInput.focus();
+            return;
+          }
+          payload.expert_fps = fpsValue;
+          payload.expert_jpeg_quality = qualityValue;
+        }
+        statusText.textContent = "Saving settings…";
+        form.querySelector("button[type='submit']").disabled = true;
+        try {
+          const response = await fetch("/api/surveillance/settings", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(payload),
+          });
+          if (!response.ok) {
+            const detail = await response.json().catch(() => null);
+            const message = detail && detail.detail ? detail.detail : "Unable to save settings.";
+            throw new Error(message);
+          }
+          const result = await response.json();
+          applySettings(result.settings);
+          statusText.textContent = "Surveillance settings saved.";
+          updateSummary();
+        } catch (error) {
+          console.error("Failed to save surveillance settings", error);
+          statusText.textContent =
+            error instanceof Error ? error.message : "Unable to save surveillance settings.";
+        } finally {
+          form.querySelector("button[type='submit']").disabled = false;
+        }
+      });
+
+      loadSettings();
+    </script>
+  </body>
+</html>

--- a/src/rev_cam/static/surveillance_settings.html
+++ b/src/rev_cam/static/surveillance_settings.html
@@ -93,6 +93,37 @@
         flex-direction: column;
         gap: var(--space-lg);
       }
+      .tablist {
+        display: flex;
+        gap: var(--space-sm);
+        margin-bottom: var(--space-lg);
+        flex-wrap: wrap;
+      }
+      .tab-button {
+        border: 1px solid var(--border-subtle);
+        background: var(--surface-soft);
+        color: var(--text-primary);
+        padding: 0.45rem 1.1rem;
+        border-radius: var(--radius-pill);
+        cursor: pointer;
+        font-weight: 600;
+        transition: border-color var(--transition), color var(--transition), background var(--transition);
+      }
+      .tab-button[aria-selected="true"] {
+        background: linear-gradient(135deg, #0a84ff, #54d1ff);
+        color: #041026;
+        border-color: transparent;
+        box-shadow: 0 12px 24px rgba(10, 132, 255, 0.25);
+      }
+      .tab-button:not([aria-selected="true"]):hover,
+      .tab-button:not([aria-selected="true"]):focus-visible {
+        border-color: var(--accent);
+        color: var(--accent);
+        outline: none;
+      }
+      [data-tab-panel][hidden] {
+        display: none !important;
+      }
       .settings-card h1 {
         margin: 0;
       }
@@ -137,6 +168,14 @@
       label.option span.helper {
         font-size: 0.85rem;
         color: var(--text-muted);
+      }
+      .option.inline-option {
+        grid-template-columns: auto 1fr;
+        align-items: center;
+        padding: var(--space-sm);
+      }
+      .option.inline-option > div {
+        margin-left: 0;
       }
       .preset-grid {
         display: grid;
@@ -197,6 +236,21 @@
         background: rgba(10, 132, 255, 0.16);
         border: 1px solid rgba(10, 132, 255, 0.4);
         font-weight: 600;
+      }
+      .motion-control {
+        margin-top: var(--space-md);
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+      }
+      .storage-grid {
+        display: grid;
+        gap: var(--space-md);
+        margin-top: var(--space-md);
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      }
+      .storage-grid input {
+        width: 100%;
       }
       button[type="submit"] {
         align-self: flex-start;
@@ -266,69 +320,137 @@
           </p>
         </header>
         <form id="surveillance-settings-form">
-          <fieldset>
-            <legend>Configuration mode</legend>
-            <label class="option">
-              <input type="radio" name="profile" value="standard" />
+          <div class="tablist" role="tablist" aria-label="Surveillance settings sections">
+            <button class="tab-button" type="button" data-tab="recording" aria-selected="true">
+              Recording
+            </button>
+            <button class="tab-button" type="button" data-tab="motion" aria-selected="false">
+              Motion detection
+            </button>
+            <button class="tab-button" type="button" data-tab="storage" aria-selected="false">
+              Storage &amp; maintenance
+            </button>
+          </div>
+          <section class="tab-panel" data-tab-panel="recording">
+            <fieldset>
+              <legend>Configuration mode</legend>
+              <label class="option">
+                <input type="radio" name="profile" value="standard" />
+                <div>
+                  <strong>Standard presets</strong>
+                  <span class="helper">Pick from tuned combinations for common setups.</span>
+                </div>
+              </label>
+              <label class="option">
+                <input type="radio" name="profile" value="expert" />
+                <div>
+                  <strong>Expert controls</strong>
+                  <span class="helper">Manually set capture frame rate and JPEG quality.</span>
+                </div>
+              </label>
+            </fieldset>
+            <section id="standard-section" aria-live="polite">
+              <h2>Standard presets</h2>
+              <p class="muted">
+                Choose the preset that best reflects your surveillance needs. Presets adjust
+                both the capture frame rate and recording compression.
+              </p>
+              <div class="preset-grid">
+                <label class="preset-label">
+                  <input type="radio" name="preset" value="balanced" />
+                  <div>
+                    <strong>Balanced coverage</strong>
+                    <span class="meta">6 fps • JPEG quality 70 — ideal all-round coverage.</span>
+                  </div>
+                </label>
+                <label class="preset-label">
+                  <input type="radio" name="preset" value="detail" />
+                  <div>
+                    <strong>High detail</strong>
+                    <span class="meta">9 fps • JPEG quality 85 — more motion clarity indoors.</span>
+                  </div>
+                </label>
+                <label class="preset-label">
+                  <input type="radio" name="preset" value="endurance" />
+                  <div>
+                    <strong>Extended endurance</strong>
+                    <span class="meta">4 fps • JPEG quality 60 — longer recordings, smaller files.</span>
+                  </div>
+                </label>
+              </div>
+            </section>
+            <section id="expert-section" hidden>
+              <h2>Expert controls</h2>
+              <p class="muted">
+                Tune capture parameters precisely. Higher frame rates and JPEG quality increase
+                detail at the cost of storage and bandwidth.
+              </p>
+              <div class="expert-grid">
+                <div class="expert-control">
+                  <label for="expert-fps">Frame rate</label>
+                  <input id="expert-fps" type="number" min="1" max="30" step="1" />
+                  <span class="muted">Frames captured per second.</span>
+                </div>
+                <div class="expert-control">
+                  <label for="expert-quality">JPEG quality</label>
+                  <input id="expert-quality" type="number" min="30" max="100" step="1" />
+                  <span class="muted">Higher values increase detail while using more space.</span>
+                </div>
+              </div>
+            </section>
+            <label class="option inline-option">
+              <input type="checkbox" id="recording-overlays" />
               <div>
-                <strong>Standard presets</strong>
-                <span class="helper">Pick from tuned combinations for common setups.</span>
+                <strong>Include overlays in recordings</strong>
+                <span class="helper">Uncheck to capture a clean video feed without UI overlays.</span>
               </div>
             </label>
-            <label class="option">
-              <input type="radio" name="profile" value="expert" />
+            <label class="option inline-option">
+              <input type="checkbox" id="remember-recording" />
               <div>
-                <strong>Expert controls</strong>
-                <span class="helper">Manually set capture frame rate and JPEG quality.</span>
+                <strong>Resume recording after restart</strong>
+                <span class="helper">Return to surveillance mode and continue recording automatically.</span>
               </div>
             </label>
-          </fieldset>
-          <section id="standard-section" aria-live="polite">
-            <h2>Standard presets</h2>
+          </section>
+          <section class="tab-panel" data-tab-panel="motion" hidden>
+            <h2>Motion detection</h2>
             <p class="muted">
-              Choose the preset that best reflects your surveillance needs. Presets adjust
-              both the capture frame rate and recording compression.
+              Enable motion detection to reduce storage usage and focus recordings on activity.
             </p>
-            <div class="preset-grid">
-              <label class="preset-label">
-                <input type="radio" name="preset" value="balanced" />
-                <div>
-                  <strong>Balanced coverage</strong>
-                  <span class="meta">6 fps • JPEG quality 70 — ideal all-round coverage.</span>
-                </div>
-              </label>
-              <label class="preset-label">
-                <input type="radio" name="preset" value="detail" />
-                <div>
-                  <strong>High detail</strong>
-                  <span class="meta">9 fps • JPEG quality 85 — more motion clarity indoors.</span>
-                </div>
-              </label>
-              <label class="preset-label">
-                <input type="radio" name="preset" value="endurance" />
-                <div>
-                  <strong>Extended endurance</strong>
-                  <span class="meta">4 fps • JPEG quality 60 — longer recordings, smaller files.</span>
-                </div>
-              </label>
+            <label class="option inline-option">
+              <input type="checkbox" id="motion-enabled" />
+              <div>
+                <strong>Enable motion detection</strong>
+                <span class="helper">Pause recording when no movement is detected and resume on motion.</span>
+              </div>
+            </label>
+            <div class="motion-control">
+              <label for="motion-sensitivity">Sensitivity</label>
+              <input id="motion-sensitivity" type="range" min="0" max="100" step="1" />
+              <span class="muted">Current sensitivity: <span id="motion-sensitivity-value">50</span>%</span>
             </div>
           </section>
-          <section id="expert-section" hidden>
-            <h2>Expert controls</h2>
+          <section class="tab-panel" data-tab-panel="storage" hidden>
+            <h2>Storage &amp; maintenance</h2>
             <p class="muted">
-              Tune capture parameters precisely. Higher frame rates and JPEG quality increase
-              detail at the cost of storage and bandwidth.
+              Automatically split recordings, protect storage capacity and remove old clips on a schedule.
             </p>
-            <div class="expert-grid">
-              <div class="expert-control">
-                <label for="expert-fps">Frame rate</label>
-                <input id="expert-fps" type="number" min="1" max="30" step="1" />
-                <span class="muted">Frames captured per second.</span>
+            <div class="storage-grid">
+              <div>
+                <label for="chunk-duration">Split recordings every (minutes)</label>
+                <input id="chunk-duration" type="number" min="0" max="1440" step="1" />
+                <span class="muted">Set to 0 to keep each recording as a single file.</span>
               </div>
-              <div class="expert-control">
-                <label for="expert-quality">JPEG quality</label>
-                <input id="expert-quality" type="number" min="30" max="100" step="1" />
-                <span class="muted">Higher values increase detail while using more space.</span>
+              <div>
+                <label for="storage-threshold">Stop recording below free space (%)</label>
+                <input id="storage-threshold" type="number" min="1" max="90" step="1" />
+                <span class="muted">Recording stops automatically when free space drops below this value.</span>
+              </div>
+              <div>
+                <label for="auto-purge-days">Auto purge recordings after (days)</label>
+                <input id="auto-purge-days" type="number" min="0" max="3650" step="1" />
+                <span class="muted">Set to 0 to keep recordings indefinitely.</span>
               </div>
             </div>
           </section>
@@ -372,8 +494,61 @@
       const expertQualityInput = document.getElementById("expert-quality");
       const statusText = document.getElementById("settings-status");
       const summary = document.getElementById("settings-summary");
+      const tabButtons = Array.from(document.querySelectorAll(".tab-button"));
+      const tabPanels = Array.from(document.querySelectorAll("[data-tab-panel]"));
+      const overlayCheckbox = document.getElementById("recording-overlays");
+      const rememberCheckbox = document.getElementById("remember-recording");
+      const chunkDurationInput = document.getElementById("chunk-duration");
+      const storageThresholdInput = document.getElementById("storage-threshold");
+      const autoPurgeInput = document.getElementById("auto-purge-days");
+      const motionEnabledInput = document.getElementById("motion-enabled");
+      const motionSensitivityInput = document.getElementById("motion-sensitivity");
+      const motionSensitivityValue = document.getElementById("motion-sensitivity-value");
 
       let currentSettings = null;
+
+      function setActiveTab(tab) {
+        const target = typeof tab === "string" && tab ? tab : "recording";
+        tabButtons.forEach((button) => {
+          const isActive = button.dataset.tab === target;
+          button.setAttribute("aria-selected", String(isActive));
+        });
+        tabPanels.forEach((panel) => {
+          const isActive = panel.dataset.tabPanel === target;
+          if (isActive) {
+            panel.removeAttribute("hidden");
+          } else {
+            panel.setAttribute("hidden", "hidden");
+          }
+        });
+      }
+
+      function updateMotionSensitivityLabel(value) {
+        if (!motionSensitivityValue) {
+          return;
+        }
+        const numeric = Number.isFinite(value)
+          ? value
+          : Number.parseInt(motionSensitivityInput?.value ?? "50", 10) || 50;
+        motionSensitivityValue.textContent = String(Math.round(numeric));
+      }
+
+      tabButtons.forEach((button) => {
+        button.addEventListener("click", () => {
+          setActiveTab(button.dataset.tab || "recording");
+        });
+      });
+      setActiveTab("recording");
+
+      if (motionSensitivityInput) {
+        motionSensitivityInput.addEventListener("input", () => {
+          updateMotionSensitivityLabel(Number(motionSensitivityInput.value));
+        });
+      }
+
+      if (chunkDurationInput) {
+        chunkDurationInput.addEventListener("input", updateSummary);
+      }
 
       function getSelectedProfile() {
         const selected = profileInputs.find((input) => input.checked);
@@ -449,6 +624,12 @@
         } else {
           text += "—";
         }
+        if (chunkDurationInput) {
+          const minutes = parseInt(chunkDurationInput.value, 10);
+          if (Number.isFinite(minutes) && minutes > 0) {
+            text += ` • Split every ${minutes} min`;
+          }
+        }
         summary.textContent = text;
       }
 
@@ -463,6 +644,34 @@
         expertFpsInput.value = settings.expert_fps ?? settings.fps ?? 6;
         expertQualityInput.value = settings.expert_jpeg_quality ?? settings.jpeg_quality ?? 75;
         updateModeVisibility();
+        if (overlayCheckbox) {
+          overlayCheckbox.checked = settings.overlays_enabled !== false;
+        }
+        if (rememberCheckbox) {
+          rememberCheckbox.checked = Boolean(settings.remember_recording_state);
+        }
+        if (chunkDurationInput) {
+          const seconds = Number(settings.chunk_duration_seconds ?? 0);
+          const minutes = Number.isFinite(seconds) && seconds > 0 ? Math.round(seconds / 60) : 0;
+          chunkDurationInput.value = minutes;
+        }
+        if (storageThresholdInput) {
+          const threshold = Number(settings.storage_threshold_percent ?? 10);
+          storageThresholdInput.value = Number.isFinite(threshold) ? threshold : 10;
+        }
+        if (autoPurgeInput) {
+          const days = Number(settings.auto_purge_days ?? 0);
+          autoPurgeInput.value = Number.isFinite(days) && days > 0 ? Math.round(days) : 0;
+        }
+        if (motionEnabledInput) {
+          motionEnabledInput.checked = Boolean(settings.motion_detection_enabled);
+        }
+        if (motionSensitivityInput) {
+          const value = Number(settings.motion_sensitivity ?? 50);
+          motionSensitivityInput.value = Number.isFinite(value) ? value : 50;
+          updateMotionSensitivityLabel(Number(motionSensitivityInput.value));
+        }
+        updateSummary();
       }
 
       async function loadSettings() {
@@ -518,6 +727,41 @@
           }
           payload.expert_fps = fpsValue;
           payload.expert_jpeg_quality = qualityValue;
+        }
+        payload.overlays_enabled = overlayCheckbox ? overlayCheckbox.checked : true;
+        payload.remember_recording_state = rememberCheckbox ? rememberCheckbox.checked : false;
+        if (motionEnabledInput) {
+          payload.motion_detection_enabled = motionEnabledInput.checked;
+        }
+        if (motionSensitivityInput) {
+          const motionValue = parseInt(motionSensitivityInput.value, 10);
+          payload.motion_sensitivity = Number.isFinite(motionValue) ? motionValue : 50;
+        }
+        if (chunkDurationInput) {
+          const chunkMinutes = parseInt(chunkDurationInput.value, 10);
+          if (Number.isFinite(chunkMinutes) && chunkMinutes > 0) {
+            if (chunkMinutes > 24 * 60) {
+              statusText.textContent = "Chunk duration must be 1440 minutes or less.";
+              chunkDurationInput.focus();
+              return;
+            }
+            payload.chunk_duration_seconds = chunkMinutes * 60;
+          } else {
+            payload.chunk_duration_seconds = 0;
+          }
+        }
+        if (storageThresholdInput) {
+          const thresholdValue = parseFloat(storageThresholdInput.value);
+          if (!Number.isFinite(thresholdValue) || thresholdValue < 1 || thresholdValue > 90) {
+            statusText.textContent = "Storage threshold must be between 1 and 90%.";
+            storageThresholdInput.focus();
+            return;
+          }
+          payload.storage_threshold_percent = thresholdValue;
+        }
+        if (autoPurgeInput) {
+          const purgeValue = parseInt(autoPurgeInput.value, 10);
+          payload.auto_purge_days = Number.isFinite(purgeValue) && purgeValue > 0 ? purgeValue : 0;
         }
         statusText.textContent = "Saving settings…";
         form.querySelector("button[type='submit']").disabled = true;

--- a/src/rev_cam/static/surveillance_timeline.html
+++ b/src/rev_cam/static/surveillance_timeline.html
@@ -1,0 +1,861 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Surveillance Recording Timeline</title>
+    <link rel="icon" type="image/svg+xml" href="images/favicon.svg" />
+    <style>
+      :root {
+        color-scheme: dark;
+        --font-family: "Inter", "Manrope", "Segoe UI", system-ui, -apple-system,
+          BlinkMacSystemFont, sans-serif;
+        --surface-0: rgba(14, 16, 22, 0.9);
+        --surface-1: rgba(26, 28, 36, 0.88);
+        --surface-soft: rgba(255, 255, 255, 0.05);
+        --border-subtle: rgba(255, 255, 255, 0.12);
+        --border-strong: rgba(255, 255, 255, 0.2);
+        --text-primary: #f5f7fb;
+        --text-muted: rgba(245, 247, 250, 0.7);
+        --accent: #0a84ff;
+        --accent-soft: rgba(10, 132, 255, 0.15);
+        --accent-hover: #2f95ff;
+        --accent-shadow: rgba(10, 132, 255, 0.35);
+        --danger: #ff453a;
+        --success: #34c759;
+        --radius-md: 0.9rem;
+        --radius-lg: 1.25rem;
+        --radius-pill: 999px;
+        --space-xs: 0.35rem;
+        --space-sm: 0.6rem;
+        --space-md: 1rem;
+        --space-lg: 1.6rem;
+        --space-xl: 2.2rem;
+        --page-gradient: radial-gradient(120% 140% at top, #1b1e26 0%, #0b0d13 60%,
+            #050609 100%);
+        --timeline-line: rgba(255, 255, 255, 0.15);
+        --timeline-marker-manual: var(--accent);
+        --timeline-marker-motion: #ffa031;
+        --chip-bg: rgba(255, 255, 255, 0.08);
+        --chip-motion-bg: rgba(255, 160, 49, 0.18);
+      }
+
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: var(--page-gradient);
+        font-family: var(--font-family);
+        color: var(--text-primary);
+        display: flex;
+        flex-direction: column;
+      }
+
+      header.page-header {
+        padding: var(--space-md) var(--space-xl);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-lg);
+        background: var(--surface-0);
+        border-bottom: 1px solid var(--border-subtle);
+        backdrop-filter: blur(18px) saturate(140%);
+        -webkit-backdrop-filter: blur(18px) saturate(140%);
+        box-shadow: 0 24px 48px rgba(0, 0, 0, 0.35);
+      }
+
+      .brand-group {
+        display: flex;
+        flex-direction: column;
+        gap: 0.15rem;
+      }
+
+      .brand-group strong {
+        font-size: 1.25rem;
+        letter-spacing: 0.05em;
+        color: var(--success);
+      }
+
+      .brand-group span {
+        color: var(--text-muted);
+        font-size: 0.95rem;
+      }
+
+      .header-actions {
+        display: inline-flex;
+        gap: var(--space-sm);
+        align-items: center;
+        flex-wrap: wrap;
+      }
+
+      .header-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        padding: 0.45rem 1.1rem;
+        border-radius: var(--radius-pill);
+        border: 1px solid var(--border-subtle);
+        background: transparent;
+        color: var(--text-primary);
+        text-decoration: none;
+        font-weight: 600;
+        transition: color 200ms ease, border-color 200ms ease,
+          background 200ms ease, box-shadow 200ms ease;
+      }
+
+      .header-link:hover,
+      .header-link:focus-visible {
+        color: var(--accent);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 1px rgba(10, 132, 255, 0.35);
+        outline: none;
+      }
+
+      main {
+        flex: 1;
+        width: min(1100px, 100%);
+        margin: 0 auto;
+        padding: var(--space-xl) var(--space-md) var(--space-xl);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-lg);
+      }
+
+      .timeline-controls {
+        background: var(--surface-1);
+        border-radius: var(--radius-lg);
+        border: 1px solid var(--border-subtle);
+        padding: var(--space-lg);
+        box-shadow: 0 24px 48px rgba(0, 0, 0, 0.35);
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-md);
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      .timeline-controls h1 {
+        margin: 0;
+        font-size: 1.6rem;
+      }
+
+      .timeline-status {
+        margin: 0;
+        color: var(--text-muted);
+        font-size: 0.95rem;
+      }
+
+      .timeline-status[data-tone="busy"] {
+        color: var(--accent);
+      }
+
+      .timeline-status[data-tone="error"] {
+        color: var(--danger);
+        font-weight: 600;
+      }
+
+      .filter-group {
+        display: inline-flex;
+        flex-wrap: wrap;
+        gap: var(--space-sm);
+        align-items: center;
+      }
+
+      .filter-button {
+        appearance: none;
+        border: 1px solid var(--border-subtle);
+        background: transparent;
+        color: var(--text-muted);
+        font-weight: 600;
+        padding: 0.45rem 1.2rem;
+        border-radius: var(--radius-pill);
+        cursor: pointer;
+        transition: background 200ms ease, color 200ms ease, border-color 200ms ease,
+          box-shadow 200ms ease;
+      }
+
+      .filter-button[aria-pressed="true"] {
+        background: var(--accent-soft);
+        border-color: rgba(10, 132, 255, 0.6);
+        color: var(--accent);
+        box-shadow: 0 10px 24px var(--accent-shadow);
+      }
+
+      .filter-button:not([aria-pressed="true"]):hover,
+      .filter-button:not([aria-pressed="true"]):focus-visible {
+        color: var(--text-primary);
+        border-color: rgba(10, 132, 255, 0.5);
+        background: rgba(10, 132, 255, 0.08);
+        outline: none;
+      }
+
+      .refresh-button {
+        appearance: none;
+        border: 1px solid var(--border-subtle);
+        background: transparent;
+        color: var(--text-primary);
+        font-weight: 600;
+        padding: 0.45rem 1.2rem;
+        border-radius: var(--radius-pill);
+        cursor: pointer;
+        transition: border-color 200ms ease, color 200ms ease,
+          background 200ms ease;
+      }
+
+      .refresh-button:hover,
+      .refresh-button:focus-visible {
+        border-color: var(--accent);
+        color: var(--accent);
+        outline: none;
+      }
+
+      .refresh-button:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+
+      .timeline {
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-lg);
+        padding-left: 2.6rem;
+      }
+
+      .timeline::before {
+        content: "";
+        position: absolute;
+        inset: 0 auto 0 1.2rem;
+        width: 2px;
+        background: var(--timeline-line);
+      }
+
+      .timeline-item {
+        position: relative;
+        background: var(--surface-1);
+        border-radius: var(--radius-lg);
+        border: 1px solid var(--border-subtle);
+        padding: var(--space-lg);
+        display: grid;
+        grid-template-columns: minmax(180px, 240px) minmax(0, 1fr);
+        gap: var(--space-lg);
+        box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
+      }
+
+      .timeline-item::before {
+        content: "";
+        position: absolute;
+        width: 16px;
+        height: 16px;
+        border-radius: 50%;
+        border: 2px solid var(--surface-1);
+        top: calc(50% - 8px);
+        left: -2.05rem;
+        background: var(--timeline-marker-manual);
+        box-shadow: 0 0 0 4px var(--surface-0);
+      }
+
+      .timeline-item[data-type="motion"]::before {
+        background: var(--timeline-marker-motion);
+        box-shadow: 0 0 0 4px rgba(255, 160, 49, 0.1);
+      }
+
+      .thumbnail-wrapper {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: rgba(0, 0, 0, 0.35);
+        border-radius: var(--radius-md);
+        border: 1px solid var(--border-subtle);
+        overflow: hidden;
+        min-height: 150px;
+      }
+
+      .timeline-thumbnail {
+        width: 100%;
+        height: 100%;
+        display: block;
+        object-fit: cover;
+        aspect-ratio: 16 / 9;
+      }
+
+      .thumbnail-placeholder {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 100%;
+        height: 100%;
+        padding: var(--space-md);
+        text-align: center;
+        color: var(--text-muted);
+        font-size: 0.9rem;
+      }
+
+      .timeline-content {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-sm);
+      }
+
+      .timeline-title {
+        display: flex;
+        align-items: baseline;
+        gap: var(--space-sm);
+        flex-wrap: wrap;
+        margin: 0;
+      }
+
+      .timeline-title strong {
+        font-size: 1.15rem;
+      }
+
+      .timeline-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        padding: 0.2rem 0.75rem;
+        border-radius: var(--radius-pill);
+        background: var(--chip-bg);
+        color: var(--text-muted);
+        font-size: 0.85rem;
+        font-weight: 600;
+      }
+
+      .timeline-item[data-type="motion"] .timeline-chip {
+        background: var(--chip-motion-bg);
+        color: #ffba66;
+      }
+
+      .timeline-meta {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.6rem;
+        color: var(--text-muted);
+        font-size: 0.9rem;
+      }
+
+      .timeline-meta span {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+      }
+
+      .timeline-status-line {
+        margin: 0;
+        font-size: 0.9rem;
+        color: var(--text-muted);
+      }
+
+      .timeline-status-line[data-tone="error"] {
+        color: var(--danger);
+        font-weight: 600;
+      }
+
+      .timeline-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-sm);
+        margin-top: var(--space-sm);
+      }
+
+      .timeline-actions .view-button {
+        appearance: none;
+        border: none;
+        border-radius: var(--radius-pill);
+        background: linear-gradient(135deg, var(--accent), var(--accent-hover));
+        color: #fff;
+        font-weight: 600;
+        padding: 0.55rem 1.35rem;
+        cursor: pointer;
+        transition: transform 150ms ease, box-shadow 150ms ease, filter 150ms ease;
+      }
+
+      .timeline-actions .view-button:hover,
+      .timeline-actions .view-button:focus-visible {
+        transform: translateY(-1px);
+        box-shadow: 0 16px 32px var(--accent-shadow);
+        outline: none;
+      }
+
+      .timeline-actions .view-button:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+        box-shadow: none;
+      }
+
+      .timeline-empty {
+        background: var(--surface-soft);
+        border-radius: var(--radius-lg);
+        border: 1px dashed var(--border-subtle);
+        padding: var(--space-lg);
+        text-align: center;
+        color: var(--text-muted);
+        font-size: 0.95rem;
+      }
+
+      @media (max-width: 960px) {
+        header.page-header {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+
+        .timeline-controls {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+
+        .timeline-item {
+          grid-template-columns: 1fr;
+        }
+
+        .timeline::before {
+          left: 0.6rem;
+        }
+
+        .timeline-item::before {
+          left: -1.45rem;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page-header">
+      <div class="brand-group">
+        <strong>RevCam</strong>
+        <span>Surveillance recording timeline</span>
+      </div>
+      <div class="header-actions">
+        <a class="header-link" href="/surveillance">← Back to dashboard</a>
+      </div>
+    </header>
+    <main>
+      <section class="timeline-controls" aria-label="Timeline controls">
+        <div>
+          <h1>Recording timeline</h1>
+          <p class="timeline-status" id="timeline-status" data-tone="busy">
+            Loading timeline…
+          </p>
+        </div>
+        <div class="filter-group" role="group" aria-label="Filter recordings">
+          <button
+            class="filter-button"
+            type="button"
+            data-filter="all"
+            aria-pressed="true"
+          >
+            All recordings
+          </button>
+          <button
+            class="filter-button"
+            type="button"
+            data-filter="manual"
+            aria-pressed="false"
+          >
+            Manual recordings
+          </button>
+          <button
+            class="filter-button"
+            type="button"
+            data-filter="motion"
+            aria-pressed="false"
+          >
+            Motion events
+          </button>
+        </div>
+        <button class="refresh-button" type="button" id="refresh-button">
+          Refresh
+        </button>
+      </section>
+      <section class="timeline" id="timeline" aria-live="polite"></section>
+    </main>
+    <script>
+      const timelineElement = document.getElementById("timeline");
+      const statusElement = document.getElementById("timeline-status");
+      const refreshButton = document.getElementById("refresh-button");
+      const filterButtons = Array.from(
+        document.querySelectorAll(".filter-button[data-filter]")
+      );
+
+      let recordings = [];
+      let activeFilter = "all";
+      let loading = false;
+
+      function setStatus(message, tone = "info") {
+        if (!statusElement) {
+          return;
+        }
+        statusElement.textContent = message;
+        statusElement.dataset.tone = tone;
+      }
+
+      function parseDate(value) {
+        if (typeof value !== "string" || !value) {
+          return null;
+        }
+        const date = new Date(value);
+        return Number.isNaN(date.getTime()) ? null : date;
+      }
+
+      function parseNameTimestamp(name) {
+        if (typeof name !== "string") {
+          return null;
+        }
+        const match = name.match(/^(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(\d{2})/);
+        if (!match) {
+          return null;
+        }
+        const [, year, month, day, hour, minute, second] = match.map(Number);
+        const date = new Date(Date.UTC(year, month - 1, day, hour, minute, second));
+        return Number.isNaN(date.getTime()) ? null : date;
+      }
+
+      function getSortTime(record) {
+        if (!record || typeof record !== "object") {
+          return 0;
+        }
+        const started = parseDate(record.started_at);
+        if (started) {
+          return started.getTime();
+        }
+        const ended = parseDate(record.ended_at);
+        if (ended) {
+          return ended.getTime();
+        }
+        const fallback = parseNameTimestamp(record.name);
+        return fallback ? fallback.getTime() : 0;
+      }
+
+      function formatBytes(bytes) {
+        if (typeof bytes !== "number" || !Number.isFinite(bytes) || bytes <= 0) {
+          return null;
+        }
+        const units = ["B", "KB", "MB", "GB", "TB"];
+        let value = bytes;
+        let unitIndex = 0;
+        while (value >= 1024 && unitIndex < units.length - 1) {
+          value /= 1024;
+          unitIndex += 1;
+        }
+        const precision = value >= 10 || unitIndex === 0 ? 0 : 1;
+        return `${value.toFixed(precision).replace(/\.0$/, "")} ${units[unitIndex]}`;
+      }
+
+      function formatDuration(seconds) {
+        if (typeof seconds !== "number" || !Number.isFinite(seconds) || seconds <= 0) {
+          return null;
+        }
+        if (seconds < 90) {
+          const precision = seconds >= 10 ? 0 : 1;
+          return `${seconds.toFixed(precision).replace(/\.0$/, "")} s`;
+        }
+        const wholeSeconds = Math.round(seconds);
+        const minutes = Math.floor(wholeSeconds / 60);
+        const remainingSeconds = wholeSeconds % 60;
+        if (minutes >= 60) {
+          const hours = Math.floor(minutes / 60);
+          const remainingMinutes = minutes % 60;
+          const parts = [`${hours} h`];
+          if (remainingMinutes > 0) {
+            parts.push(`${remainingMinutes} min`);
+          }
+          if (remainingSeconds > 0) {
+            parts.push(`${remainingSeconds} s`);
+          }
+          return parts.join(" ");
+        }
+        if (remainingSeconds === 0) {
+          return `${minutes} min`;
+        }
+        return `${minutes} min ${remainingSeconds} s`;
+      }
+
+      function isMotionRecording(record) {
+        if (!record || typeof record !== "object") {
+          return false;
+        }
+        if (typeof record.motion_event_index === "number") {
+          return true;
+        }
+        if (record.motion_detection && typeof record.motion_detection === "object") {
+          const eventIndex = record.motion_detection.event_index;
+          if (typeof eventIndex === "number") {
+            return true;
+          }
+        }
+        if (typeof record.name === "string" && record.name.includes(".motion")) {
+          return true;
+        }
+        if (typeof record.motion_events === "number" && record.motion_events > 0) {
+          return true;
+        }
+        return false;
+      }
+
+      function normaliseRecords(items) {
+        if (!Array.isArray(items)) {
+          return [];
+        }
+        const map = new Map();
+        items.forEach((entry) => {
+          if (!entry || typeof entry !== "object") {
+            return;
+          }
+          const name = typeof entry.name === "string" ? entry.name : null;
+          if (!name) {
+            return;
+          }
+          const existing = map.get(name);
+          if (!existing) {
+            map.set(name, entry);
+            return;
+          }
+          const existingEnded = Boolean(existing.ended_at);
+          const candidateEnded = Boolean(entry.ended_at);
+          if (!existingEnded && candidateEnded) {
+            map.set(name, entry);
+            return;
+          }
+          if (existing.processing && !entry.processing) {
+            map.set(name, entry);
+            return;
+          }
+          if (
+            (existing.size_bytes == null || existing.size_bytes === 0) &&
+            typeof entry.size_bytes === "number"
+          ) {
+            map.set(name, entry);
+          }
+        });
+        return Array.from(map.values());
+      }
+
+      function describeType(type) {
+        return type === "motion" ? "Motion event" : "Manual recording";
+      }
+
+      function buildTimelineItem(record) {
+        const type = isMotionRecording(record) ? "motion" : "manual";
+        const item = document.createElement("article");
+        item.className = "timeline-item";
+        item.dataset.type = type;
+
+        const thumbnailWrapper = document.createElement("div");
+        thumbnailWrapper.className = "thumbnail-wrapper";
+        const thumbnail = document.createElement("img");
+        thumbnail.className = "timeline-thumbnail";
+        if (typeof record.thumbnail === "string" && record.thumbnail.length > 0) {
+          thumbnail.src = `data:image/jpeg;base64,${record.thumbnail}`;
+          thumbnail.alt = `Recording ${record.name} thumbnail`;
+          thumbnailWrapper.appendChild(thumbnail);
+        } else {
+          const placeholder = document.createElement("div");
+          placeholder.className = "thumbnail-placeholder";
+          placeholder.textContent = "No preview available";
+          thumbnailWrapper.appendChild(placeholder);
+        }
+        item.appendChild(thumbnailWrapper);
+
+        const content = document.createElement("div");
+        content.className = "timeline-content";
+
+        const title = document.createElement("div");
+        title.className = "timeline-title";
+        const nameElement = document.createElement("strong");
+        nameElement.textContent = typeof record.name === "string" ? record.name : "Recording";
+        const chip = document.createElement("span");
+        chip.className = "timeline-chip";
+        chip.textContent = describeType(type);
+        title.appendChild(nameElement);
+        title.appendChild(chip);
+        content.appendChild(title);
+
+        const meta = document.createElement("div");
+        meta.className = "timeline-meta";
+        const startedAt = parseDate(record.started_at) || parseNameTimestamp(record.name);
+        if (startedAt) {
+          const span = document.createElement("span");
+          span.textContent = `Started ${startedAt.toLocaleString()}`;
+          meta.appendChild(span);
+        }
+        if (typeof record.duration_seconds === "number") {
+          const label = formatDuration(record.duration_seconds);
+          if (label) {
+            const span = document.createElement("span");
+            span.textContent = `Duration ${label}`;
+            meta.appendChild(span);
+          }
+        }
+        if (typeof record.frame_count === "number") {
+          const span = document.createElement("span");
+          span.textContent = `${record.frame_count} frame${record.frame_count === 1 ? "" : "s"}`;
+          meta.appendChild(span);
+        }
+        if (typeof record.size_bytes === "number") {
+          const label = formatBytes(record.size_bytes);
+          if (label) {
+            const span = document.createElement("span");
+            span.textContent = `Size ${label}`;
+            meta.appendChild(span);
+          }
+        }
+        if (type === "motion") {
+          if (typeof record.motion_event_index === "number") {
+            const span = document.createElement("span");
+            span.textContent = `Motion clip #${record.motion_event_index}`;
+            meta.appendChild(span);
+          }
+          if (
+            typeof record.motion_events === "number" &&
+            record.motion_events > 1 &&
+            !meta.textContent.includes("clip #")
+          ) {
+            const span = document.createElement("span");
+            span.textContent = `${record.motion_events} motion events`;
+            meta.appendChild(span);
+          }
+        }
+        if (meta.childElementCount > 0) {
+          content.appendChild(meta);
+        }
+
+        const statusLine = document.createElement("p");
+        statusLine.className = "timeline-status-line";
+        if (record.processing_error) {
+          statusLine.dataset.tone = "error";
+          statusLine.textContent = `Processing failed: ${record.processing_error}`;
+        } else if (record.processing) {
+          statusLine.textContent = "Processing video clip…";
+        } else if (typeof record.stop_reason === "string") {
+          statusLine.textContent = `Finished (${record.stop_reason.replace(/_/g, " ")})`;
+        } else {
+          statusLine.textContent = "Ready to play";
+        }
+        content.appendChild(statusLine);
+
+        const actions = document.createElement("div");
+        actions.className = "timeline-actions";
+        const viewButton = document.createElement("button");
+        viewButton.type = "button";
+        viewButton.className = "view-button";
+        viewButton.textContent = record.processing ? "Processing…" : "View recording";
+        viewButton.disabled = Boolean(record.processing);
+        viewButton.addEventListener("click", () => {
+          if (typeof record.name === "string" && record.name) {
+            const href = `/surveillance/player?name=${encodeURIComponent(record.name)}`;
+            window.location.href = href;
+          }
+        });
+        actions.appendChild(viewButton);
+        content.appendChild(actions);
+
+        item.appendChild(content);
+        return item;
+      }
+
+      function applyFilter(items, filter) {
+        if (filter === "motion") {
+          return items.filter((item) => isMotionRecording(item));
+        }
+        if (filter === "manual") {
+          return items.filter((item) => !isMotionRecording(item));
+        }
+        return items.slice();
+      }
+
+      function renderTimeline() {
+        if (!timelineElement) {
+          return;
+        }
+        timelineElement.innerHTML = "";
+        const filtered = applyFilter(recordings, activeFilter)
+          .slice()
+          .sort((a, b) => getSortTime(a) - getSortTime(b));
+        if (!filtered.length) {
+          const empty = document.createElement("div");
+          empty.className = "timeline-empty";
+          empty.textContent =
+            activeFilter === "all"
+              ? "No recordings available yet."
+              : "No recordings match the selected filter.";
+          timelineElement.appendChild(empty);
+          setStatus(empty.textContent, "info");
+          return;
+        }
+        filtered.forEach((record) => {
+          timelineElement.appendChild(buildTimelineItem(record));
+        });
+        const count = filtered.length;
+        const label =
+          count === 1
+            ? "Displaying 1 recording."
+            : `Displaying ${count} recordings.`;
+        setStatus(label, "info");
+      }
+
+      async function loadRecordings() {
+        if (loading) {
+          return;
+        }
+        loading = true;
+        if (refreshButton) {
+          refreshButton.disabled = true;
+        }
+        setStatus("Loading timeline…", "busy");
+        try {
+          const response = await fetch("/api/surveillance/recordings", {
+            cache: "no-store",
+          });
+          if (!response.ok) {
+            throw new Error(`Request failed with ${response.status}`);
+          }
+          const payload = await response.json();
+          recordings = normaliseRecords(payload && payload.recordings);
+          renderTimeline();
+        } catch (error) {
+          console.error("Failed to load surveillance recordings", error);
+          setStatus("Unable to load recordings", "error");
+          if (timelineElement && !timelineElement.childElementCount) {
+            const empty = document.createElement("div");
+            empty.className = "timeline-empty";
+            empty.textContent = "Unable to load recordings.";
+            timelineElement.appendChild(empty);
+          }
+        } finally {
+          loading = false;
+          if (refreshButton) {
+            refreshButton.disabled = false;
+          }
+        }
+      }
+
+      function setActiveFilter(filter) {
+        activeFilter = filter;
+        filterButtons.forEach((button) => {
+          const isActive = button.dataset.filter === filter;
+          button.setAttribute("aria-pressed", String(isActive));
+        });
+        renderTimeline();
+      }
+
+      filterButtons.forEach((button) => {
+        button.addEventListener("click", () => {
+          const target = button.dataset.filter || "all";
+          setActiveFilter(target);
+        });
+      });
+
+      if (refreshButton) {
+        refreshButton.addEventListener("click", () => {
+          loadRecordings();
+        });
+      }
+
+      loadRecordings();
+    </script>
+  </body>
+</html>

--- a/tests/test_app_surveillance.py
+++ b/tests/test_app_surveillance.py
@@ -162,6 +162,11 @@ def test_surveillance_status_storage(client: TestClient) -> None:
     assert isinstance(storage, dict)
     assert "free_percent" in storage
     assert "threshold_percent" in storage
+    assert "motion" in payload
+    motion = payload.get("motion")
+    if motion is not None:
+        assert isinstance(motion, dict)
+        assert "enabled" in motion
     resume_state = payload.get("resume_state")
     assert isinstance(resume_state, dict)
     assert resume_state.get("mode") in {"revcam", "surveillance"}

--- a/tests/test_app_surveillance.py
+++ b/tests/test_app_surveillance.py
@@ -1,0 +1,93 @@
+"""Tests for the surveillance settings API."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("httpx")
+
+from fastapi.testclient import TestClient
+
+from rev_cam import app as app_module
+from rev_cam.config import ConfigManager, SURVEILLANCE_STANDARD_PRESETS
+
+
+@pytest.fixture
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    class _StubBatteryMonitor:
+        def __init__(self, *args, **kwargs) -> None:
+            self.capacity_mah = kwargs.get("capacity_mah", 1000)
+
+        def read(self):  # pragma: no cover - indirect use
+            return SimpleNamespace(to_dict=lambda: {})
+
+    class _StubSupervisor:
+        def start(self) -> None:  # pragma: no cover - indirect use
+            return None
+
+        async def aclose(self) -> None:  # pragma: no cover - indirect use
+            return None
+
+    class _StubDistanceMonitor:
+        def __init__(self, *args, **kwargs) -> None:
+            self.i2c_bus = kwargs.get("i2c_bus")
+
+    def _noop_overlay(*args, **kwargs):
+        return lambda frame: frame
+
+    monkeypatch.setattr(app_module, "BatteryMonitor", lambda *args, **kwargs: _StubBatteryMonitor(*args, **kwargs))
+    monkeypatch.setattr(app_module, "BatterySupervisor", lambda *args, **kwargs: _StubSupervisor())
+    monkeypatch.setattr(app_module, "DistanceMonitor", lambda *args, **kwargs: _StubDistanceMonitor(*args, **kwargs))
+    monkeypatch.setattr(app_module, "create_battery_overlay", lambda *args, **kwargs: _noop_overlay())
+    monkeypatch.setattr(app_module, "create_wifi_overlay", lambda *args, **kwargs: _noop_overlay())
+    monkeypatch.setattr(app_module, "create_distance_overlay", lambda *args, **kwargs: _noop_overlay())
+    monkeypatch.setattr(app_module, "create_reversing_aids_overlay", lambda *args, **kwargs: _noop_overlay())
+
+    config_path = tmp_path / "config.json"
+    app = app_module.create_app(config_path)
+    with TestClient(app) as test_client:
+        test_client.config_path = config_path
+        yield test_client
+
+
+def test_get_surveillance_settings(client: TestClient) -> None:
+    response = client.get("/api/surveillance/settings")
+    assert response.status_code == 200
+    payload = response.json()
+    assert "settings" in payload
+    assert payload["settings"]["profile"] == "standard"
+    assert payload["settings"]["preset"] in SURVEILLANCE_STANDARD_PRESETS
+    assert "presets" in payload
+    assert any(item["name"] == payload["settings"]["preset"] for item in payload["presets"])
+
+
+def test_update_surveillance_settings_standard(client: TestClient) -> None:
+    response = client.post(
+        "/api/surveillance/settings",
+        json={"profile": "standard", "preset": "detail"},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["settings"]["profile"] == "standard"
+    assert payload["settings"]["preset"] == "detail"
+    expected = SURVEILLANCE_STANDARD_PRESETS["detail"]
+    assert payload["settings"]["fps"] == expected[0]
+    assert payload["settings"]["jpeg_quality"] == expected[1]
+
+    manager = ConfigManager(client.config_path)
+    stored = manager.get_surveillance_settings()
+    assert stored.preset == "detail"
+    assert stored.resolved_fps == expected[0]
+
+
+def test_update_surveillance_settings_expert_validation(client: TestClient) -> None:
+    response = client.post(
+        "/api/surveillance/settings",
+        json={"profile": "expert", "expert_fps": "fast"},
+    )
+    assert response.status_code == 400
+    detail = response.json()
+    assert detail["detail"]

--- a/tests/test_app_surveillance.py
+++ b/tests/test_app_surveillance.py
@@ -171,6 +171,9 @@ def test_surveillance_status_storage(client: TestClient) -> None:
     payload = response.json()
     assert payload["mode"] in {"revcam", "surveillance"}
     assert payload.get("recording_mode") in {"idle", "continuous", "motion"}
+    assert "recording_started_at" in payload
+    started_at = payload.get("recording_started_at")
+    assert started_at is None or isinstance(started_at, str)
     storage = payload.get("storage")
     assert isinstance(storage, dict)
     assert "free_percent" in storage

--- a/tests/test_app_surveillance.py
+++ b/tests/test_app_surveillance.py
@@ -165,6 +165,9 @@ def test_surveillance_status_storage(client: TestClient) -> None:
     assert isinstance(storage, dict)
     assert "free_percent" in storage
     assert "threshold_percent" in storage
+    assert "processing" in payload
+    assert payload["processing"] in {True, False}
+    assert "processing_recording" in payload
     assert "motion" in payload
     motion = payload.get("motion")
     if motion is not None:

--- a/tests/test_app_surveillance.py
+++ b/tests/test_app_surveillance.py
@@ -186,6 +186,8 @@ def test_surveillance_status_storage(client: TestClient) -> None:
         assert "session_state" in motion
         assert "session_active" in motion
         assert "session_override" in motion
+        assert "session_recording" in motion
+        assert "event_active" in motion
         assert "post_event_record_seconds" in motion
     resume_state = payload.get("resume_state")
     assert isinstance(resume_state, dict)

--- a/tests/test_app_surveillance.py
+++ b/tests/test_app_surveillance.py
@@ -161,6 +161,7 @@ def test_surveillance_status_storage(client: TestClient) -> None:
     assert response.status_code == 200
     payload = response.json()
     assert payload["mode"] in {"revcam", "surveillance"}
+    assert payload.get("recording_mode") in {"idle", "continuous", "motion"}
     storage = payload.get("storage")
     assert isinstance(storage, dict)
     assert "free_percent" in storage
@@ -173,6 +174,9 @@ def test_surveillance_status_storage(client: TestClient) -> None:
     if motion is not None:
         assert isinstance(motion, dict)
         assert "enabled" in motion
+        assert "session_state" in motion
+        assert "session_active" in motion
+        assert "session_override" in motion
     resume_state = payload.get("resume_state")
     assert isinstance(resume_state, dict)
     assert resume_state.get("mode") in {"revcam", "surveillance"}

--- a/tests/test_app_surveillance.py
+++ b/tests/test_app_surveillance.py
@@ -128,6 +128,12 @@ def test_update_surveillance_settings_advanced(client: TestClient) -> None:
     assert payload["auto_purge_days"] == 10
     assert payload["storage_threshold_percent"] == 20
 
+    status_response = client.get("/api/surveillance/status")
+    assert status_response.status_code == 200
+    status_payload = status_response.json()["settings"]
+    assert status_payload["motion_frame_decimation"] == 2
+    assert status_payload["motion_post_event_seconds"] == 0.5
+
 
 def test_update_surveillance_settings_expert_validation(client: TestClient) -> None:
     response = client.post(

--- a/tests/test_app_surveillance.py
+++ b/tests/test_app_surveillance.py
@@ -71,6 +71,7 @@ def test_get_surveillance_settings(client: TestClient) -> None:
     assert settings["remember_recording_state"] is False
     assert settings["storage_threshold_percent"] == 10
     assert settings["motion_detection_enabled"] is False
+    assert settings["motion_frame_decimation"] == 1
     assert "presets" in payload
     assert any(item["name"] == settings["preset"] for item in payload["presets"])
 
@@ -106,6 +107,7 @@ def test_update_surveillance_settings_advanced(client: TestClient) -> None:
             "remember_recording_state": True,
             "motion_detection_enabled": True,
             "motion_sensitivity": 65,
+            "motion_frame_decimation": 2,
             "auto_purge_days": 10,
             "storage_threshold_percent": 20,
         },
@@ -119,6 +121,7 @@ def test_update_surveillance_settings_advanced(client: TestClient) -> None:
     assert payload["remember_recording_state"] is True
     assert payload["motion_detection_enabled"] is True
     assert payload["motion_sensitivity"] == 65
+    assert payload["motion_frame_decimation"] == 2
     assert payload["auto_purge_days"] == 10
     assert payload["storage_threshold_percent"] == 20
 

--- a/tests/test_app_surveillance.py
+++ b/tests/test_app_surveillance.py
@@ -72,6 +72,7 @@ def test_get_surveillance_settings(client: TestClient) -> None:
     assert settings["storage_threshold_percent"] == 10
     assert settings["motion_detection_enabled"] is False
     assert settings["motion_frame_decimation"] == 1
+    assert settings["motion_post_event_seconds"] == 2.0
     assert "presets" in payload
     assert any(item["name"] == settings["preset"] for item in payload["presets"])
 
@@ -108,6 +109,7 @@ def test_update_surveillance_settings_advanced(client: TestClient) -> None:
             "motion_detection_enabled": True,
             "motion_sensitivity": 65,
             "motion_frame_decimation": 2,
+            "motion_post_event_seconds": 0.5,
             "auto_purge_days": 10,
             "storage_threshold_percent": 20,
         },
@@ -122,6 +124,7 @@ def test_update_surveillance_settings_advanced(client: TestClient) -> None:
     assert payload["motion_detection_enabled"] is True
     assert payload["motion_sensitivity"] == 65
     assert payload["motion_frame_decimation"] == 2
+    assert payload["motion_post_event_seconds"] == 0.5
     assert payload["auto_purge_days"] == 10
     assert payload["storage_threshold_percent"] == 20
 
@@ -177,6 +180,7 @@ def test_surveillance_status_storage(client: TestClient) -> None:
         assert "session_state" in motion
         assert "session_active" in motion
         assert "session_override" in motion
+        assert "post_event_record_seconds" in motion
     resume_state = payload.get("resume_state")
     assert isinstance(resume_state, dict)
     assert resume_state.get("mode") in {"revcam", "surveillance"}

--- a/tests/test_app_surveillance.py
+++ b/tests/test_app_surveillance.py
@@ -190,3 +190,9 @@ def test_surveillance_status_storage(client: TestClient) -> None:
     resume_state = payload.get("resume_state")
     assert isinstance(resume_state, dict)
     assert resume_state.get("mode") in {"revcam", "surveillance"}
+
+
+def test_surveillance_timeline_page(client: TestClient) -> None:
+    response = client.get("/surveillance/timeline")
+    assert response.status_code == 200
+    assert "Recording timeline" in response.text

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -215,23 +215,55 @@ def test_default_surveillance_settings(tmp_path: Path) -> None:
     preset_values = SURVEILLANCE_STANDARD_PRESETS[settings.preset]
     assert settings.resolved_fps == preset_values[0]
     assert settings.resolved_jpeg_quality == preset_values[1]
+    assert settings.chunk_duration_seconds is None
+    assert settings.overlays_enabled is True
+    assert settings.remember_recording_state is False
+    assert settings.motion_detection_enabled is False
+    assert settings.motion_sensitivity == 50
+    assert settings.auto_purge_days is None
+    assert settings.storage_threshold_percent == 10.0
 
 
 def test_surveillance_settings_persistence(tmp_path: Path) -> None:
     config_file = tmp_path / "config.json"
     manager = ConfigManager(config_file)
     updated = manager.set_surveillance_settings(
-        {"profile": "expert", "expert_fps": 12, "expert_jpeg_quality": 92}
+        {
+            "profile": "expert",
+            "expert_fps": 12,
+            "expert_jpeg_quality": 92,
+            "chunk_duration_seconds": 600,
+            "overlays_enabled": False,
+            "remember_recording_state": True,
+            "motion_detection_enabled": True,
+            "motion_sensitivity": 72,
+            "auto_purge_days": 5,
+            "storage_threshold_percent": 15,
+        }
     )
     assert isinstance(updated, SurveillanceSettings)
     assert updated.profile == "expert"
     assert updated.expert_fps == 12
     assert updated.expert_jpeg_quality == 92
+    assert updated.chunk_duration_seconds == 600
+    assert updated.overlays_enabled is False
+    assert updated.remember_recording_state is True
+    assert updated.motion_detection_enabled is True
+    assert updated.motion_sensitivity == 72
+    assert updated.auto_purge_days == 5
+    assert updated.storage_threshold_percent == 15
     reloaded = ConfigManager(config_file)
     reloaded_settings = reloaded.get_surveillance_settings()
     assert reloaded_settings.profile == "expert"
     assert reloaded_settings.expert_fps == 12
     assert reloaded_settings.expert_jpeg_quality == 92
+    assert reloaded_settings.chunk_duration_seconds == 600
+    assert reloaded_settings.overlays_enabled is False
+    assert reloaded_settings.remember_recording_state is True
+    assert reloaded_settings.motion_detection_enabled is True
+    assert reloaded_settings.motion_sensitivity == 72
+    assert reloaded_settings.auto_purge_days == 5
+    assert reloaded_settings.storage_threshold_percent == 15
 
 
 def test_surveillance_settings_validation(tmp_path: Path) -> None:
@@ -244,6 +276,19 @@ def test_surveillance_settings_validation(tmp_path: Path) -> None:
         manager.set_surveillance_settings({"expert_fps": "fast"})
     with pytest.raises(ValueError):
         manager.set_surveillance_settings({"expert_jpeg_quality": "sharp"})
+
+
+def test_surveillance_state_persistence(tmp_path: Path) -> None:
+    config_file = tmp_path / "config.json"
+    manager = ConfigManager(config_file)
+    state = manager.get_surveillance_state()
+    assert state.mode == "revcam"
+    assert state.recording is False
+    manager.update_surveillance_state("surveillance", True)
+    reloaded = ConfigManager(config_file)
+    persisted = reloaded.get_surveillance_state()
+    assert persisted.mode == "surveillance"
+    assert persisted.recording is True
 
 
 def test_default_reversing_aids(tmp_path: Path) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -220,6 +220,7 @@ def test_default_surveillance_settings(tmp_path: Path) -> None:
     assert settings.remember_recording_state is False
     assert settings.motion_detection_enabled is False
     assert settings.motion_sensitivity == 50
+    assert settings.motion_frame_decimation == 1
     assert settings.auto_purge_days is None
     assert settings.storage_threshold_percent == 10.0
 
@@ -237,6 +238,7 @@ def test_surveillance_settings_persistence(tmp_path: Path) -> None:
             "remember_recording_state": True,
             "motion_detection_enabled": True,
             "motion_sensitivity": 72,
+            "motion_frame_decimation": 3,
             "auto_purge_days": 5,
             "storage_threshold_percent": 15,
         }
@@ -250,6 +252,7 @@ def test_surveillance_settings_persistence(tmp_path: Path) -> None:
     assert updated.remember_recording_state is True
     assert updated.motion_detection_enabled is True
     assert updated.motion_sensitivity == 72
+    assert updated.motion_frame_decimation == 3
     assert updated.auto_purge_days == 5
     assert updated.storage_threshold_percent == 15
     reloaded = ConfigManager(config_file)
@@ -262,6 +265,7 @@ def test_surveillance_settings_persistence(tmp_path: Path) -> None:
     assert reloaded_settings.remember_recording_state is True
     assert reloaded_settings.motion_detection_enabled is True
     assert reloaded_settings.motion_sensitivity == 72
+    assert reloaded_settings.motion_frame_decimation == 3
     assert reloaded_settings.auto_purge_days == 5
     assert reloaded_settings.storage_threshold_percent == 15
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -221,6 +221,7 @@ def test_default_surveillance_settings(tmp_path: Path) -> None:
     assert settings.motion_detection_enabled is False
     assert settings.motion_sensitivity == 50
     assert settings.motion_frame_decimation == 1
+    assert settings.motion_post_event_seconds == 2.0
     assert settings.auto_purge_days is None
     assert settings.storage_threshold_percent == 10.0
 
@@ -239,6 +240,7 @@ def test_surveillance_settings_persistence(tmp_path: Path) -> None:
             "motion_detection_enabled": True,
             "motion_sensitivity": 72,
             "motion_frame_decimation": 3,
+            "motion_post_event_seconds": 0.75,
             "auto_purge_days": 5,
             "storage_threshold_percent": 15,
         }
@@ -253,6 +255,7 @@ def test_surveillance_settings_persistence(tmp_path: Path) -> None:
     assert updated.motion_detection_enabled is True
     assert updated.motion_sensitivity == 72
     assert updated.motion_frame_decimation == 3
+    assert updated.motion_post_event_seconds == 0.75
     assert updated.auto_purge_days == 5
     assert updated.storage_threshold_percent == 15
     reloaded = ConfigManager(config_file)
@@ -266,6 +269,7 @@ def test_surveillance_settings_persistence(tmp_path: Path) -> None:
     assert reloaded_settings.motion_detection_enabled is True
     assert reloaded_settings.motion_sensitivity == 72
     assert reloaded_settings.motion_frame_decimation == 3
+    assert reloaded_settings.motion_post_event_seconds == 0.75
     assert reloaded_settings.auto_purge_days == 5
     assert reloaded_settings.storage_threshold_percent == 15
 

--- a/tests/test_motion_detection.py
+++ b/tests/test_motion_detection.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import types
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from rev_cam.camera import BaseCamera
+from rev_cam.config import Orientation
+from rev_cam.pipeline import FramePipeline
+from rev_cam.recording import MotionDetector, RecordingManager
+
+
+class _StaticCamera(BaseCamera):
+    async def get_frame(self) -> np.ndarray:  # pragma: no cover - not exercised in tests
+        return np.zeros((8, 8, 3), dtype=np.uint8)
+
+
+def _pipeline() -> FramePipeline:
+    return FramePipeline(lambda: Orientation(rotation=0, flip_horizontal=False, flip_vertical=False))
+
+
+def test_motion_detector_pauses_and_resumes() -> None:
+    detector = MotionDetector(enabled=True, sensitivity=75, inactivity_timeout=0.1)
+    still = np.zeros((16, 16, 3), dtype=np.uint8)
+    assert detector.should_record(still, 0.0) is True
+    # Still frames before inactivity threshold should continue recording.
+    assert detector.should_record(still, 0.05) is True
+    # After inactivity threshold with no change we pause.
+    assert detector.should_record(still, 0.2) is False
+    meta = detector.snapshot()
+    assert meta["pause_count"] == 1
+    assert meta["active"] is False
+    # Motion resumes recording immediately.
+    moving = still.copy()
+    moving[:4, :4, :] = 255
+    assert detector.should_record(moving, 0.25) is True
+    meta = detector.snapshot()
+    assert meta["active"] is True
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_recording_manager_records_only_when_motion_detected(tmp_path: Path, anyio_backend) -> None:
+    camera = _StaticCamera()
+    pipeline = _pipeline()
+    manager = RecordingManager(
+        camera=camera,
+        pipeline=pipeline,
+        directory=tmp_path,
+        motion_detection_enabled=True,
+        motion_sensitivity=80,
+        motion_inactivity_timeout_seconds=0.05,
+    )
+
+    async def _noop(self):
+        return None
+
+    manager._ensure_producer_running = types.MethodType(_noop, manager)
+    await manager.start_recording()
+
+    still = np.zeros((32, 32, 3), dtype=np.uint8)
+    await manager._record_frame(b"frame1", 0.0, still)
+    await manager._record_frame(b"frame2", 0.02, still)
+    # Past inactivity threshold with no motion, frame is skipped.
+    await manager._record_frame(b"frame3", 0.2, still)
+    assert len(manager._recording_frames) == 2
+
+    moving = still.copy()
+    moving[:4, :4, :] = 255
+    await manager._record_frame(b"frame4", 0.25, moving)
+    assert len(manager._recording_frames) == 3
+
+    metadata = await manager.stop_recording()
+    motion = metadata["motion_detection"]
+    assert motion["enabled"] is True
+    assert motion["pause_count"] >= 1
+    assert motion["skipped_frames"] >= 1
+    assert motion["recorded_frames"] == 3
+    await manager.aclose()

--- a/tests/test_motion_detection.py
+++ b/tests/test_motion_detection.py
@@ -9,6 +9,7 @@ import asyncio
 import numpy as np
 import pytest
 
+import rev_cam.recording as recording
 from rev_cam.camera import BaseCamera
 from rev_cam.config import Orientation
 from rev_cam.pipeline import FramePipeline
@@ -357,3 +358,45 @@ async def test_recording_manager_writes_compressed_chunks(tmp_path: Path, anyio_
     assert isinstance(frames, list)
     assert len(frames) == metadata["frame_count"]
     assert frames and "jpeg" in frames[0]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_recording_manager_streams_chunk_writes(
+    tmp_path: Path, anyio_backend, monkeypatch
+) -> None:
+    camera = _StaticCamera()
+    pipeline = _pipeline()
+    manager = RecordingManager(
+        camera=camera,
+        pipeline=pipeline,
+        directory=tmp_path,
+        fps=4,
+        chunk_duration_seconds=1,
+    )
+
+    async def _noop(self):
+        return None
+
+    manager._ensure_producer_running = types.MethodType(_noop, manager)
+
+    observed: list[str] = []
+    original_dump = recording._dump_json_to_path
+
+    def _tracking_dump(path, payload):
+        observed.append(path.name if isinstance(path, Path) else str(path))
+        return original_dump(path, payload)
+
+    monkeypatch.setattr(recording, "_dump_json_to_path", _tracking_dump)
+
+    await manager.start_recording()
+    frame = np.zeros((32, 32, 3), dtype=np.uint8)
+    for index in range(10):
+        await manager._record_frame(f"frame{index}".encode(), index * 0.25, frame)
+
+    await manager.stop_recording()
+    await manager.wait_for_processing()
+    await manager.aclose()
+
+    chunk_calls = [name for name in observed if "chunk" in name]
+    assert not chunk_calls

--- a/tests/test_motion_detection.py
+++ b/tests/test_motion_detection.py
@@ -101,7 +101,10 @@ async def test_recording_manager_records_only_when_motion_detected(tmp_path: Pat
     snapshot = manager.get_motion_status()
     assert snapshot["recorded_frames"] == 3
 
-    metadata = await manager.stop_recording()
+    placeholder = await manager.stop_recording()
+    assert placeholder["processing"] is True
+    metadata = await manager.wait_for_processing()
+    assert metadata is not None
     motion = metadata["motion_detection"]
     assert motion["enabled"] is True
     assert motion["pause_count"] >= 1
@@ -133,7 +136,10 @@ async def test_recording_manager_writes_compressed_chunks(tmp_path: Path, anyio_
     for index in range(5):
         await manager._record_frame(f"frame{index}".encode(), index * 0.2, frame)
 
-    metadata = await manager.stop_recording()
+    placeholder = await manager.stop_recording()
+    assert placeholder["processing"] is True
+    metadata = await manager.wait_for_processing()
+    assert metadata is not None
     await manager.aclose()
 
     assert metadata["chunk_count"] >= 1


### PR DESCRIPTION
## Summary
- add configuration support and APIs for surveillance settings including standard presets and expert controls
- create a surveillance settings page and link from the surveillance dashboard, with timestamp-aware playback fixes
- cover the new behaviour with unit and integration tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68defb15c43c8332b33db7e99a322d2d