### PR TITLE
Add optional MP4 chunk export for surveillance recordings

### DIFF
--- a/src/rev_cam/app.py
+++ b/src/rev_cam/app.py
@@ -176,6 +176,7 @@ class SurveillanceSettingsPayload(BaseModel):
     expert_fps: int | None = None
     expert_jpeg_quality: int | None = None
     chunk_duration_seconds: int | None = None
+    chunk_mp4_enabled: bool | None = None
     overlays_enabled: bool | None = None
     remember_recording_state: bool | None = None
     motion_detection_enabled: bool | None = None
@@ -620,6 +621,7 @@ def create_app(
                 jpeg_quality=jpeg_quality,
                 directory=RECORDINGS_DIR,
                 chunk_duration_seconds=surveillance_settings.chunk_duration_seconds,
+                chunk_mp4_enabled=surveillance_settings.chunk_mp4_enabled,
                 storage_threshold_percent=surveillance_settings.storage_threshold_percent,
                 motion_detection_enabled=surveillance_settings.motion_detection_enabled,
                 motion_sensitivity=surveillance_settings.motion_sensitivity,
@@ -633,6 +635,7 @@ def create_app(
                 fps=fps,
                 jpeg_quality=jpeg_quality,
                 chunk_duration_seconds=surveillance_settings.chunk_duration_seconds,
+                chunk_mp4_enabled=surveillance_settings.chunk_mp4_enabled,
                 storage_threshold_percent=surveillance_settings.storage_threshold_percent,
                 motion_detection_enabled=surveillance_settings.motion_detection_enabled,
                 motion_sensitivity=surveillance_settings.motion_sensitivity,
@@ -1824,6 +1827,7 @@ def create_app(
                     fps=settings.resolved_fps,
                     jpeg_quality=settings.resolved_jpeg_quality,
                     chunk_duration_seconds=settings.chunk_duration_seconds,
+                    chunk_mp4_enabled=settings.chunk_mp4_enabled,
                     storage_threshold_percent=settings.storage_threshold_percent,
                     motion_detection_enabled=settings.motion_detection_enabled,
                     motion_sensitivity=settings.motion_sensitivity,

--- a/src/rev_cam/config.py
+++ b/src/rev_cam/config.py
@@ -141,6 +141,7 @@ class SurveillanceSettings:
     expert_fps: int = 6
     expert_jpeg_quality: int = 75
     chunk_duration_seconds: int | None = None
+    chunk_mp4_enabled: bool = False
     overlays_enabled: bool = True
     remember_recording_state: bool = False
     motion_detection_enabled: bool = False
@@ -244,6 +245,7 @@ class SurveillanceSettings:
         object.__setattr__(self, "motion_post_event_seconds", float(post_seconds))
         object.__setattr__(self, "auto_purge_days", auto_purge)
         object.__setattr__(self, "storage_threshold_percent", threshold_percent)
+        object.__setattr__(self, "chunk_mp4_enabled", bool(self.chunk_mp4_enabled))
 
     def resolved_values(self) -> tuple[int, int]:
         """Return the effective fps and JPEG quality for surveillance recording."""
@@ -267,6 +269,7 @@ class SurveillanceSettings:
             "expert_fps": int(self.expert_fps),
             "expert_jpeg_quality": int(self.expert_jpeg_quality),
             "chunk_duration_seconds": self.chunk_duration_seconds,
+            "chunk_mp4_enabled": bool(self.chunk_mp4_enabled),
             "overlays_enabled": bool(self.overlays_enabled),
             "remember_recording_state": bool(self.remember_recording_state),
             "motion_detection_enabled": bool(self.motion_detection_enabled),

--- a/src/rev_cam/static/surveillance_settings.html
+++ b/src/rev_cam/static/surveillance_settings.html
@@ -457,6 +457,15 @@
                 <input id="chunk-duration" type="number" min="0" max="86400" step="1" />
                 <span class="muted">Set to 0 to keep each recording as a single file.</span>
               </div>
+              <label class="option inline-option">
+                <input type="checkbox" id="chunk-mp4-enabled" />
+                <div>
+                  <strong>Create MP4 chunk files</strong>
+                  <span class="helper"
+                    >Generate an .mp4 alongside each JSON chunk for quick playback.</span
+                  >
+                </div>
+              </label>
               <div>
                 <label for="storage-threshold">Stop recording below free space (%)</label>
                 <input id="storage-threshold" type="number" min="1" max="90" step="1" />
@@ -518,6 +527,7 @@
       const overlayCheckbox = document.getElementById("recording-overlays");
       const rememberCheckbox = document.getElementById("remember-recording");
       const chunkDurationInput = document.getElementById("chunk-duration");
+      const chunkMp4Checkbox = document.getElementById("chunk-mp4-enabled");
       const storageThresholdInput = document.getElementById("storage-threshold");
       const autoPurgeInput = document.getElementById("auto-purge-days");
       const motionEnabledInput = document.getElementById("motion-enabled");
@@ -711,6 +721,10 @@
         chunkDurationInput.addEventListener("input", updateSummary);
       }
 
+      if (chunkMp4Checkbox) {
+        chunkMp4Checkbox.addEventListener("change", updateSummary);
+      }
+
       function getSelectedProfile() {
         const selected = profileInputs.find((input) => input.checked);
         return selected ? selected.value : "standard";
@@ -792,6 +806,9 @@
             text += ` • Split every ${durationLabel}`;
           }
         }
+        if (chunkMp4Checkbox && chunkMp4Checkbox.checked) {
+          text += " • MP4 chunk export enabled";
+        }
         if (motionEnabledInput && motionEnabledInput.checked && effective.fps) {
           const decimation = getMotionDecimation();
           const motionFps = effective.fps / Math.max(1, decimation);
@@ -835,6 +852,9 @@
           const seconds = Number(settings.chunk_duration_seconds ?? 0);
           const normalised = Number.isFinite(seconds) && seconds > 0 ? Math.round(seconds) : 0;
           chunkDurationInput.value = normalised;
+        }
+        if (chunkMp4Checkbox) {
+          chunkMp4Checkbox.checked = settings.chunk_mp4_enabled === true;
         }
         if (storageThresholdInput) {
           const threshold = Number(settings.storage_threshold_percent ?? 10);
@@ -970,6 +990,9 @@
           } else {
             payload.chunk_duration_seconds = 0;
           }
+        }
+        if (chunkMp4Checkbox) {
+          payload.chunk_mp4_enabled = chunkMp4Checkbox.checked;
         }
         if (storageThresholdInput) {
           const thresholdValue = parseFloat(storageThresholdInput.value);

--- a/tests/test_motion_detection.py
+++ b/tests/test_motion_detection.py
@@ -168,6 +168,54 @@ async def test_start_recording_survives_cancellation(tmp_path: Path, anyio_backe
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_chunk_mp4_generation(tmp_path: Path, anyio_backend) -> None:
+    camera = _StaticCamera()
+    pipeline = _pipeline()
+    manager = RecordingManager(
+        camera=camera,
+        pipeline=pipeline,
+        directory=tmp_path,
+        fps=2,
+        chunk_duration_seconds=1,
+        chunk_mp4_enabled=True,
+    )
+
+    async def _noop(self):
+        return None
+
+    manager._ensure_producer_running = types.MethodType(_noop, manager)
+    await manager.start_recording()
+
+    frame = np.zeros((24, 24, 3), dtype=np.uint8)
+    frame[:8, :8, :] = 255
+    jpeg_payload = manager._encode_frame(frame)
+
+    await manager._record_frame(jpeg_payload, 0.0, frame)
+    await manager._record_frame(jpeg_payload, 0.5, frame)
+    await manager._record_frame(jpeg_payload, 1.1, frame)
+
+    placeholder = await manager.stop_recording()
+    assert placeholder["processing"] is True
+    metadata = await manager.wait_for_processing()
+    assert metadata is not None
+    chunks = metadata.get("chunks") or []
+    assert chunks
+    for entry in chunks:
+        assert entry.get("video_file")
+        assert entry.get("video_size_bytes", 0) > 0
+    for entry in chunks:
+        video_path = tmp_path / str(entry["video_file"])
+        assert video_path.exists()
+        with av.open(str(video_path), mode="r") as container:
+            video_streams = [stream for stream in container.streams if stream.type == "video"]
+            assert video_streams
+            first_frame = next(container.decode(video=0), None)
+            assert first_frame is not None
+    await manager.aclose()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
 async def test_manual_recording_disables_motion_when_requested(
     tmp_path: Path, anyio_backend
 ) -> None:


### PR DESCRIPTION
## Summary
- add a `chunk_mp4_enabled` surveillance setting and expose it in the settings API/UI
- update the recording manager to render MP4 files alongside chunk JSON when enabled
- cover the new behaviour with a test that validates the generated MP4 chunks

## Testing
- pytest tests/test_motion_detection.py::test_chunk_mp4_generation

------
https://chatgpt.com/codex/tasks/task_e_68e1924d887c833292a07ed92f72436b