### PR TITLE
Add scrubbing slider and time indicators to surveillance playback

### DIFF
--- a/src/rev_cam/static/surveillance_player.html
+++ b/src/rev_cam/static/surveillance_player.html
@@ -70,6 +70,34 @@
         font-size: 0.85rem;
         color: var(--text-muted);
       }
+      .playback-controls {
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+        padding-inline: 0.4rem;
+      }
+      .playback-controls[hidden] {
+        display: none;
+      }
+      .time-display {
+        display: flex;
+        justify-content: space-between;
+        font-size: 0.9rem;
+        color: var(--text-muted);
+        gap: 0.5rem;
+      }
+      .time-display span {
+        white-space: nowrap;
+      }
+      input[type="range"] {
+        width: 100%;
+        accent-color: var(--accent);
+        cursor: pointer;
+      }
+      input[type="range"]:disabled {
+        cursor: not-allowed;
+        opacity: 0.5;
+      }
       .error {
         color: var(--danger);
         font-weight: 600;
@@ -93,6 +121,21 @@
         <p class="muted" id="status-text">Preparing playback…</p>
       </header>
       <img id="playback-frame" class="playback-frame" alt="Recording playback" hidden />
+      <div class="playback-controls" id="playback-controls" hidden>
+        <div class="time-display" aria-live="polite">
+          <span id="current-time" aria-label="Current position">Current 0:00</span>
+          <span id="total-time" aria-label="Clip length">Length 0:00</span>
+        </div>
+        <input
+          id="playback-slider"
+          type="range"
+          min="0"
+          max="0"
+          value="0"
+          step="1"
+          aria-label="Scrub through recording"
+        />
+      </div>
       <p class="muted">
         <a class="link" href="/surveillance">Back to surveillance</a>
       </p>
@@ -105,7 +148,21 @@
       const chunkSummary = document.getElementById("chunk-summary");
       const statusText = document.getElementById("status-text");
       const playbackFrame = document.getElementById("playback-frame");
-      let playbackTimer = null;
+      const playbackControls = document.getElementById("playback-controls");
+      const playbackSlider = document.getElementById("playback-slider");
+      const currentTimeLabel = document.getElementById("current-time");
+      const totalTimeLabel = document.getElementById("total-time");
+
+      const playbackState = {
+        frames: [],
+        intervals: [],
+        frameTimes: [],
+        fallbackInterval: 200,
+        index: 0,
+        timer: null,
+        isScrubbing: false,
+        totalDuration: 0,
+      };
 
       function setStatus(message, tone = "info") {
         if (tone === "error") {
@@ -129,6 +186,152 @@
         }
         const display = value >= 10 || index === 0 ? value.toFixed(0) : value.toFixed(1);
         return `${display.replace(/\.0$/, "")} ${units[index]}`;
+      }
+
+      function formatTime(seconds) {
+        if (typeof seconds !== "number" || !Number.isFinite(seconds) || seconds < 0) {
+          return "0:00";
+        }
+        const totalSeconds = Math.floor(seconds);
+        const hours = Math.floor(totalSeconds / 3600);
+        const minutes = Math.floor((totalSeconds % 3600) / 60);
+        const secs = totalSeconds % 60;
+        const pad = (value) => value.toString().padStart(2, "0");
+        if (hours > 0) {
+          return `${hours}:${pad(minutes)}:${pad(secs)}`;
+        }
+        return `${minutes}:${pad(secs)}`;
+      }
+
+      function stopPlaybackTimer() {
+        if (playbackState.timer) {
+          window.clearTimeout(playbackState.timer);
+          playbackState.timer = null;
+        }
+      }
+
+      function updateTimeDisplay(index) {
+        if (currentTimeLabel) {
+          const seconds = playbackState.frameTimes[index] ?? 0;
+          currentTimeLabel.textContent = `Current ${formatTime(seconds)}`;
+        }
+        if (totalTimeLabel) {
+          totalTimeLabel.textContent = `Length ${formatTime(playbackState.totalDuration)}`;
+        }
+      }
+
+      function showFrame(index, { updateSlider = true } = {}) {
+        if (!playbackFrame || !playbackState.frames.length) {
+          return;
+        }
+        const normalizedIndex = Math.max(0, Math.min(index, playbackState.frames.length - 1));
+        const frame = playbackState.frames[normalizedIndex];
+        if (!frame || typeof frame.jpeg !== "string") {
+          return;
+        }
+        playbackState.index = normalizedIndex;
+        playbackFrame.src = `data:image/jpeg;base64,${frame.jpeg}`;
+        if (
+          playbackSlider &&
+          updateSlider &&
+          !playbackState.isScrubbing &&
+          Number.isFinite(normalizedIndex)
+        ) {
+          playbackSlider.value = String(normalizedIndex);
+        }
+        updateTimeDisplay(normalizedIndex);
+      }
+
+      function scheduleNextFrame() {
+        stopPlaybackTimer();
+        if (playbackState.isScrubbing || playbackState.frames.length <= 1) {
+          return;
+        }
+        const currentIndex = playbackState.index;
+        const delay = playbackState.intervals[currentIndex] ?? playbackState.fallbackInterval;
+        playbackState.timer = window.setTimeout(() => {
+          if (playbackState.isScrubbing || !playbackState.frames.length) {
+            scheduleNextFrame();
+            return;
+          }
+          const nextIndex = (playbackState.index + 1) % playbackState.frames.length;
+          showFrame(nextIndex);
+          scheduleNextFrame();
+        }, delay);
+      }
+
+      function prepareControls(playable, frameTimes, intervals, fallbackInterval, cycleDurationMs) {
+        playbackState.frames = playable;
+        playbackState.frameTimes = frameTimes;
+        playbackState.fallbackInterval = fallbackInterval;
+        if (Array.isArray(intervals) && intervals.length === playable.length) {
+          playbackState.intervals = [...intervals];
+        } else {
+          playbackState.intervals = new Array(playable.length).fill(fallbackInterval);
+        }
+        const lastTime = frameTimes[frameTimes.length - 1];
+        const derivedTotal = Number.isFinite(lastTime) ? lastTime : 0;
+        const cycleSeconds = Number.isFinite(cycleDurationMs)
+          ? Math.max(0, cycleDurationMs / 1000)
+          : 0;
+        playbackState.totalDuration = derivedTotal > 0 ? derivedTotal : cycleSeconds;
+        playbackState.index = 0;
+        playbackState.isScrubbing = false;
+        stopPlaybackTimer();
+
+        if (playbackControls) {
+          playbackControls.hidden = false;
+        }
+        if (playbackSlider) {
+          playbackSlider.max = String(Math.max(playable.length - 1, 0));
+          playbackSlider.value = "0";
+          playbackSlider.disabled = playable.length <= 1;
+        }
+        updateTimeDisplay(0);
+      }
+
+      function setupSliderEvents() {
+        if (!playbackSlider) {
+          return;
+        }
+        if (playbackSlider.dataset.enhanced === "true") {
+          return;
+        }
+        const beginScrub = () => {
+          playbackState.isScrubbing = true;
+          stopPlaybackTimer();
+        };
+        const endScrub = () => {
+          if (!playbackState.frames.length) {
+            return;
+          }
+          playbackState.isScrubbing = false;
+          scheduleNextFrame();
+        };
+        playbackSlider.addEventListener("input", (event) => {
+          if (!playbackState.frames.length) {
+            return;
+          }
+          beginScrub();
+          const target = event.target;
+          const value = Number(target && typeof target.value === "string" ? target.value : playbackSlider.value);
+          if (Number.isFinite(value)) {
+            showFrame(Math.round(value), { updateSlider: false });
+          }
+        });
+        playbackSlider.addEventListener("change", endScrub);
+        playbackSlider.addEventListener("pointerdown", beginScrub);
+        playbackSlider.addEventListener("pointerup", endScrub);
+        playbackSlider.addEventListener("mousedown", beginScrub);
+        playbackSlider.addEventListener("mouseup", endScrub);
+        playbackSlider.addEventListener("touchstart", beginScrub, { passive: true });
+        playbackSlider.addEventListener("touchend", endScrub, { passive: true });
+        playbackSlider.addEventListener("blur", () => {
+          if (playbackState.isScrubbing) {
+            endScrub();
+          }
+        });
+        playbackSlider.dataset.enhanced = "true";
       }
 
       function renderMeta(data) {
@@ -267,18 +470,32 @@
           return delay;
         });
 
-        let index = 0;
+        const frameTimes = [];
+        for (let idx = 0; idx < playable.length; idx += 1) {
+          if (idx === 0) {
+            frameTimes.push(0);
+            continue;
+          }
+          const currentTs = playable[idx].timestamp;
+          if (
+            currentTs !== null &&
+            Number.isFinite(currentTs) &&
+            firstTimestamp !== null &&
+            Number.isFinite(firstTimestamp)
+          ) {
+            frameTimes.push(Math.max(0, currentTs - firstTimestamp));
+            continue;
+          }
+          const priorTime = frameTimes[idx - 1] ?? 0;
+          const interval = intervals[idx - 1] ?? fallbackInterval;
+          frameTimes.push(priorTime + interval / 1000);
+        }
+
         playbackFrame.hidden = false;
-
-        const advance = () => {
-          const frame = playable[index];
-          playbackFrame.src = `data:image/jpeg;base64,${frame.jpeg}`;
-          const delay = intervals[index] ?? fallbackInterval;
-          index = (index + 1) % playable.length;
-          playbackTimer = window.setTimeout(advance, delay);
-        };
-
-        advance();
+        setupSliderEvents();
+        prepareControls(playable, frameTimes, intervals, fallbackInterval, cycleDurationMs);
+        showFrame(0);
+        scheduleNextFrame();
       }
 
       async function loadRecording() {
@@ -309,9 +526,7 @@
       }
 
       window.addEventListener("beforeunload", () => {
-        if (playbackTimer) {
-          window.clearTimeout(playbackTimer);
-        }
+        stopPlaybackTimer();
       });
 
       loadRecording();

--- a/src/rev_cam/static/surveillance_player.html
+++ b/src/rev_cam/static/surveillance_player.html
@@ -73,7 +73,7 @@
       .playback-controls {
         display: flex;
         flex-direction: column;
-        gap: 0.35rem;
+        gap: 0.75rem;
         padding-inline: 0.4rem;
       }
       .playback-controls[hidden] {
@@ -97,6 +97,88 @@
       input[type="range"]:disabled {
         cursor: not-allowed;
         opacity: 0.5;
+      }
+      .transport {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+      }
+      .transport-buttons {
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
+        justify-content: center;
+        flex-wrap: wrap;
+      }
+      .transport-buttons button {
+        min-width: 3rem;
+      }
+      .playback-options {
+        display: flex;
+        gap: 0.75rem;
+        justify-content: center;
+        flex-wrap: wrap;
+        align-items: center;
+        color: var(--text-muted);
+        font-size: 0.85rem;
+      }
+      .playback-options label {
+        display: flex;
+        gap: 0.35rem;
+        align-items: center;
+      }
+      button,
+      select {
+        font: inherit;
+      }
+      button {
+        border: 1px solid var(--border-subtle);
+        background: rgba(255, 255, 255, 0.04);
+        color: var(--text-primary);
+        padding: 0.45rem 0.8rem;
+        border-radius: 999px;
+        cursor: pointer;
+        transition: background 0.15s ease, border-color 0.15s ease;
+      }
+      button:hover,
+      button:focus-visible {
+        background: rgba(10, 132, 255, 0.18);
+        border-color: rgba(10, 132, 255, 0.55);
+        outline: none;
+      }
+      button:disabled {
+        cursor: not-allowed;
+        opacity: 0.5;
+      }
+      select {
+        border-radius: 999px;
+        border: 1px solid var(--border-subtle);
+        background: rgba(255, 255, 255, 0.03);
+        color: var(--text-primary);
+        padding: 0.35rem 0.75rem;
+      }
+      select:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+      }
+      .sr-only {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+      }
+      .play-pause-button[aria-pressed="true"] {
+        background: rgba(10, 132, 255, 0.25);
+        border-color: rgba(10, 132, 255, 0.7);
+      }
+      .loop-button[aria-pressed="true"] {
+        background: rgba(10, 132, 255, 0.2);
+        border-color: rgba(10, 132, 255, 0.6);
       }
       .error {
         color: var(--danger);
@@ -135,6 +217,53 @@
           step="1"
           aria-label="Scrub through recording"
         />
+        <div class="transport" role="group" aria-label="Playback controls">
+          <div class="transport-buttons">
+            <button type="button" id="jump-start" aria-label="Go to start">
+              ⏮
+            </button>
+            <button type="button" id="frame-back" aria-label="Step back one frame">
+              ⏪
+            </button>
+            <button
+              type="button"
+              id="play-pause"
+              class="play-pause-button"
+              aria-pressed="false"
+              aria-label="Play or pause recording"
+            >
+              Play
+            </button>
+            <button type="button" id="frame-forward" aria-label="Step forward one frame">
+              ⏩
+            </button>
+            <button type="button" id="jump-end" aria-label="Go to end">
+              ⏭
+            </button>
+          </div>
+          <div class="playback-options">
+            <label for="playback-rate">
+              Speed
+              <select id="playback-rate" aria-label="Playback speed">
+                <option value="0.25">0.25×</option>
+                <option value="0.5">0.5×</option>
+                <option value="0.75">0.75×</option>
+                <option value="1" selected>1×</option>
+                <option value="1.5">1.5×</option>
+                <option value="2">2×</option>
+              </select>
+            </label>
+            <button
+              type="button"
+              id="loop-toggle"
+              class="loop-button"
+              aria-pressed="false"
+              aria-label="Toggle looping playback"
+            >
+              Loop off
+            </button>
+          </div>
+        </div>
       </div>
       <p class="muted">
         <a class="link" href="/surveillance">Back to surveillance</a>
@@ -152,6 +281,13 @@
       const playbackSlider = document.getElementById("playback-slider");
       const currentTimeLabel = document.getElementById("current-time");
       const totalTimeLabel = document.getElementById("total-time");
+      const playPauseButton = document.getElementById("play-pause");
+      const frameBackButton = document.getElementById("frame-back");
+      const frameForwardButton = document.getElementById("frame-forward");
+      const jumpStartButton = document.getElementById("jump-start");
+      const jumpEndButton = document.getElementById("jump-end");
+      const loopToggleButton = document.getElementById("loop-toggle");
+      const playbackRateSelect = document.getElementById("playback-rate");
 
       const playbackState = {
         frames: [],
@@ -162,6 +298,9 @@
         timer: null,
         isScrubbing: false,
         totalDuration: 0,
+        isPlaying: false,
+        isLooping: false,
+        playbackRate: 1,
       };
 
       function setStatus(message, tone = "info") {
@@ -220,6 +359,53 @@
         }
       }
 
+      function updateTransportState() {
+        const { frames, index, isPlaying, isLooping } = playbackState;
+        const multiFrame = frames.length > 1;
+        const lastIndex = Math.max(0, frames.length - 1);
+
+        if (playPauseButton) {
+          playPauseButton.disabled = !multiFrame;
+          playPauseButton.textContent = isPlaying ? "Pause" : "Play";
+          playPauseButton.setAttribute("aria-pressed", isPlaying ? "true" : "false");
+          playPauseButton.setAttribute(
+            "aria-label",
+            isPlaying ? "Pause recording" : "Play recording",
+          );
+        }
+        if (frameBackButton) {
+          frameBackButton.disabled = !multiFrame || index <= 0;
+        }
+        if (frameForwardButton) {
+          frameForwardButton.disabled = !multiFrame || index >= lastIndex;
+        }
+        if (jumpStartButton) {
+          jumpStartButton.disabled = !multiFrame || index <= 0;
+        }
+        if (jumpEndButton) {
+          jumpEndButton.disabled = !multiFrame || index >= lastIndex;
+        }
+        if (loopToggleButton) {
+          loopToggleButton.disabled = !multiFrame;
+          loopToggleButton.textContent = isLooping ? "Loop on" : "Loop off";
+          loopToggleButton.setAttribute("aria-pressed", isLooping ? "true" : "false");
+        }
+        if (playbackRateSelect) {
+          playbackRateSelect.disabled = !multiFrame;
+        }
+      }
+
+      function getFrameDelay(index) {
+        const baseInterval = playbackState.intervals[index] ?? playbackState.fallbackInterval;
+        const rate = playbackState.playbackRate > 0 ? playbackState.playbackRate : 1;
+        const scaled = baseInterval / rate;
+        const minimum = 16;
+        if (!Number.isFinite(scaled) || scaled <= 0) {
+          return Math.max(minimum, playbackState.fallbackInterval);
+        }
+        return Math.max(minimum, Math.round(scaled));
+      }
+
       function showFrame(index, { updateSlider = true } = {}) {
         if (!playbackFrame || !playbackState.frames.length) {
           return;
@@ -240,24 +426,134 @@
           playbackSlider.value = String(normalizedIndex);
         }
         updateTimeDisplay(normalizedIndex);
+        updateTransportState();
       }
 
       function scheduleNextFrame() {
         stopPlaybackTimer();
-        if (playbackState.isScrubbing || playbackState.frames.length <= 1) {
+        if (
+          !playbackState.isPlaying ||
+          playbackState.isScrubbing ||
+          playbackState.frames.length <= 1
+        ) {
           return;
         }
         const currentIndex = playbackState.index;
-        const delay = playbackState.intervals[currentIndex] ?? playbackState.fallbackInterval;
+        const delay = getFrameDelay(currentIndex);
         playbackState.timer = window.setTimeout(() => {
-          if (playbackState.isScrubbing || !playbackState.frames.length) {
-            scheduleNextFrame();
+          playbackState.timer = null;
+          if (
+            !playbackState.isPlaying ||
+            playbackState.isScrubbing ||
+            !playbackState.frames.length
+          ) {
             return;
           }
-          const nextIndex = (playbackState.index + 1) % playbackState.frames.length;
+          let nextIndex = playbackState.index + 1;
+          if (nextIndex >= playbackState.frames.length) {
+            if (playbackState.isLooping && playbackState.frames.length) {
+              nextIndex = 0;
+              showFrame(nextIndex);
+              scheduleNextFrame();
+            } else {
+              playbackState.isPlaying = false;
+              updateTransportState();
+            }
+            return;
+          }
           showFrame(nextIndex);
           scheduleNextFrame();
         }, delay);
+      }
+
+      function pausePlayback() {
+        if (!playbackState.frames.length) {
+          return;
+        }
+        playbackState.isPlaying = false;
+        stopPlaybackTimer();
+        updateTransportState();
+      }
+
+      function startPlayback({ restart = false } = {}) {
+        if (!playbackState.frames.length) {
+          return;
+        }
+        if (playbackState.frames.length <= 1) {
+          playbackState.isPlaying = false;
+          updateTransportState();
+          return;
+        }
+        if (
+          restart ||
+          (playbackState.index >= playbackState.frames.length - 1 && !playbackState.isLooping)
+        ) {
+          showFrame(0);
+        }
+        playbackState.isPlaying = true;
+        updateTransportState();
+        scheduleNextFrame();
+      }
+
+      function togglePlayback() {
+        if (playbackState.isPlaying) {
+          pausePlayback();
+        } else {
+          startPlayback();
+        }
+      }
+
+      function stepFrame(step) {
+        if (!playbackState.frames.length || !Number.isFinite(step)) {
+          return;
+        }
+        const target = Math.max(
+          0,
+          Math.min(playbackState.index + Math.trunc(step), playbackState.frames.length - 1),
+        );
+        pausePlayback();
+        showFrame(target);
+      }
+
+      function jumpToStart() {
+        if (!playbackState.frames.length) {
+          return;
+        }
+        showFrame(0);
+        if (playbackState.isPlaying) {
+          scheduleNextFrame();
+        }
+      }
+
+      function jumpToEnd() {
+        if (!playbackState.frames.length) {
+          return;
+        }
+        const lastIndex = playbackState.frames.length - 1;
+        showFrame(lastIndex);
+        pausePlayback();
+      }
+
+      function toggleLooping() {
+        if (!playbackState.frames.length) {
+          return;
+        }
+        playbackState.isLooping = !playbackState.isLooping;
+        updateTransportState();
+        if (playbackState.isPlaying) {
+          scheduleNextFrame();
+        }
+      }
+
+      function setPlaybackRate(rate) {
+        if (!Number.isFinite(rate) || rate <= 0) {
+          return;
+        }
+        playbackState.playbackRate = rate;
+        updateTransportState();
+        if (playbackState.isPlaying) {
+          scheduleNextFrame();
+        }
       }
 
       function prepareControls(playable, frameTimes, intervals, fallbackInterval, cycleDurationMs) {
@@ -277,6 +573,9 @@
         playbackState.totalDuration = derivedTotal > 0 ? derivedTotal : cycleSeconds;
         playbackState.index = 0;
         playbackState.isScrubbing = false;
+        playbackState.isPlaying = false;
+        playbackState.isLooping = false;
+        playbackState.playbackRate = 1;
         stopPlaybackTimer();
 
         if (playbackControls) {
@@ -287,7 +586,15 @@
           playbackSlider.value = "0";
           playbackSlider.disabled = playable.length <= 1;
         }
+        if (playbackRateSelect) {
+          playbackRateSelect.value = "1";
+        }
+        if (loopToggleButton) {
+          loopToggleButton.setAttribute("aria-pressed", "false");
+          loopToggleButton.textContent = "Loop off";
+        }
         updateTimeDisplay(0);
+        updateTransportState();
       }
 
       function setupSliderEvents() {
@@ -303,10 +610,16 @@
         };
         const endScrub = () => {
           if (!playbackState.frames.length) {
+            playbackState.isScrubbing = false;
+            updateTransportState();
             return;
           }
           playbackState.isScrubbing = false;
-          scheduleNextFrame();
+          if (playbackState.isPlaying) {
+            scheduleNextFrame();
+          } else {
+            updateTransportState();
+          }
         };
         playbackSlider.addEventListener("input", (event) => {
           if (!playbackState.frames.length) {
@@ -333,6 +646,47 @@
         });
         playbackSlider.dataset.enhanced = "true";
       }
+
+      if (playPauseButton) {
+        playPauseButton.addEventListener("click", () => {
+          togglePlayback();
+        });
+      }
+      if (frameBackButton) {
+        frameBackButton.addEventListener("click", () => {
+          stepFrame(-1);
+        });
+      }
+      if (frameForwardButton) {
+        frameForwardButton.addEventListener("click", () => {
+          stepFrame(1);
+        });
+      }
+      if (jumpStartButton) {
+        jumpStartButton.addEventListener("click", () => {
+          jumpToStart();
+        });
+      }
+      if (jumpEndButton) {
+        jumpEndButton.addEventListener("click", () => {
+          jumpToEnd();
+        });
+      }
+      if (loopToggleButton) {
+        loopToggleButton.addEventListener("click", () => {
+          toggleLooping();
+        });
+      }
+      if (playbackRateSelect) {
+        playbackRateSelect.addEventListener("change", (event) => {
+          const value = Number(event.target && event.target.value);
+          if (Number.isFinite(value) && value > 0) {
+            setPlaybackRate(value);
+          }
+        });
+      }
+
+      updateTransportState();
 
       function renderMeta(data) {
         metaList.innerHTML = "";
@@ -495,7 +849,7 @@
         setupSliderEvents();
         prepareControls(playable, frameTimes, intervals, fallbackInterval, cycleDurationMs);
         showFrame(0);
-        scheduleNextFrame();
+        startPlayback();
       }
 
       async function loadRecording() {


### PR DESCRIPTION
## Summary
- add a range slider and time display to the surveillance recording playback page
- refactor the player script to manage playback state, support scrubbing, and update timing metadata

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e14c309308833284f36140073cdb31