### PR TITLE
Fix manual recording status handling

### DIFF
--- a/src/rev_cam/static/surveillance.html
+++ b/src/rev_cam/static/surveillance.html
@@ -426,10 +426,10 @@
         <p class="muted" id="preview-message">Preparing surveillance stream…</p>
         <div class="controls">
           <button class="action" type="button" id="record-button" aria-pressed="false">
-            Start recording
+            Start manual recording
           </button>
           <button class="action" type="button" id="motion-record-button" aria-pressed="false">
-            Start motion recording
+            Start motion detection
           </button>
           <div class="recording-timer" id="recording-timer" aria-live="polite" hidden>
             <span class="recording-timer-icon" aria-hidden="true">⏱</span>
@@ -479,14 +479,12 @@
         ? Array.from(modeToggle.querySelectorAll(".mode-toggle-button"))
         : [];
       let currentMode = "surveillance";
-      let isRecording = false;
-      let recordingMode = "idle";
-      let manualRecordingPinned = false;
+      let sessionState = "idle";
+      let pendingManualResume = null;
       let previewUrl = null;
       let recordingTimerStartMs = null;
       let recordingTimerInterval = null;
       let recordingTimerSource = null;
-      let lastMotionSnapshot = null;
       const STATUS_REFRESH_ACTIVE_MS = 2000;
       const STATUS_REFRESH_IDLE_MS = 5000;
       let statusRefreshHandle = null;
@@ -513,10 +511,11 @@
         if (!pageVisible) {
           return;
         }
-        const interval =
-          isRecording && recordingMode === "motion"
-            ? STATUS_REFRESH_ACTIVE_MS
-            : STATUS_REFRESH_IDLE_MS;
+        const activeSession =
+          sessionState === "manual" ||
+          sessionState === "motion-monitoring" ||
+          sessionState === "motion-recording";
+        const interval = activeSession ? STATUS_REFRESH_ACTIVE_MS : STATUS_REFRESH_IDLE_MS;
         clearScheduledStatusRefresh();
         statusRefreshHandle = window.setTimeout(() => {
           statusRefreshHandle = null;
@@ -583,20 +582,13 @@
         recordingTimerInterval = window.setInterval(renderRecordingTimer, 1000);
       }
 
-      function syncRecordingTimer(startIso, motionSnapshot) {
+      function syncRecordingTimer(startIso, currentSession) {
         if (!recordingTimer) {
           return;
         }
         const hasStart = typeof startIso === "string" && startIso.length > 0;
-        const isContinuousRecording = isRecording && recordingMode === "continuous";
-        let isMotionRecording = false;
-        if (recordingMode === "motion" && motionSnapshot && motionSnapshot.session_active) {
-          const sessionRecording = motionSnapshot.session_recording === true;
-          const sessionState = motionSnapshot.session_state;
-          const eventActive = motionSnapshot.event_active === true;
-          isMotionRecording = sessionRecording || eventActive || sessionState === "recording";
-        }
-        const shouldRun = hasStart && (isContinuousRecording || isMotionRecording);
+        const shouldRun =
+          hasStart && (currentSession === "manual" || currentSession === "motion-recording");
         if (!shouldRun) {
           stopRecordingTimer();
           return;
@@ -673,21 +665,95 @@
         previewMessage.textContent = "Live surveillance preview.";
       }
 
-      function updateControlButtons() {
-        const isContinuous = recordingMode === "continuous";
-        const isMotion = recordingMode === "motion";
+      function isMotionRecordingActive(snapshot) {
+        if (!snapshot || typeof snapshot !== "object") {
+          return false;
+        }
+        const sessionState = snapshot.session_state;
+        if (sessionState === "recording") {
+          return true;
+        }
+        const sessionRecording = snapshot.session_recording === true;
+        const eventActive = snapshot.event_active === true;
+        return sessionRecording || eventActive;
+      }
+
+      function determineSessionState(serverRecording, serverMode, motionSnapshot) {
+        if (serverRecording && serverMode === "continuous") {
+          return "manual";
+        }
+        if (serverRecording && serverMode === "motion") {
+          return isMotionRecordingActive(motionSnapshot)
+            ? "motion-recording"
+            : "motion-monitoring";
+        }
+        return "idle";
+      }
+
+      function updateStatusForSession(currentSession, options = {}) {
+        const { processingActive = false, processingRecord = null } = options;
+        const manualProcessing = processingActive && isManualProcessingRecord(processingRecord);
+        if (currentSession === "manual") {
+          setStatus("Manual recording in progress…", "alert");
+          return;
+        }
+        if (currentSession === "motion-recording") {
+          setStatus("Motion detected — recording…", "alert");
+          return;
+        }
+        if (currentSession === "motion-monitoring") {
+          setStatus("Motion detection active.", "monitor");
+          return;
+        }
+        if (manualProcessing) {
+          setStatus("Finalising manual recording…", "busy");
+          return;
+        }
+        if (processingActive) {
+          setStatus("Finalising motion recording…", "busy");
+          return;
+        }
+        setStatus("Idle. Ready to record.", "info");
+      }
+
+      function applySessionVisuals(currentSession, options = {}) {
+        const { processingActive = false, processingRecord = null } = options;
+        sessionState = currentSession;
         if (recordButton) {
-          recordButton.textContent = isContinuous ? "Stop recording" : "Start recording";
-          recordButton.setAttribute("aria-pressed", String(isContinuous));
-          recordButton.disabled = isMotion;
+          const manualActive = currentSession === "manual";
+          recordButton.textContent = manualActive ? "Stop recording" : "Start manual recording";
+          recordButton.setAttribute("aria-pressed", String(manualActive));
+          recordButton.disabled =
+            currentSession === "motion-monitoring" || currentSession === "motion-recording";
+          recordButton.classList.toggle("recording-active", manualActive);
         }
         if (motionRecordButton) {
-          motionRecordButton.textContent = isMotion
-            ? "Stop motion recording"
-            : "Start motion recording";
-          motionRecordButton.setAttribute("aria-pressed", String(isMotion));
-          motionRecordButton.disabled = isContinuous;
+          const motionSession =
+            currentSession === "motion-monitoring" || currentSession === "motion-recording";
+          const motionRecording = currentSession === "motion-recording";
+          motionRecordButton.textContent = motionSession
+            ? "Stop motion detection"
+            : "Start motion detection";
+          motionRecordButton.setAttribute("aria-pressed", String(motionSession));
+          motionRecordButton.disabled = currentSession === "manual";
+          motionRecordButton.classList.remove("motion-monitoring", "motion-alert", "recording-active");
+          if (motionRecording) {
+            motionRecordButton.classList.add("motion-alert", "recording-active");
+          } else if (motionSession) {
+            motionRecordButton.classList.add("motion-monitoring");
+          }
         }
+        if (previewCard) {
+          previewCard.classList.remove("motion-monitoring", "motion-alert", "recording-active");
+          if (currentSession === "manual") {
+            previewCard.classList.add("recording-active");
+          } else if (currentSession === "motion-recording") {
+            previewCard.classList.add("motion-alert", "recording-active");
+          } else if (currentSession === "motion-monitoring") {
+            previewCard.classList.add("motion-monitoring");
+          }
+        }
+        updateStatusForSession(currentSession, { processingActive, processingRecord });
       }
 
       function formatBytes(bytes) {
@@ -730,48 +796,6 @@
         const threshold = Number(storage.threshold_percent ?? 0);
         if (Number.isFinite(threshold) && threshold > 0 && freePercent <= threshold) {
           storageStatus.classList.add("is-low");
-        }
-      }
-
-      function updateMotionIndicators(motionSnapshot) {
-        const manualRecordingActive = isRecording && recordingMode === "continuous";
-        if (recordButton) {
-          recordButton.classList.toggle("recording-active", manualRecordingActive);
-        }
-        if (previewCard) {
-          previewCard.classList.remove("motion-monitoring", "motion-alert");
-          previewCard.classList.toggle("recording-active", manualRecordingActive);
-        }
-        if (!motionRecordButton) {
-          return;
-        }
-        motionRecordButton.classList.remove(
-          "motion-monitoring",
-          "motion-alert",
-          "recording-active",
-        );
-        if (manualRecordingActive) {
-          return;
-        }
-        const isMotionSession = recordingMode === "motion";
-        if (!isMotionSession) {
-          return;
-        }
-        const sessionState = motionSnapshot ? motionSnapshot.session_state : null;
-        const sessionRecording = motionSnapshot && motionSnapshot.session_recording === true;
-        const eventActive = motionSnapshot && motionSnapshot.event_active === true;
-        const motionRecording = sessionRecording || sessionState === "recording" || eventActive;
-        if (motionRecording) {
-          motionRecordButton.classList.add("motion-alert", "recording-active");
-          if (previewCard) {
-            previewCard.classList.add("motion-alert", "recording-active");
-          }
-        } else {
-          motionRecordButton.classList.add("motion-monitoring");
-          if (previewCard && !manualRecordingActive) {
-            previewCard.classList.add("motion-monitoring");
-            previewCard.classList.remove("recording-active");
-          }
         }
       }
 
@@ -959,70 +983,31 @@
               serverModeHint = candidate;
             }
           }
-          let serverRecordingMode = serverRecording ? serverModeHint : "idle";
-          if (serverRecordingMode === "idle" && serverRecording) {
-            serverRecordingMode = "continuous";
-          }
-          const manualSessionOverride = Boolean(
-            serverRecording &&
-              motionSnapshot &&
-              motionSnapshot.session_override === true &&
-              motionSnapshot.enabled === false,
+          const derivedSession = determineSessionState(
+            serverRecording,
+            serverModeHint,
+            motionSnapshot,
           );
-          const manualProcessingActive = Boolean(
-            isProcessing && isManualProcessingRecord(processingRecord),
-          );
-          const manualServerActive =
-            manualSessionOverride ||
-            manualProcessingActive ||
-            (manualRecordingPinned && serverRecording && serverRecordingMode === "continuous");
-          if (manualRecordingPinned) {
-            if (!manualServerActive) {
-              manualRecordingPinned = false;
-            }
-          } else if (manualServerActive) {
-            manualRecordingPinned = true;
-          }
-          let nextRecordingMode = serverRecording ? serverRecordingMode : "idle";
-          if (manualRecordingPinned && serverRecording) {
-            nextRecordingMode = "continuous";
-          }
-          recordingMode = nextRecordingMode;
-          isRecording = serverRecording;
-          updateControlButtons();
+          const previousSession = sessionState;
+          applySessionVisuals(derivedSession, {
+            processingActive: isProcessing,
+            processingRecord,
+          });
           updatePreview(payload ? payload.preview : null);
           renderRecordings(payload && Array.isArray(payload.recordings) ? payload.recordings : []);
           const storage = payload ? payload.storage : null;
           updateStorage(storage);
-          lastMotionSnapshot = motionSnapshot;
-          updateMotionIndicators(motionSnapshot);
           const startedAtIso =
             payload && typeof payload.recording_started_at === "string"
               ? payload.recording_started_at
               : null;
-          syncRecordingTimer(startedAtIso, motionSnapshot);
+          syncRecordingTimer(startedAtIso, sessionState);
           const processingError =
             processingRecord &&
             typeof processingRecord.processing_error === "string" &&
             processingRecord.processing_error.length > 0;
-          if (isRecording) {
-            if (recordingMode === "motion" && motionSnapshot && motionSnapshot.session_active) {
-              const sessionState = motionSnapshot.session_state;
-              const sessionRecording = motionSnapshot.session_recording === true;
-              if (sessionRecording || sessionState === "recording") {
-                setStatus("Motion recording", "alert");
-              } else {
-                setStatus("Monitoring for motion", "monitor");
-              }
-            } else {
-              setStatus("Recording", "busy");
-            }
-          } else if (isProcessing) {
-            setStatus("Processing video clip…", "busy");
-          } else if (processingError) {
+          if (processingError) {
             setStatus("Recording processing failed", "error");
-          } else {
-            setStatus("Surveillance ready", "info");
           }
           if (
             storage &&
@@ -1032,6 +1017,23 @@
             storage.free_percent <= storage.threshold_percent
           ) {
             setStatus("Low storage — recordings will pause automatically", "error");
+          }
+          if (previousSession === "manual" && sessionState !== "manual") {
+            const resumeTarget = pendingManualResume;
+            pendingManualResume = null;
+            if (resumeTarget === "motion") {
+              window.setTimeout(() => {
+                resumeMotionAfterManual().catch((error) => {
+                  console.error("Failed to resume motion detection", error);
+                  setStatus("Unable to restart motion detection", "error");
+                  loadStatus({ showLoading: false, suppressError: true }).catch((loadError) => {
+                    console.error("Follow-up status refresh after resume failure failed", loadError);
+                  });
+                });
+              }, 0);
+            }
+          } else if (sessionState !== "manual") {
+            pendingManualResume = null;
           }
           scheduleStatusRefresh();
         } catch (error) {
@@ -1049,6 +1051,37 @@
         }
       }
 
+      async function postRecordingCommand(endpoint, options = {}) {
+        const { allowConflict = false } = options;
+        const response = await fetch(endpoint, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+        });
+        if (!response.ok) {
+          if (allowConflict && response.status === 409) {
+            return null;
+          }
+          let detail = null;
+          try {
+            const payload = await response.json();
+            if (payload && typeof payload.detail === "string") {
+              detail = payload.detail;
+            }
+          } catch (parseError) {
+            // Ignore parse errors and fall back to status text.
+          }
+          const error = new Error(detail || `Request failed with ${response.status}`);
+          error.status = response.status;
+          throw error;
+        }
+        return response;
+      }
+
+      async function resumeMotionAfterManual() {
+        await postRecordingCommand("/api/surveillance/recordings/start-motion");
+        await loadStatus({ showLoading: true, suppressError: true });
+      }
+
       if (recordButton) {
         recordButton.addEventListener("click", async () => {
           const buttons = [recordButton, motionRecordButton].filter(Boolean);
@@ -1056,33 +1089,50 @@
             button.disabled = true;
           });
           try {
-            const stopMode = recordingMode === "continuous";
-            const endpoint = stopMode
-              ? "/api/surveillance/recordings/stop"
-              : "/api/surveillance/recordings/start";
-            const response = await fetch(endpoint, {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-            });
-            if (!response.ok) {
-              throw new Error(`Recording request failed with ${response.status}`);
-            }
-            if (stopMode) {
-              manualRecordingPinned = false;
-              recordingMode = "idle";
-              isRecording = false;
-              stopRecordingTimer();
+            const currentSession = sessionState;
+            const stoppingManual = currentSession === "manual";
+            if (stoppingManual) {
+              await postRecordingCommand("/api/surveillance/recordings/stop", {
+                allowConflict: true,
+              });
             } else {
-              manualRecordingPinned = true;
-              recordingMode = "continuous";
-              isRecording = true;
-              startRecordingTimer(new Date().toISOString());
+              const wasMotionSession =
+                currentSession === "motion-monitoring" || currentSession === "motion-recording";
+              pendingManualResume = wasMotionSession ? "motion" : null;
+              if (wasMotionSession) {
+                await postRecordingCommand("/api/surveillance/recordings/stop", {
+                  allowConflict: true,
+                });
+              }
+              try {
+                await postRecordingCommand("/api/surveillance/recordings/start");
+                applySessionVisuals("manual");
+                startRecordingTimer(new Date().toISOString());
+              } catch (startError) {
+                if (pendingManualResume === "motion") {
+                  pendingManualResume = null;
+                  try {
+                    await postRecordingCommand("/api/surveillance/recordings/start-motion");
+                  } catch (resumeError) {
+                    console.error(
+                      "Failed to restore motion detection after manual start failure",
+                      resumeError,
+                    );
+                  }
+                }
+                throw startError;
+              }
             }
-            updateControlButtons();
-            updateMotionIndicators(lastMotionSnapshot);
           } catch (error) {
-            console.error("Recording control error", error);
-            setStatus("Recording request failed", "error");
+            console.error("Manual recording control error", error);
+            if (!stoppingManual) {
+              pendingManualResume = null;
+            }
+            const message =
+              error && typeof error.message === "string"
+                ? error.message
+                : "Recording request failed";
+            setStatus(message, "error");
             buttons.forEach((button) => {
               button.disabled = false;
             });
@@ -1092,8 +1142,8 @@
             await loadStatus({ showLoading: true });
           } catch (error) {
             console.error("Recording status refresh error", error);
-          } finally {
-            updateControlButtons();
+            applySessionVisuals(sessionState);
+            scheduleStatusRefresh();
           }
         });
       }
@@ -1105,23 +1155,23 @@
             button.disabled = true;
           });
           try {
-            const stopMode = recordingMode === "motion";
-            const endpoint = stopMode
-              ? "/api/surveillance/recordings/stop"
-              : "/api/surveillance/recordings/start-motion";
-            const response = await fetch(endpoint, {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-            });
-            if (!response.ok) {
-              throw new Error(`Recording request failed with ${response.status}`);
-            }
-            if (!stopMode) {
-              manualRecordingPinned = false;
+            const motionActive =
+              sessionState === "motion-monitoring" || sessionState === "motion-recording";
+            if (motionActive) {
+              await postRecordingCommand("/api/surveillance/recordings/stop", {
+                allowConflict: true,
+              });
+            } else {
+              pendingManualResume = null;
+              await postRecordingCommand("/api/surveillance/recordings/start-motion");
             }
           } catch (error) {
-            console.error("Motion recording control error", error);
-            setStatus("Recording request failed", "error");
+            console.error("Motion detection control error", error);
+            const message =
+              error && typeof error.message === "string"
+                ? error.message
+                : "Recording request failed";
+            setStatus(message, "error");
             buttons.forEach((button) => {
               button.disabled = false;
             });
@@ -1130,9 +1180,9 @@
           try {
             await loadStatus({ showLoading: true });
           } catch (error) {
-            console.error("Motion recording status refresh error", error);
-          } finally {
-            updateControlButtons();
+            console.error("Motion detection status refresh error", error);
+            applySessionVisuals(sessionState);
+            scheduleStatusRefresh();
           }
         });
       }

--- a/src/rev_cam/static/surveillance.html
+++ b/src/rev_cam/static/surveillance.html
@@ -942,19 +942,23 @@
             }
           }
           const serverRecording = Boolean(payload && payload.recording);
+          const serverRecordingMode = serverRecording ? nextRecordingMode : "idle";
           if (!serverRecording) {
             nextRecordingMode = "idle";
           } else if (nextRecordingMode === "idle") {
             nextRecordingMode = "continuous";
           }
           if (manualRecordingPinned) {
-            if (!serverRecording || nextRecordingMode === "idle") {
+            const serverManual = serverRecording && serverRecordingMode !== "motion";
+            if (!serverManual) {
               manualRecordingPinned = false;
-            } else {
-              nextRecordingMode = "continuous";
             }
-          } else if (nextRecordingMode === "continuous" && serverRecording) {
+          }
+          if (!manualRecordingPinned && serverRecording && serverRecordingMode !== "motion") {
             manualRecordingPinned = true;
+          }
+          if (manualRecordingPinned) {
+            nextRecordingMode = "continuous";
           }
           recordingMode = nextRecordingMode;
           isRecording = recordingMode !== "idle";

--- a/src/rev_cam/static/surveillance.html
+++ b/src/rev_cam/static/surveillance.html
@@ -941,10 +941,12 @@
               nextRecordingMode = candidate;
             }
           }
-          if (nextRecordingMode === "idle" && payload && payload.recording) {
+          const serverRecording = Boolean(payload && payload.recording);
+          if (!serverRecording) {
+            nextRecordingMode = "idle";
+          } else if (nextRecordingMode === "idle") {
             nextRecordingMode = "continuous";
           }
-          const serverRecording = Boolean(payload && payload.recording);
           if (manualRecordingPinned) {
             if (!serverRecording || nextRecordingMode === "idle") {
               manualRecordingPinned = false;

--- a/src/rev_cam/static/surveillance.html
+++ b/src/rev_cam/static/surveillance.html
@@ -775,6 +775,20 @@
         }
       }
 
+      function isManualProcessingRecord(record) {
+        if (!record || typeof record !== "object") {
+          return false;
+        }
+        const motionInfo = record.motion_detection;
+        if (!motionInfo || typeof motionInfo !== "object") {
+          return false;
+        }
+        if (motionInfo.enabled === false) {
+          return true;
+        }
+        return motionInfo.session_override === true && motionInfo.enabled !== true;
+      }
+
       function createActionButton(label, className) {
         const button = document.createElement("button");
         button.type = "button";
@@ -934,40 +948,52 @@
               return;
             }
           }
-          let nextRecordingMode = "idle";
+          const processingRecord = payload ? payload.processing_recording : null;
+          const isProcessing = Boolean(payload && payload.processing);
+          const motionSnapshot = payload ? payload.motion : null;
+          const serverRecording = Boolean(payload && payload.recording);
+          let serverModeHint = "idle";
           if (payload && typeof payload.recording_mode === "string") {
             const candidate = payload.recording_mode;
             if (candidate === "motion" || candidate === "continuous") {
-              nextRecordingMode = candidate;
+              serverModeHint = candidate;
             }
           }
-          const serverRecording = Boolean(payload && payload.recording);
-          const serverRecordingMode = serverRecording ? nextRecordingMode : "idle";
-          if (!serverRecording) {
-            nextRecordingMode = "idle";
-          } else if (nextRecordingMode === "idle") {
-            nextRecordingMode = "continuous";
+          let serverRecordingMode = serverRecording ? serverModeHint : "idle";
+          if (serverRecordingMode === "idle" && serverRecording) {
+            serverRecordingMode = "continuous";
           }
+          const manualSessionOverride = Boolean(
+            serverRecording &&
+              motionSnapshot &&
+              motionSnapshot.session_override === true &&
+              motionSnapshot.enabled === false,
+          );
+          const manualProcessingActive = Boolean(
+            isProcessing && isManualProcessingRecord(processingRecord),
+          );
+          const manualServerActive =
+            manualSessionOverride ||
+            manualProcessingActive ||
+            (manualRecordingPinned && serverRecording && serverRecordingMode === "continuous");
           if (manualRecordingPinned) {
-            const serverManual = serverRecording && serverRecordingMode !== "motion";
-            if (!serverManual) {
+            if (!manualServerActive) {
               manualRecordingPinned = false;
             }
-          }
-          if (!manualRecordingPinned && serverRecording && serverRecordingMode !== "motion") {
+          } else if (manualServerActive) {
             manualRecordingPinned = true;
           }
-          if (manualRecordingPinned) {
+          let nextRecordingMode = serverRecording ? serverRecordingMode : "idle";
+          if (manualRecordingPinned && serverRecording) {
             nextRecordingMode = "continuous";
           }
           recordingMode = nextRecordingMode;
-          isRecording = recordingMode !== "idle";
+          isRecording = serverRecording;
           updateControlButtons();
           updatePreview(payload ? payload.preview : null);
           renderRecordings(payload && Array.isArray(payload.recordings) ? payload.recordings : []);
           const storage = payload ? payload.storage : null;
           updateStorage(storage);
-          const motionSnapshot = payload ? payload.motion : null;
           lastMotionSnapshot = motionSnapshot;
           updateMotionIndicators(motionSnapshot);
           const startedAtIso =
@@ -975,8 +1001,6 @@
               ? payload.recording_started_at
               : null;
           syncRecordingTimer(startedAtIso, motionSnapshot);
-          const processingRecord = payload ? payload.processing_recording : null;
-          const isProcessing = Boolean(payload && payload.processing);
           const processingError =
             processingRecord &&
             typeof processingRecord.processing_error === "string" &&

--- a/src/rev_cam/static/surveillance.html
+++ b/src/rev_cam/static/surveillance.html
@@ -428,6 +428,9 @@
           <button class="action" type="button" id="record-button" aria-pressed="false">
             Start manual recording
           </button>
+          <button class="action" type="button" id="manual-test-button" aria-pressed="false">
+            Test manual recording
+          </button>
           <button class="action" type="button" id="motion-record-button" aria-pressed="false">
             Start motion detection
           </button>
@@ -465,6 +468,7 @@
       const previewImage = document.getElementById("surveillance-preview");
       const previewMessage = document.getElementById("preview-message");
       const recordButton = document.getElementById("record-button");
+      const manualTestButton = document.getElementById("manual-test-button");
       const motionRecordButton = document.getElementById("motion-record-button");
       const recordingTimer = document.getElementById("recording-timer");
       const recordingTimerValue = recordingTimer
@@ -759,6 +763,14 @@
           recordButton.disabled =
             currentSession === "motion-monitoring" || currentSession === "motion-recording";
           recordButton.classList.toggle("recording-active", manualActive);
+        }
+        if (manualTestButton) {
+          const manualActive = currentSession === "manual";
+          manualTestButton.textContent = manualActive
+            ? "Stop manual test recording"
+            : "Test manual recording";
+          manualTestButton.setAttribute("aria-pressed", String(manualActive));
+          manualTestButton.classList.toggle("recording-active", manualActive);
         }
         if (motionRecordButton) {
           const motionSession =
@@ -1126,6 +1138,83 @@
         return response;
       }
 
+      async function executeManualToggle(options = {}) {
+        const { resumePreviousMotion = true } = options;
+        const currentSession = sessionState;
+        const stoppingManual = currentSession === "manual";
+        try {
+          if (stoppingManual) {
+            await postRecordingCommand("/api/surveillance/recordings/stop", {
+              allowConflict: true,
+            });
+            manualSessionPending = false;
+            manualSessionGraceDeadline = 0;
+            if (!resumePreviousMotion) {
+              pendingManualResume = null;
+            }
+          } else {
+            const wasMotionSession =
+              currentSession === "motion-monitoring" || currentSession === "motion-recording";
+            const shouldResumeMotion = resumePreviousMotion && wasMotionSession;
+            pendingManualResume = shouldResumeMotion ? "motion" : null;
+            if (wasMotionSession) {
+              await postRecordingCommand("/api/surveillance/recordings/stop", {
+                allowConflict: true,
+              });
+            }
+            try {
+              const response = await postRecordingCommand("/api/surveillance/recordings/start");
+              let startIso = null;
+              if (response) {
+                try {
+                  const payload = await response.json();
+                  if (
+                    payload &&
+                    typeof payload === "object" &&
+                    payload.recording &&
+                    typeof payload.recording === "object" &&
+                    typeof payload.recording.started_at === "string"
+                  ) {
+                    startIso = payload.recording.started_at;
+                  }
+                } catch (parseError) {
+                  console.warn("Failed to parse manual start response", parseError);
+                }
+              }
+              const fallbackIso = new Date().toISOString();
+              manualSessionPending = true;
+              manualSessionGraceDeadline = Date.now() + MANUAL_CONFIRMATION_GRACE_MS;
+              applySessionVisuals("manual");
+              startRecordingTimer(startIso || fallbackIso);
+            } catch (startError) {
+              if (pendingManualResume === "motion") {
+                pendingManualResume = null;
+                try {
+                  await postRecordingCommand("/api/surveillance/recordings/start-motion");
+                } catch (resumeError) {
+                  console.error(
+                    "Failed to restore motion detection after manual start failure",
+                    resumeError,
+                  );
+                }
+              }
+              throw startError;
+            }
+          }
+          return { stoppingManual };
+        } catch (error) {
+          if (!stoppingManual) {
+            pendingManualResume = null;
+            manualSessionPending = false;
+            manualSessionGraceDeadline = 0;
+          }
+          const failure =
+            error instanceof Error ? error : new Error("Recording request failed");
+          failure.stoppingManual = stoppingManual;
+          throw failure;
+        }
+      }
+
       async function resumeMotionAfterManual() {
         await postRecordingCommand("/api/surveillance/recordings/start-motion");
         await loadStatus({ showLoading: true, suppressError: true });
@@ -1133,74 +1222,14 @@
 
       if (recordButton) {
         recordButton.addEventListener("click", async () => {
-          const buttons = [recordButton, motionRecordButton].filter(Boolean);
+          const buttons = [recordButton, manualTestButton, motionRecordButton].filter(Boolean);
           buttons.forEach((button) => {
             button.disabled = true;
           });
           try {
-            const currentSession = sessionState;
-            const stoppingManual = currentSession === "manual";
-            if (stoppingManual) {
-              await postRecordingCommand("/api/surveillance/recordings/stop", {
-                allowConflict: true,
-              });
-              manualSessionPending = false;
-              manualSessionGraceDeadline = 0;
-            } else {
-              const wasMotionSession =
-                currentSession === "motion-monitoring" || currentSession === "motion-recording";
-              pendingManualResume = wasMotionSession ? "motion" : null;
-              if (wasMotionSession) {
-                await postRecordingCommand("/api/surveillance/recordings/stop", {
-                  allowConflict: true,
-                });
-              }
-              try {
-                const response = await postRecordingCommand("/api/surveillance/recordings/start");
-                let startIso = null;
-                if (response) {
-                  try {
-                    const payload = await response.json();
-                    if (
-                      payload &&
-                      typeof payload === "object" &&
-                      payload.recording &&
-                      typeof payload.recording === "object" &&
-                      typeof payload.recording.started_at === "string"
-                    ) {
-                      startIso = payload.recording.started_at;
-                    }
-                  } catch (parseError) {
-                    console.warn("Failed to parse manual start response", parseError);
-                  }
-                }
-                const fallbackIso = new Date().toISOString();
-                manualSessionPending = true;
-                manualSessionGraceDeadline = Date.now() + MANUAL_CONFIRMATION_GRACE_MS;
-                applySessionVisuals("manual");
-                startRecordingTimer(startIso || fallbackIso);
-              } catch (startError) {
-                if (pendingManualResume === "motion") {
-                  pendingManualResume = null;
-                  try {
-                    await postRecordingCommand("/api/surveillance/recordings/start-motion");
-                  } catch (resumeError) {
-                    console.error(
-                      "Failed to restore motion detection after manual start failure",
-                      resumeError,
-                    );
-                  }
-                }
-                throw startError;
-              }
-            }
+            await executeManualToggle({ resumePreviousMotion: true });
           } catch (error) {
             console.error("Manual recording control error", error);
-            if (!stoppingManual) {
-              pendingManualResume = null;
-              manualSessionPending = false;
-              manualSessionGraceDeadline = 0;
-            }
             const message =
               error && typeof error.message === "string"
                 ? error.message
@@ -1217,13 +1246,51 @@
             console.error("Recording status refresh error", error);
             applySessionVisuals(sessionState);
             scheduleStatusRefresh();
+          } finally {
+            buttons.forEach((button) => {
+              button.disabled = false;
+            });
+          }
+        });
+      }
+
+      if (manualTestButton) {
+        manualTestButton.addEventListener("click", async () => {
+          const buttons = [recordButton, manualTestButton, motionRecordButton].filter(Boolean);
+          buttons.forEach((button) => {
+            button.disabled = true;
+          });
+          try {
+            await executeManualToggle({ resumePreviousMotion: false });
+          } catch (error) {
+            console.error("Manual test control error", error);
+            const message =
+              error && typeof error.message === "string"
+                ? error.message
+                : "Recording request failed";
+            setStatus(message, "error");
+            buttons.forEach((button) => {
+              button.disabled = false;
+            });
+            return;
+          }
+          try {
+            await loadStatus({ showLoading: true });
+          } catch (error) {
+            console.error("Recording status refresh error", error);
+            applySessionVisuals(sessionState);
+            scheduleStatusRefresh();
+          } finally {
+            buttons.forEach((button) => {
+              button.disabled = false;
+            });
           }
         });
       }
 
       if (motionRecordButton) {
         motionRecordButton.addEventListener("click", async () => {
-          const buttons = [recordButton, motionRecordButton].filter(Boolean);
+          const buttons = [recordButton, manualTestButton, motionRecordButton].filter(Boolean);
           buttons.forEach((button) => {
             button.disabled = true;
           });
@@ -1256,6 +1323,10 @@
             console.error("Motion detection status refresh error", error);
             applySessionVisuals(sessionState);
             scheduleStatusRefresh();
+          } finally {
+            buttons.forEach((button) => {
+              button.disabled = false;
+            });
           }
         });
       }

--- a/src/rev_cam/static/surveillance.html
+++ b/src/rev_cam/static/surveillance.html
@@ -687,8 +687,32 @@
         return sessionRecording || eventActive;
       }
 
+      function isManualOverrideActive(serverRecording, serverMode, motionSnapshot) {
+        if (!serverRecording) {
+          return false;
+        }
+        if (serverMode === "continuous") {
+          return true;
+        }
+        if (!motionSnapshot || typeof motionSnapshot !== "object") {
+          return serverMode !== "motion";
+        }
+        if (motionSnapshot.session_override === true && motionSnapshot.enabled !== true) {
+          return true;
+        }
+        if (motionSnapshot.enabled === false) {
+          return true;
+        }
+        const sessionActive = motionSnapshot.session_active === true;
+        const sessionState = motionSnapshot.session_state;
+        if (!sessionActive && (sessionState === null || sessionState === undefined)) {
+          return true;
+        }
+        return false;
+      }
+
       function determineSessionState(serverRecording, serverMode, motionSnapshot) {
-        if (serverRecording && serverMode === "continuous") {
+        if (isManualOverrideActive(serverRecording, serverMode, motionSnapshot)) {
           return "manual";
         }
         if (serverRecording && serverMode === "motion") {

--- a/src/rev_cam/static/surveillance.html
+++ b/src/rev_cam/static/surveillance.html
@@ -485,8 +485,11 @@
       let recordingTimerStartMs = null;
       let recordingTimerInterval = null;
       let recordingTimerSource = null;
+      let manualSessionPending = false;
+      let manualSessionGraceDeadline = 0;
       const STATUS_REFRESH_ACTIVE_MS = 2000;
       const STATUS_REFRESH_IDLE_MS = 5000;
+      const MANUAL_CONFIRMATION_GRACE_MS = 5000;
       let statusRefreshHandle = null;
       let statusRequestSequence = 0;
       let latestAppliedStatusSequence = 0;
@@ -590,6 +593,12 @@
         const shouldRun =
           hasStart && (currentSession === "manual" || currentSession === "motion-recording");
         if (!shouldRun) {
+          const localManualActive =
+            currentSession === "manual" && recordingTimerStartMs !== null;
+          if (localManualActive) {
+            renderRecordingTimer();
+            return;
+          }
           stopRecordingTimer();
           return;
         }
@@ -989,7 +998,20 @@
             motionSnapshot,
           );
           const previousSession = sessionState;
-          applySessionVisuals(derivedSession, {
+          let effectiveSession = derivedSession;
+          if (manualSessionPending) {
+            const now = Date.now();
+            if (derivedSession === "manual") {
+              manualSessionPending = false;
+              manualSessionGraceDeadline = 0;
+            } else if (now < manualSessionGraceDeadline) {
+              effectiveSession = "manual";
+            } else {
+              manualSessionPending = false;
+              manualSessionGraceDeadline = 0;
+            }
+          }
+          applySessionVisuals(effectiveSession, {
             processingActive: isProcessing,
             processingRecord,
           });
@@ -1018,10 +1040,13 @@
           ) {
             setStatus("Low storage — recordings will pause automatically", "error");
           }
-          if (previousSession === "manual" && sessionState !== "manual") {
+          const manualSessionConcluded =
+            previousSession === "manual" && sessionState !== "manual" && !manualSessionPending;
+          if (manualSessionConcluded) {
             const resumeTarget = pendingManualResume;
             pendingManualResume = null;
-            if (resumeTarget === "motion") {
+            const canResumeMotion = resumeTarget === "motion" && !serverRecording;
+            if (canResumeMotion) {
               window.setTimeout(() => {
                 resumeMotionAfterManual().catch((error) => {
                   console.error("Failed to resume motion detection", error);
@@ -1032,7 +1057,7 @@
                 });
               }, 0);
             }
-          } else if (sessionState !== "manual") {
+          } else if (sessionState !== "manual" && !manualSessionPending) {
             pendingManualResume = null;
           }
           scheduleStatusRefresh();
@@ -1095,6 +1120,8 @@
               await postRecordingCommand("/api/surveillance/recordings/stop", {
                 allowConflict: true,
               });
+              manualSessionPending = false;
+              manualSessionGraceDeadline = 0;
             } else {
               const wasMotionSession =
                 currentSession === "motion-monitoring" || currentSession === "motion-recording";
@@ -1105,9 +1132,29 @@
                 });
               }
               try {
-                await postRecordingCommand("/api/surveillance/recordings/start");
+                const response = await postRecordingCommand("/api/surveillance/recordings/start");
+                let startIso = null;
+                if (response) {
+                  try {
+                    const payload = await response.json();
+                    if (
+                      payload &&
+                      typeof payload === "object" &&
+                      payload.recording &&
+                      typeof payload.recording === "object" &&
+                      typeof payload.recording.started_at === "string"
+                    ) {
+                      startIso = payload.recording.started_at;
+                    }
+                  } catch (parseError) {
+                    console.warn("Failed to parse manual start response", parseError);
+                  }
+                }
+                const fallbackIso = new Date().toISOString();
+                manualSessionPending = true;
+                manualSessionGraceDeadline = Date.now() + MANUAL_CONFIRMATION_GRACE_MS;
                 applySessionVisuals("manual");
-                startRecordingTimer(new Date().toISOString());
+                startRecordingTimer(startIso || fallbackIso);
               } catch (startError) {
                 if (pendingManualResume === "motion") {
                   pendingManualResume = null;
@@ -1127,6 +1174,8 @@
             console.error("Manual recording control error", error);
             if (!stoppingManual) {
               pendingManualResume = null;
+              manualSessionPending = false;
+              manualSessionGraceDeadline = 0;
             }
             const message =
               error && typeof error.message === "string"

--- a/src/rev_cam/static/surveillance.html
+++ b/src/rev_cam/static/surveillance.html
@@ -428,9 +428,6 @@
           <button class="action" type="button" id="record-button" aria-pressed="false">
             Start manual recording
           </button>
-          <button class="action" type="button" id="manual-test-button" aria-pressed="false">
-            Test manual recording
-          </button>
           <button class="action" type="button" id="motion-record-button" aria-pressed="false">
             Start motion detection
           </button>
@@ -468,7 +465,6 @@
       const previewImage = document.getElementById("surveillance-preview");
       const previewMessage = document.getElementById("preview-message");
       const recordButton = document.getElementById("record-button");
-      const manualTestButton = document.getElementById("manual-test-button");
       const motionRecordButton = document.getElementById("motion-record-button");
       const recordingTimer = document.getElementById("recording-timer");
       const recordingTimerValue = recordingTimer
@@ -491,6 +487,7 @@
       let recordingTimerSource = null;
       let manualSessionPending = false;
       let manualSessionGraceDeadline = 0;
+      let lastStatusSnapshot = null;
       const STATUS_REFRESH_ACTIVE_MS = 2000;
       const STATUS_REFRESH_IDLE_MS = 5000;
       const MANUAL_CONFIRMATION_GRACE_MS = 5000;
@@ -764,14 +761,6 @@
             currentSession === "motion-monitoring" || currentSession === "motion-recording";
           recordButton.classList.toggle("recording-active", manualActive);
         }
-        if (manualTestButton) {
-          const manualActive = currentSession === "manual";
-          manualTestButton.textContent = manualActive
-            ? "Stop manual test recording"
-            : "Test manual recording";
-          manualTestButton.setAttribute("aria-pressed", String(manualActive));
-          manualTestButton.classList.toggle("recording-active", manualActive);
-        }
         if (motionRecordButton) {
           const motionSession =
             currentSession === "motion-monitoring" || currentSession === "motion-recording";
@@ -799,6 +788,34 @@
           }
         }
         updateStatusForSession(currentSession, { processingActive, processingRecord });
+      }
+
+      function isManualSessionActive() {
+        if (sessionState === "manual" || manualSessionPending) {
+          return true;
+        }
+        const payload = lastStatusSnapshot;
+        if (!payload || typeof payload !== "object") {
+          return false;
+        }
+        if (payload.recording !== true) {
+          return false;
+        }
+        const mode = typeof payload.recording_mode === "string" ? payload.recording_mode : null;
+        if (mode === "continuous") {
+          return true;
+        }
+        const motionInfo = payload.motion;
+        if (!motionInfo || typeof motionInfo !== "object") {
+          return false;
+        }
+        if (motionInfo.session_override === true && motionInfo.enabled !== true) {
+          return true;
+        }
+        if (motionInfo.enabled === false) {
+          return true;
+        }
+        return false;
       }
 
       function formatBytes(bytes) {
@@ -1021,6 +1038,7 @@
           const isProcessing = Boolean(payload && payload.processing);
           const motionSnapshot = payload ? payload.motion : null;
           const serverRecording = Boolean(payload && payload.recording);
+          lastStatusSnapshot = payload && typeof payload === "object" ? payload : null;
           let serverModeHint = "idle";
           if (payload && typeof payload.recording_mode === "string") {
             const candidate = payload.recording_mode;
@@ -1040,7 +1058,7 @@
             if (derivedSession === "manual") {
               manualSessionPending = false;
               manualSessionGraceDeadline = 0;
-            } else if (now < manualSessionGraceDeadline) {
+            } else if (serverRecording || now < manualSessionGraceDeadline) {
               effectiveSession = "manual";
             } else {
               manualSessionPending = false;
@@ -1077,7 +1095,10 @@
             setStatus("Low storage — recordings will pause automatically", "error");
           }
           const manualSessionConcluded =
-            previousSession === "manual" && sessionState !== "manual" && !manualSessionPending;
+            previousSession === "manual" &&
+            sessionState !== "manual" &&
+            !manualSessionPending &&
+            !serverRecording;
           if (manualSessionConcluded) {
             const resumeTarget = pendingManualResume;
             pendingManualResume = null;
@@ -1141,7 +1162,8 @@
       async function executeManualToggle(options = {}) {
         const { resumePreviousMotion = true } = options;
         const currentSession = sessionState;
-        const stoppingManual = currentSession === "manual";
+        const manualActive = isManualSessionActive();
+        const stoppingManual = manualActive;
         try {
           if (stoppingManual) {
             await postRecordingCommand("/api/surveillance/recordings/stop", {
@@ -1222,7 +1244,7 @@
 
       if (recordButton) {
         recordButton.addEventListener("click", async () => {
-          const buttons = [recordButton, manualTestButton, motionRecordButton].filter(Boolean);
+          const buttons = [recordButton, motionRecordButton].filter(Boolean);
           buttons.forEach((button) => {
             button.disabled = true;
           });
@@ -1254,43 +1276,9 @@
         });
       }
 
-      if (manualTestButton) {
-        manualTestButton.addEventListener("click", async () => {
-          const buttons = [recordButton, manualTestButton, motionRecordButton].filter(Boolean);
-          buttons.forEach((button) => {
-            button.disabled = true;
-          });
-          try {
-            await executeManualToggle({ resumePreviousMotion: false });
-          } catch (error) {
-            console.error("Manual test control error", error);
-            const message =
-              error && typeof error.message === "string"
-                ? error.message
-                : "Recording request failed";
-            setStatus(message, "error");
-            buttons.forEach((button) => {
-              button.disabled = false;
-            });
-            return;
-          }
-          try {
-            await loadStatus({ showLoading: true });
-          } catch (error) {
-            console.error("Recording status refresh error", error);
-            applySessionVisuals(sessionState);
-            scheduleStatusRefresh();
-          } finally {
-            buttons.forEach((button) => {
-              button.disabled = false;
-            });
-          }
-        });
-      }
-
       if (motionRecordButton) {
         motionRecordButton.addEventListener("click", async () => {
-          const buttons = [recordButton, manualTestButton, motionRecordButton].filter(Boolean);
+          const buttons = [recordButton, motionRecordButton].filter(Boolean);
           buttons.forEach((button) => {
             button.disabled = true;
           });


### PR DESCRIPTION
## Summary
- ensure the surveillance status parser treats an inactive manual recording as idle even if the mode hint remains continuous
- keep the UI buttons and timer in sync with the server once a manual recording has finished processing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e11f72ece4833286cc15507d38d1eb