### PR TITLE
Add bulk deletion and download support to surveillance timeline

### DIFF
--- a/src/rev_cam/recording.py
+++ b/src/rev_cam/recording.py
@@ -9,7 +9,7 @@ import json
 import logging
 import shutil
 import time
-import zipfile
+from fractions import Fraction
 from copy import deepcopy
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
@@ -17,6 +17,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 from tempfile import SpooledTemporaryFile
 from typing import AsyncGenerator, Awaitable, Callable, Iterable, Mapping
+
+import av
+import simplejpeg
 
 try:  # pragma: no cover - optional dependency on numpy
     import numpy as _np
@@ -189,51 +192,95 @@ def load_recording_payload(directory: Path, name: str) -> dict[str, object]:
     return payload
 
 
-def build_recording_archive(
+def build_recording_video(
     directory: Path, name: str
 ) -> tuple[str, SpooledTemporaryFile]:
-    """Package recording files for ``name`` into a ZIP archive."""
+    """Render recording ``name`` to an MP4 file and return a file-like object."""
 
     safe_name = _safe_recording_name(name)
-    meta_path = directory / f"{safe_name}.meta.json"
-    data_path = directory / f"{safe_name}.json"
-    gz_path = directory / f"{safe_name}.json.gz"
-    metadata: dict[str, object] | None = None
-    if meta_path.exists() and meta_path.is_file():
+    payload = load_recording_payload(directory, safe_name)
+    raw_frames = payload.get("frames")
+    if not isinstance(raw_frames, list):
+        raise ValueError("Recording does not contain any frames")
+
+    frames: list[Mapping[str, object]] = [
+        frame for frame in raw_frames if isinstance(frame, Mapping)
+    ]
+    if not frames:
+        raise ValueError("Recording does not contain any frames")
+
+    frame_rate_value = payload.get("fps")
+    if isinstance(frame_rate_value, (int, float)) and frame_rate_value > 0:
+        frame_rate = float(frame_rate_value)
+    else:
+        frame_rate = 10.0
+
+    # Identify the first usable frame so we can determine the output dimensions.
+    first_index = None
+    first_array = None
+    for idx, frame in enumerate(frames):
+        jpeg_data = frame.get("jpeg")
+        if not isinstance(jpeg_data, str) or not jpeg_data:
+            continue
         try:
-            metadata = json.loads(meta_path.read_text(encoding="utf-8"))
-        except Exception:  # pragma: no cover - best-effort parsing
-            metadata = None
-    paths: list[Path] = []
-    seen: set[Path] = set()
+            decoded = base64.b64decode(jpeg_data)
+            array = simplejpeg.decode_jpeg(decoded, colorspace="BGR")
+        except Exception as exc:
+            raise ValueError("Recording frames are invalid") from exc
+        if array.ndim != 3 or array.shape[2] != 3:
+            raise ValueError("Recording frames are invalid")
+        first_index = idx
+        first_array = array
+        break
 
-    def _add_path(candidate: Path) -> None:
-        if candidate.exists() and candidate.is_file() and candidate not in seen:
-            paths.append(candidate)
-            seen.add(candidate)
+    if first_index is None or first_array is None:
+        raise ValueError("Recording does not contain any usable frames")
 
-    if meta_path.exists() and meta_path.is_file():
-        _add_path(meta_path)
-    if data_path.exists() and data_path.is_file():
-        _add_path(data_path)
-    elif gz_path.exists() and gz_path.is_file():
-        _add_path(gz_path)
-    if isinstance(metadata, Mapping):
-        chunks = metadata.get("chunks")
-        if isinstance(chunks, list):
-            for entry in chunks:
-                if isinstance(entry, Mapping):
-                    filename = entry.get("file")
-                    if isinstance(filename, str):
-                        chunk_path = directory / filename
-                        _add_path(chunk_path)
-    if not paths:
-        raise FileNotFoundError("Recording not found")
+    height, width = first_array.shape[:2]
+    archive = SpooledTemporaryFile(max_size=64 * 1024 * 1024)
+    frame_rate_fraction = Fraction(str(frame_rate)).limit_denominator(1000)
+    time_base = Fraction(
+        frame_rate_fraction.denominator, frame_rate_fraction.numerator
+    )
 
-    archive = SpooledTemporaryFile(max_size=8 * 1024 * 1024)
-    with zipfile.ZipFile(archive, "w", compression=zipfile.ZIP_DEFLATED) as handle:
-        for path in paths:
-            handle.write(path, arcname=path.name)
+    with av.open(archive, mode="w", format="mp4") as container:
+        stream = container.add_stream("h264", rate=frame_rate_fraction)
+        stream.width = int(width)
+        stream.height = int(height)
+        stream.pix_fmt = "yuv420p"
+        stream.time_base = time_base
+        stream.options = {"movflags": "+faststart"}
+
+        def _encode(array_data: "_np.ndarray", position: int) -> None:
+            frame = av.VideoFrame.from_ndarray(array_data, format="bgr24")
+            frame.pts = position
+            frame.time_base = time_base
+            for packet in stream.encode(frame):
+                container.mux(packet)
+
+        position = 0
+        _encode(first_array, position)
+        position += 1
+
+        for frame in frames[first_index + 1 :]:
+            jpeg_data = frame.get("jpeg")
+            if not isinstance(jpeg_data, str) or not jpeg_data:
+                continue
+            try:
+                decoded = base64.b64decode(jpeg_data)
+                array = simplejpeg.decode_jpeg(decoded, colorspace="BGR")
+            except Exception:  # pragma: no cover - skip invalid frames
+                continue
+            if array.ndim != 3 or array.shape[2] != 3:
+                continue
+            if array.shape[0] != height or array.shape[1] != width:
+                continue
+            _encode(array, position)
+            position += 1
+
+        for packet in stream.encode():
+            container.mux(packet)
+
     archive.seek(0)
     return safe_name, archive
 
@@ -1577,7 +1624,7 @@ class RecordingManager:
 __all__ = [
     "MotionDetector",
     "RecordingManager",
-    "build_recording_archive",
+    "build_recording_video",
     "load_recording_metadata",
     "load_recording_payload",
     "remove_recording_files",

--- a/src/rev_cam/static/surveillance_timeline.html
+++ b/src/rev_cam/static/surveillance_timeline.html
@@ -1002,7 +1002,7 @@
             name
           )}/download`;
           downloadLink.href = downloadHref;
-          downloadLink.download = `${name}.zip`;
+          downloadLink.download = `${name}.mp4`;
           if (record.processing) {
             downloadLink.classList.add("is-disabled");
             downloadLink.setAttribute("aria-disabled", "true");

--- a/src/rev_cam/static/surveillance_timeline.html
+++ b/src/rev_cam/static/surveillance_timeline.html
@@ -135,7 +135,7 @@
         display: flex;
         flex-wrap: wrap;
         gap: var(--space-md);
-        align-items: center;
+        align-items: flex-start;
         justify-content: space-between;
       }
 
@@ -194,6 +194,76 @@
         outline: none;
       }
 
+      .control-groups {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-sm);
+        align-items: flex-end;
+      }
+
+      .selection-actions {
+        display: inline-flex;
+        flex-wrap: wrap;
+        gap: var(--space-sm);
+        align-items: center;
+        justify-content: flex-end;
+      }
+
+      .secondary-button {
+        appearance: none;
+        border: 1px solid var(--border-subtle);
+        background: transparent;
+        color: var(--text-muted);
+        font-weight: 600;
+        padding: 0.45rem 1.1rem;
+        border-radius: var(--radius-pill);
+        cursor: pointer;
+        transition: border-color 200ms ease, color 200ms ease, background 200ms ease;
+      }
+
+      .secondary-button:hover,
+      .secondary-button:focus-visible {
+        border-color: rgba(10, 132, 255, 0.5);
+        color: var(--text-primary);
+        background: rgba(10, 132, 255, 0.08);
+        outline: none;
+      }
+
+      .secondary-button:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+        color: var(--text-muted);
+        background: transparent;
+      }
+
+      .danger-button {
+        appearance: none;
+        border: 1px solid rgba(255, 69, 58, 0.4);
+        background: rgba(255, 69, 58, 0.12);
+        color: var(--danger);
+        font-weight: 600;
+        padding: 0.45rem 1.2rem;
+        border-radius: var(--radius-pill);
+        cursor: pointer;
+        transition: background 200ms ease, border-color 200ms ease, color 200ms ease,
+          transform 150ms ease;
+      }
+
+      .danger-button:hover,
+      .danger-button:focus-visible {
+        background: rgba(255, 69, 58, 0.2);
+        border-color: rgba(255, 69, 58, 0.6);
+        color: #ff6b61;
+        outline: none;
+        transform: translateY(-1px);
+      }
+
+      .danger-button:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+        transform: none;
+      }
+
       .refresh-button {
         appearance: none;
         border: 1px solid var(--border-subtle);
@@ -247,6 +317,11 @@
         box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
       }
 
+      .timeline-item.is-selected {
+        border-color: rgba(10, 132, 255, 0.65);
+        box-shadow: 0 24px 48px rgba(10, 132, 255, 0.25);
+      }
+
       .timeline-item::before {
         content: "";
         position: absolute;
@@ -260,9 +335,32 @@
         box-shadow: 0 0 0 4px var(--surface-0);
       }
 
+      .timeline-item.is-selected::before {
+        box-shadow: 0 0 0 4px rgba(10, 132, 255, 0.35);
+      }
+
       .timeline-item[data-type="motion"]::before {
         background: var(--timeline-marker-motion);
         box-shadow: 0 0 0 4px rgba(255, 160, 49, 0.1);
+      }
+
+      .timeline-select {
+        position: absolute;
+        top: var(--space-md);
+        right: var(--space-md);
+        z-index: 1;
+      }
+
+      .timeline-select-checkbox {
+        width: 1.1rem;
+        height: 1.1rem;
+        cursor: pointer;
+        accent-color: var(--accent);
+      }
+
+      .timeline-select-checkbox:disabled {
+        cursor: not-allowed;
+        opacity: 0.6;
       }
 
       .thumbnail-wrapper {
@@ -388,6 +486,39 @@
         box-shadow: none;
       }
 
+      .timeline-actions .ghost-button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.5rem 1.2rem;
+        border-radius: var(--radius-pill);
+        border: 1px solid var(--border-subtle);
+        color: var(--text-primary);
+        font-weight: 600;
+        text-decoration: none;
+        background: transparent;
+        transition: color 200ms ease, border-color 200ms ease, background 200ms ease;
+      }
+
+      .timeline-actions .ghost-button:hover,
+      .timeline-actions .ghost-button:focus-visible {
+        color: var(--accent);
+        border-color: rgba(10, 132, 255, 0.6);
+        background: rgba(10, 132, 255, 0.1);
+        outline: none;
+      }
+
+      .timeline-actions .ghost-button:focus-visible {
+        box-shadow: 0 0 0 2px rgba(10, 132, 255, 0.35);
+      }
+
+      .timeline-actions .ghost-button.is-disabled {
+        opacity: 0.6;
+        pointer-events: none;
+        cursor: not-allowed;
+        background: transparent;
+      }
+
       .timeline-empty {
         background: var(--surface-soft);
         border-radius: var(--radius-lg);
@@ -407,6 +538,16 @@
         .timeline-controls {
           flex-direction: column;
           align-items: flex-start;
+        }
+
+        .control-groups {
+          width: 100%;
+          align-items: flex-start;
+        }
+
+        .selection-actions {
+          width: 100%;
+          justify-content: flex-start;
         }
 
         .timeline-item {
@@ -441,35 +582,62 @@
             Loading timeline…
           </p>
         </div>
-        <div class="filter-group" role="group" aria-label="Filter recordings">
-          <button
-            class="filter-button"
-            type="button"
-            data-filter="all"
-            aria-pressed="true"
+        <div class="control-groups">
+          <div class="filter-group" role="group" aria-label="Filter recordings">
+            <button
+              class="filter-button"
+              type="button"
+              data-filter="all"
+              aria-pressed="true"
+            >
+              All recordings
+            </button>
+            <button
+              class="filter-button"
+              type="button"
+              data-filter="manual"
+              aria-pressed="false"
+            >
+              Manual recordings
+            </button>
+            <button
+              class="filter-button"
+              type="button"
+              data-filter="motion"
+              aria-pressed="false"
+            >
+              Motion events
+            </button>
+          </div>
+          <div
+            class="selection-actions"
+            role="group"
+            aria-label="Recording selection actions"
           >
-            All recordings
-          </button>
-          <button
-            class="filter-button"
-            type="button"
-            data-filter="manual"
-            aria-pressed="false"
-          >
-            Manual recordings
-          </button>
-          <button
-            class="filter-button"
-            type="button"
-            data-filter="motion"
-            aria-pressed="false"
-          >
-            Motion events
-          </button>
+            <button class="secondary-button" type="button" id="select-all-button">
+              Select all
+            </button>
+            <button
+              class="secondary-button"
+              type="button"
+              id="clear-selection-button"
+              disabled
+            >
+              Clear selection
+            </button>
+            <button
+              class="danger-button"
+              type="button"
+              id="delete-selected-button"
+              disabled
+            >
+              Delete selected
+            </button>
+            <button class="refresh-button" type="button" id="refresh-button">
+              Refresh
+            </button>
+          </div>
         </div>
-        <button class="refresh-button" type="button" id="refresh-button">
-          Refresh
-        </button>
       </section>
       <section class="timeline" id="timeline" aria-live="polite"></section>
     </main>
@@ -480,10 +648,19 @@
       const filterButtons = Array.from(
         document.querySelectorAll(".filter-button[data-filter]")
       );
+      const deleteSelectedButton = document.getElementById(
+        "delete-selected-button"
+      );
+      const selectAllButton = document.getElementById("select-all-button");
+      const clearSelectionButton = document.getElementById(
+        "clear-selection-button"
+      );
 
       let recordings = [];
       let activeFilter = "all";
       let loading = false;
+      let deleting = false;
+      let selectedRecordings = new Set();
 
       function setStatus(message, tone = "info") {
         if (!statusElement) {
@@ -491,6 +668,38 @@
         }
         statusElement.textContent = message;
         statusElement.dataset.tone = tone;
+      }
+
+      function updateSelectionUI() {
+        const selectedCount = selectedRecordings.size;
+        if (deleteSelectedButton) {
+          deleteSelectedButton.disabled =
+            selectedCount === 0 || deleting || loading;
+          deleteSelectedButton.textContent =
+            selectedCount > 0
+              ? `Delete selected (${selectedCount})`
+              : "Delete selected";
+        }
+        if (clearSelectionButton) {
+          clearSelectionButton.disabled =
+            selectedCount === 0 || deleting || loading;
+        }
+        if (selectAllButton) {
+          const visible = applyFilter(recordings, activeFilter);
+          selectAllButton.disabled =
+            deleting || loading || visible.length === 0;
+        }
+        if (refreshButton) {
+          refreshButton.disabled = loading || deleting;
+        }
+        if (timelineElement) {
+          const checkboxes = timelineElement.querySelectorAll(
+            ".timeline-select-checkbox"
+          );
+          checkboxes.forEach((input) => {
+            input.disabled = deleting;
+          });
+        }
       }
 
       function parseDate(value) {
@@ -512,6 +721,14 @@
         const [, year, month, day, hour, minute, second] = match.map(Number);
         const date = new Date(Date.UTC(year, month - 1, day, hour, minute, second));
         return Number.isNaN(date.getTime()) ? null : date;
+      }
+
+      function getRecordName(record) {
+        if (!record || typeof record !== "object") {
+          return null;
+        }
+        const { name } = record;
+        return typeof name === "string" && name ? name : null;
       }
 
       function getSortTime(record) {
@@ -605,7 +822,7 @@
           if (!entry || typeof entry !== "object") {
             return;
           }
-          const name = typeof entry.name === "string" ? entry.name : null;
+          const name = getRecordName(entry);
           if (!name) {
             return;
           }
@@ -643,6 +860,32 @@
         const item = document.createElement("article");
         item.className = "timeline-item";
         item.dataset.type = type;
+        const name = getRecordName(record);
+        if (name && selectedRecordings.has(name)) {
+          item.classList.add("is-selected");
+        }
+
+        if (name) {
+          const selection = document.createElement("div");
+          selection.className = "timeline-select";
+          const checkbox = document.createElement("input");
+          checkbox.type = "checkbox";
+          checkbox.className = "timeline-select-checkbox";
+          checkbox.checked = selectedRecordings.has(name);
+          checkbox.disabled = deleting;
+          checkbox.addEventListener("change", (event) => {
+            const checked = Boolean(event.target && event.target.checked);
+            if (checked) {
+              selectedRecordings.add(name);
+            } else {
+              selectedRecordings.delete(name);
+            }
+            item.classList.toggle("is-selected", checked);
+            updateSelectionUI();
+          });
+          selection.appendChild(checkbox);
+          item.appendChild(selection);
+        }
 
         const thumbnailWrapper = document.createElement("div");
         thumbnailWrapper.className = "thumbnail-wrapper";
@@ -666,7 +909,7 @@
         const title = document.createElement("div");
         title.className = "timeline-title";
         const nameElement = document.createElement("strong");
-        nameElement.textContent = typeof record.name === "string" ? record.name : "Recording";
+        nameElement.textContent = name || "Recording";
         const chip = document.createElement("span");
         chip.className = "timeline-chip";
         chip.textContent = describeType(type);
@@ -745,12 +988,28 @@
         viewButton.textContent = record.processing ? "Processing…" : "View recording";
         viewButton.disabled = Boolean(record.processing);
         viewButton.addEventListener("click", () => {
-          if (typeof record.name === "string" && record.name) {
-            const href = `/surveillance/player?name=${encodeURIComponent(record.name)}`;
+          if (name) {
+            const href = `/surveillance/player?name=${encodeURIComponent(name)}`;
             window.location.href = href;
           }
         });
         actions.appendChild(viewButton);
+        if (name) {
+          const downloadLink = document.createElement("a");
+          downloadLink.className = "ghost-button download-button";
+          downloadLink.textContent = "Download";
+          const downloadHref = `/api/surveillance/recordings/${encodeURIComponent(
+            name
+          )}/download`;
+          downloadLink.href = downloadHref;
+          downloadLink.download = `${name}.zip`;
+          if (record.processing) {
+            downloadLink.classList.add("is-disabled");
+            downloadLink.setAttribute("aria-disabled", "true");
+            downloadLink.tabIndex = -1;
+          }
+          actions.appendChild(downloadLink);
+        }
         content.appendChild(actions);
 
         item.appendChild(content);
@@ -784,6 +1043,7 @@
               : "No recordings match the selected filter.";
           timelineElement.appendChild(empty);
           setStatus(empty.textContent, "info");
+          updateSelectionUI();
           return;
         }
         filtered.forEach((record) => {
@@ -795,6 +1055,7 @@
             ? "Displaying 1 recording."
             : `Displaying ${count} recordings.`;
         setStatus(label, "info");
+        updateSelectionUI();
       }
 
       async function loadRecordings() {
@@ -802,9 +1063,7 @@
           return;
         }
         loading = true;
-        if (refreshButton) {
-          refreshButton.disabled = true;
-        }
+        updateSelectionUI();
         setStatus("Loading timeline…", "busy");
         try {
           const response = await fetch("/api/surveillance/recordings", {
@@ -814,7 +1073,17 @@
             throw new Error(`Request failed with ${response.status}`);
           }
           const payload = await response.json();
-          recordings = normaliseRecords(payload && payload.recordings);
+          const previousSelection = new Set(selectedRecordings);
+          const nextRecords = normaliseRecords(payload && payload.recordings);
+          const availableNames = new Set(
+            nextRecords
+              .map((record) => getRecordName(record))
+              .filter((name) => typeof name === "string")
+          );
+          selectedRecordings = new Set(
+            Array.from(previousSelection).filter((name) => availableNames.has(name))
+          );
+          recordings = nextRecords;
           renderTimeline();
         } catch (error) {
           console.error("Failed to load surveillance recordings", error);
@@ -828,8 +1097,9 @@
         } finally {
           loading = false;
           if (refreshButton) {
-            refreshButton.disabled = false;
+            refreshButton.disabled = deleting;
           }
+          updateSelectionUI();
         }
       }
 
@@ -840,6 +1110,121 @@
           button.setAttribute("aria-pressed", String(isActive));
         });
         renderTimeline();
+        updateSelectionUI();
+      }
+
+      function selectAllVisibleRecordings() {
+        const visible = applyFilter(recordings, activeFilter);
+        let changed = false;
+        visible.forEach((record) => {
+          const name = getRecordName(record);
+          if (name && !selectedRecordings.has(name)) {
+            selectedRecordings.add(name);
+            changed = true;
+          }
+        });
+        if (changed) {
+          renderTimeline();
+        } else {
+          updateSelectionUI();
+        }
+      }
+
+      function clearSelection() {
+        if (selectedRecordings.size === 0) {
+          return;
+        }
+        selectedRecordings = new Set();
+        renderTimeline();
+        updateSelectionUI();
+      }
+
+      async function deleteRecordingRequest(name) {
+        const response = await fetch(
+          `/api/surveillance/recordings/${encodeURIComponent(name)}`,
+          { method: "DELETE" }
+        );
+        if (response.status === 404) {
+          return;
+        }
+        if (!response.ok) {
+          let detail = "";
+          try {
+            const payload = await response.json();
+            if (payload && typeof payload.detail === "string") {
+              detail = payload.detail;
+            }
+          } catch (error) {
+            // Ignore JSON parsing failures.
+          }
+          if (!detail) {
+            detail = `Request failed with ${response.status}`;
+          }
+          throw new Error(detail);
+        }
+      }
+
+      async function deleteSelectedRecordings() {
+        if (deleting || loading) {
+          return;
+        }
+        const names = Array.from(selectedRecordings);
+        if (!names.length) {
+          return;
+        }
+        const confirmationMessage =
+          names.length === 1
+            ? `Delete recording "${names[0]}"?`
+            : `Delete ${names.length} recordings?`;
+        if (!window.confirm(confirmationMessage)) {
+          return;
+        }
+        deleting = true;
+        updateSelectionUI();
+        const failedNames = new Set();
+        for (const name of names) {
+          try {
+            await deleteRecordingRequest(name);
+          } catch (error) {
+            console.error("Failed to delete surveillance recording", name, error);
+            failedNames.add(name);
+          }
+        }
+        names.forEach((name) => {
+          if (!failedNames.has(name)) {
+            selectedRecordings.delete(name);
+          }
+        });
+        deleting = false;
+        updateSelectionUI();
+        await loadRecordings();
+        const successNames = names.filter((name) => !failedNames.has(name));
+        const successCount = successNames.length;
+        let message = "";
+        let tone = failedNames.size ? "error" : "info";
+        if (failedNames.size && successCount) {
+          message =
+            failedNames.size === 1
+              ? `Deleted ${successCount} recordings, but failed to delete ${Array.from(
+                  failedNames
+                )[0]}.`
+              : `Deleted ${successCount} recordings, but failed to delete ${failedNames.size}.`;
+        } else if (failedNames.size) {
+          if (failedNames.size === 1) {
+            const [failedName] = failedNames;
+            message = `Unable to delete ${failedName}.`;
+          } else {
+            message = `Unable to delete ${failedNames.size} recordings.`;
+          }
+        } else if (successCount) {
+          message =
+            successCount === 1
+              ? `Deleted recording ${successNames[0]}.`
+              : `Deleted ${successCount} recordings.`;
+        }
+        if (message) {
+          setStatus(message, tone);
+        }
       }
 
       filterButtons.forEach((button) => {
@@ -849,12 +1234,31 @@
         });
       });
 
+      if (selectAllButton) {
+        selectAllButton.addEventListener("click", () => {
+          selectAllVisibleRecordings();
+        });
+      }
+
+      if (clearSelectionButton) {
+        clearSelectionButton.addEventListener("click", () => {
+          clearSelection();
+        });
+      }
+
+      if (deleteSelectedButton) {
+        deleteSelectedButton.addEventListener("click", () => {
+          deleteSelectedRecordings();
+        });
+      }
+
       if (refreshButton) {
         refreshButton.addEventListener("click", () => {
           loadRecordings();
         });
       }
 
+      updateSelectionUI();
       loadRecordings();
     </script>
   </body>


### PR DESCRIPTION
## Summary
- add a download endpoint that streams a ZIP archive for each surveillance recording
- factor out a helper to package recording metadata, data, and chunk files for export
- update the surveillance timeline UI with multi-select controls, bulk deletion, and per-item download links

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e0fb7b2e7883328e11f29c0d23fd01