### PR TITLE
Expand live view stream to viewport width

### DIFF
--- a/src/rev_cam/static/index.html
+++ b/src/rev_cam/static/index.html
@@ -132,8 +132,9 @@
         padding: clamp(var(--space-lg), 4vw, var(--space-2xl));
       }
       .stream-wrapper {
-        width: min(100%, max(320px, calc(100vh - 6rem)));
-        max-width: min(1100px, max(360px, calc(100vh - 3rem)));
+        --frame-padding: clamp(var(--space-lg), 4vw, var(--space-2xl));
+        width: min(100%, calc(100vw - 2 * var(--frame-padding)));
+        max-width: 100%;
         margin: 0;
       }
       .stream-display {


### PR DESCRIPTION
## Summary
- allow the live view stream container to span the viewport width rather than being limited by viewport height
- keep the video element responsive within the expanded container

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0fbd4747483329e21ac15143796b5