### PR TITLE
Prevent stale surveillance status responses from updating UI

### DIFF
--- a/src/rev_cam/static/surveillance.html
+++ b/src/rev_cam/static/surveillance.html
@@ -493,6 +493,7 @@
       const MANUAL_CONFIRMATION_GRACE_MS = 5000;
       let statusRefreshHandle = null;
       let statusRequestSequence = 0;
+      let latestRequestedStatusSequence = 0;
       let latestAppliedStatusSequence = 0;
       let pageVisible = true;
 
@@ -1011,6 +1012,7 @@
       async function loadStatus(options = {}) {
         const { showLoading = false, suppressError = false } = options;
         const requestSequence = ++statusRequestSequence;
+        latestRequestedStatusSequence = requestSequence;
         if (showLoading) {
           setStatus("Loading surveillance status…", "busy");
         }
@@ -1019,6 +1021,10 @@
           const response = await fetch("/api/surveillance/status", { cache: "no-store" });
           if (!response.ok) {
             throw new Error(`Status request failed with ${response.status}`);
+          }
+          if (requestSequence < latestRequestedStatusSequence) {
+            scheduleStatusRefresh();
+            return;
           }
           const payload = await response.json();
           if (requestSequence < latestAppliedStatusSequence) {


### PR DESCRIPTION
## Summary
- track the most recent surveillance status request issued by the UI
- ignore older surveillance status responses before applying their payloads

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1a39493c8833283f2eb702191ed54