### PR TITLE
Switch surveillance recording chunks to MP4

### DIFF
--- a/src/rev_cam/config.py
+++ b/src/rev_cam/config.py
@@ -141,7 +141,6 @@ class SurveillanceSettings:
     expert_fps: int = 6
     expert_jpeg_quality: int = 75
     chunk_duration_seconds: int | None = None
-    chunk_mp4_enabled: bool = False
     overlays_enabled: bool = True
     remember_recording_state: bool = False
     motion_detection_enabled: bool = False
@@ -245,7 +244,6 @@ class SurveillanceSettings:
         object.__setattr__(self, "motion_post_event_seconds", float(post_seconds))
         object.__setattr__(self, "auto_purge_days", auto_purge)
         object.__setattr__(self, "storage_threshold_percent", threshold_percent)
-        object.__setattr__(self, "chunk_mp4_enabled", bool(self.chunk_mp4_enabled))
 
     def resolved_values(self) -> tuple[int, int]:
         """Return the effective fps and JPEG quality for surveillance recording."""
@@ -269,7 +267,6 @@ class SurveillanceSettings:
             "expert_fps": int(self.expert_fps),
             "expert_jpeg_quality": int(self.expert_jpeg_quality),
             "chunk_duration_seconds": self.chunk_duration_seconds,
-            "chunk_mp4_enabled": bool(self.chunk_mp4_enabled),
             "overlays_enabled": bool(self.overlays_enabled),
             "remember_recording_state": bool(self.remember_recording_state),
             "motion_detection_enabled": bool(self.motion_detection_enabled),

--- a/src/rev_cam/static/surveillance_player.html
+++ b/src/rev_cam/static/surveillance_player.html
@@ -16,11 +16,18 @@
         --text-primary: #f5f7fb;
         --text-muted: rgba(245, 247, 250, 0.7);
         --accent: #0a84ff;
+        --accent-soft: rgba(10, 132, 255, 0.18);
         --danger: #ff453a;
         --radius-lg: 1.2rem;
+        --radius-sm: 0.75rem;
         --space-md: 1rem;
         --space-lg: 1.6rem;
-        --page-gradient: radial-gradient(120% 140% at top, #1b1e26 0%, #0b0d13 60%, #050609 100%);
+        --page-gradient: radial-gradient(
+          120% 140% at top,
+          #1b1e26 0%,
+          #0b0d13 60%,
+          #050609 100%
+        );
       }
       body {
         margin: 0;
@@ -44,7 +51,7 @@
         flex-direction: column;
         gap: var(--space-md);
       }
-      .player-card header {
+      header {
         display: flex;
         flex-direction: column;
         gap: 0.35rem;
@@ -54,10 +61,10 @@
       }
       .playback-frame {
         width: 100%;
+        aspect-ratio: 16 / 9;
         border-radius: 0.9rem;
         border: 1px solid var(--border-subtle);
         background: #000;
-        min-height: 260px;
       }
       .meta-list {
         display: flex;
@@ -66,131 +73,91 @@
         color: var(--text-muted);
         font-size: 0.95rem;
       }
-      .chunk-summary {
-        font-size: 0.85rem;
-        color: var(--text-muted);
+      .meta-pill {
+        padding: 0.35rem 0.7rem;
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.05);
+        border: 1px solid var(--border-subtle);
       }
-      .playback-controls {
+      .status {
+        min-height: 1.25rem;
+      }
+      .status.error {
+        color: var(--danger);
+        font-weight: 600;
+      }
+      .video-actions {
         display: flex;
         flex-direction: column;
         gap: 0.75rem;
-        padding-inline: 0.4rem;
       }
-      .playback-controls[hidden] {
-        display: none;
-      }
-      .time-display {
+      .chunk-navigation {
         display: flex;
+        align-items: center;
         justify-content: space-between;
-        font-size: 0.9rem;
-        color: var(--text-muted);
-        gap: 0.5rem;
-      }
-      .time-display span {
-        white-space: nowrap;
-      }
-      input[type="range"] {
-        width: 100%;
-        accent-color: var(--accent);
-        cursor: pointer;
-      }
-      input[type="range"]:disabled {
-        cursor: not-allowed;
-        opacity: 0.5;
-      }
-      .transport {
-        display: flex;
-        flex-direction: column;
-        gap: 0.5rem;
-      }
-      .transport-buttons {
-        display: flex;
-        gap: 0.5rem;
-        align-items: center;
-        justify-content: center;
-        flex-wrap: wrap;
-      }
-      .transport-buttons button {
-        min-width: 3rem;
-      }
-      .playback-options {
-        display: flex;
         gap: 0.75rem;
-        justify-content: center;
-        flex-wrap: wrap;
-        align-items: center;
-        color: var(--text-muted);
-        font-size: 0.85rem;
       }
-      .playback-options label {
-        display: flex;
-        gap: 0.35rem;
-        align-items: center;
+      .chunk-indicator {
+        flex: 1;
+        text-align: center;
+        color: var(--text-muted);
       }
       button,
-      select {
+      a.link {
         font: inherit;
-      }
-      button {
         border: 1px solid var(--border-subtle);
         background: rgba(255, 255, 255, 0.04);
         color: var(--text-primary);
-        padding: 0.45rem 0.8rem;
+        padding: 0.45rem 0.85rem;
         border-radius: 999px;
         cursor: pointer;
         transition: background 0.15s ease, border-color 0.15s ease;
+        text-decoration: none;
       }
       button:hover,
-      button:focus-visible {
-        background: rgba(10, 132, 255, 0.18);
+      button:focus-visible,
+      a.link:hover,
+      a.link:focus-visible {
+        background: var(--accent-soft);
         border-color: rgba(10, 132, 255, 0.55);
         outline: none;
       }
       button:disabled {
         cursor: not-allowed;
-        opacity: 0.5;
+        opacity: 0.55;
       }
-      select {
-        border-radius: 999px;
+      .chunk-list {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+      }
+      .chunk-pill {
+        padding: 0.35rem 0.6rem;
+        border-radius: var(--radius-sm);
         border: 1px solid var(--border-subtle);
-        background: rgba(255, 255, 255, 0.03);
+        background: rgba(255, 255, 255, 0.04);
+        font-size: 0.85rem;
+        color: var(--text-muted);
+        cursor: pointer;
+        transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+      }
+      .chunk-pill:hover,
+      .chunk-pill:focus-visible {
+        background: var(--accent-soft);
+        border-color: rgba(10, 132, 255, 0.55);
         color: var(--text-primary);
-        padding: 0.35rem 0.75rem;
+        outline: none;
       }
-      select:disabled {
-        opacity: 0.6;
-        cursor: not-allowed;
-      }
-      .sr-only {
-        position: absolute;
-        width: 1px;
-        height: 1px;
-        padding: 0;
-        margin: -1px;
-        overflow: hidden;
-        clip: rect(0, 0, 0, 0);
-        white-space: nowrap;
-        border: 0;
-      }
-      .play-pause-button[aria-pressed="true"] {
+      .chunk-pill.active {
         background: rgba(10, 132, 255, 0.25);
-        border-color: rgba(10, 132, 255, 0.7);
+        border-color: rgba(10, 132, 255, 0.8);
+        color: var(--text-primary);
       }
-      .loop-button[aria-pressed="true"] {
-        background: rgba(10, 132, 255, 0.2);
-        border-color: rgba(10, 132, 255, 0.6);
-      }
-      .error {
-        color: var(--danger);
-        font-weight: 600;
-      }
-      a.link {
-        color: var(--accent);
-        text-decoration: none;
-      }
-      a.link:hover,
-      a.link:focus-visible {
-        text-decoration: underline;
+      .footer-links {
+        display: flex;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+        align-items: center;
       }
     </style>
   </head>
@@ -199,143 +166,78 @@
       <header>
         <h1 id="recording-title">Loading recording…</h1>
         <div class="meta-list" id="recording-meta"></div>
-        <div class="chunk-summary" id="chunk-summary"></div>
-        <p class="muted" id="status-text">Preparing playback…</p>
+        <p id="status-text" class="status muted">Preparing playback…</p>
       </header>
-      <img id="playback-frame" class="playback-frame" alt="Recording playback" hidden />
-      <div class="playback-controls" id="playback-controls" hidden>
-        <div class="time-display" aria-live="polite">
-          <span id="current-time" aria-label="Current position">Current 0:00</span>
-          <span id="total-time" aria-label="Clip length">Length 0:00</span>
+      <video
+        id="playback-video"
+        class="playback-frame"
+        controls
+        preload="metadata"
+        hidden
+      >
+        <p>Your browser does not support HTML5 video playback.</p>
+      </video>
+      <div class="video-actions" id="video-actions" hidden>
+        <div class="chunk-navigation">
+          <button type="button" id="prev-chunk" aria-label="Previous chunk">⏮</button>
+          <div id="chunk-indicator" class="chunk-indicator">Chunk 0 of 0</div>
+          <button type="button" id="next-chunk" aria-label="Next chunk">⏭</button>
         </div>
-        <input
-          id="playback-slider"
-          type="range"
-          min="0"
-          max="0"
-          value="0"
-          step="1"
-          aria-label="Scrub through recording"
-        />
-        <div class="transport" role="group" aria-label="Playback controls">
-          <div class="transport-buttons">
-            <button type="button" id="jump-start" aria-label="Go to start">
-              ⏮
-            </button>
-            <button type="button" id="frame-back" aria-label="Step back one frame">
-              ⏪
-            </button>
-            <button
-              type="button"
-              id="play-pause"
-              class="play-pause-button"
-              aria-pressed="false"
-              aria-label="Play or pause recording"
-            >
-              Play
-            </button>
-            <button type="button" id="frame-forward" aria-label="Step forward one frame">
-              ⏩
-            </button>
-            <button type="button" id="jump-end" aria-label="Go to end">
-              ⏭
-            </button>
-          </div>
-          <div class="playback-options">
-            <label for="playback-rate">
-              Speed
-              <select id="playback-rate" aria-label="Playback speed">
-                <option value="0.25">0.25×</option>
-                <option value="0.5">0.5×</option>
-                <option value="0.75">0.75×</option>
-                <option value="1" selected>1×</option>
-                <option value="1.5">1.5×</option>
-                <option value="2">2×</option>
-              </select>
-            </label>
-            <button
-              type="button"
-              id="loop-toggle"
-              class="loop-button"
-              aria-pressed="false"
-              aria-label="Toggle looping playback"
-            >
-              Loop off
-            </button>
-          </div>
-        </div>
+        <div class="chunk-list" id="chunk-list" aria-live="polite"></div>
       </div>
-      <p class="muted">
+      <div class="footer-links muted">
+        <a class="link" id="download-link" href="#" download>Download recording</a>
+        <span aria-hidden="true">·</span>
         <a class="link" href="/surveillance">Back to surveillance</a>
-      </p>
+      </div>
     </div>
     <script>
       const params = new URLSearchParams(window.location.search);
       const recordingName = params.get("name");
       const title = document.getElementById("recording-title");
       const metaList = document.getElementById("recording-meta");
-      const chunkSummary = document.getElementById("chunk-summary");
       const statusText = document.getElementById("status-text");
-      const playbackFrame = document.getElementById("playback-frame");
-      const playbackControls = document.getElementById("playback-controls");
-      const playbackSlider = document.getElementById("playback-slider");
-      const currentTimeLabel = document.getElementById("current-time");
-      const totalTimeLabel = document.getElementById("total-time");
-      const playPauseButton = document.getElementById("play-pause");
-      const frameBackButton = document.getElementById("frame-back");
-      const frameForwardButton = document.getElementById("frame-forward");
-      const jumpStartButton = document.getElementById("jump-start");
-      const jumpEndButton = document.getElementById("jump-end");
-      const loopToggleButton = document.getElementById("loop-toggle");
-      const playbackRateSelect = document.getElementById("playback-rate");
+      const video = document.getElementById("playback-video");
+      const actions = document.getElementById("video-actions");
+      const prevChunkButton = document.getElementById("prev-chunk");
+      const nextChunkButton = document.getElementById("next-chunk");
+      const chunkIndicator = document.getElementById("chunk-indicator");
+      const chunkList = document.getElementById("chunk-list");
+      const downloadLink = document.getElementById("download-link");
 
-      const playbackState = {
-        frames: [],
-        intervals: [],
-        frameTimes: [],
-        fallbackInterval: 200,
-        index: 0,
-        timer: null,
-        isScrubbing: false,
-        totalDuration: 0,
-        isPlaying: false,
-        isLooping: false,
-        playbackRate: 1,
-        firstTimestamp: null,
-        hasInitialFrame: false,
-        autoPlayRequested: true,
-        initialised: false,
-      };
+      let chunks = [];
+      let currentChunkIndex = 0;
+      let recordingMetadata = null;
 
       function setStatus(message, tone = "info") {
+        statusText.textContent = message;
         if (tone === "error") {
           statusText.classList.add("error");
         } else {
           statusText.classList.remove("error");
         }
-        statusText.textContent = message;
       }
 
       function formatBytes(bytes) {
-        if (typeof bytes !== "number" || !Number.isFinite(bytes) || bytes < 0) {
+        if (typeof bytes !== "number" || !Number.isFinite(bytes) || bytes <= 0) {
           return null;
         }
         const units = ["B", "KB", "MB", "GB", "TB"];
         let value = bytes;
-        let index = 0;
-        while (value >= 1024 && index < units.length - 1) {
+        let unit = 0;
+        while (value >= 1024 && unit < units.length - 1) {
           value /= 1024;
-          index += 1;
+          unit += 1;
         }
-        const display = value >= 10 || index === 0 ? value.toFixed(0) : value.toFixed(1);
-        return `${display.replace(/\.0$/, "")} ${units[index]}`;
+        const display = value >= 10 || unit === 0 ? value.toFixed(0) : value.toFixed(1);
+        return `${display.replace(/\.0$/, "")} ${units[unit]}`;
       }
 
-      function formatTime(seconds) {
+      function formatDuration(seconds) {
         if (typeof seconds !== "number" || !Number.isFinite(seconds) || seconds < 0) {
           return "0:00";
         }
-        const totalSeconds = Math.floor(seconds);
+        const totalSeconds = Math.round(seconds);
         const hours = Math.floor(totalSeconds / 3600);
         const minutes = Math.floor((totalSeconds % 3600) / 60);
         const secs = totalSeconds % 60;
@@ -346,698 +248,160 @@
         return `${minutes}:${pad(secs)}`;
       }
 
-      function updateFallbackFromFps(fps) {
-        if (typeof fps === "number" && Number.isFinite(fps) && fps > 0) {
-          playbackState.fallbackInterval = Math.max(40, Math.round(1000 / fps));
-        } else {
-          playbackState.fallbackInterval = 200;
+      function updateMetaDisplay(recording) {
+        const items = [];
+        if (recording.duration_seconds) {
+          items.push(`Duration ${formatDuration(recording.duration_seconds)}`);
         }
-      }
-
-      function resetPlaybackState(fps) {
-        updateFallbackFromFps(fps);
-        playbackState.frames = [];
-        playbackState.intervals = [];
-        playbackState.frameTimes = [];
-        playbackState.index = 0;
-        playbackState.totalDuration = 0;
-        playbackState.isPlaying = false;
-        playbackState.isLooping = false;
-        playbackState.playbackRate = 1;
-        playbackState.isScrubbing = false;
-        playbackState.firstTimestamp = null;
-        playbackState.hasInitialFrame = false;
-        playbackState.autoPlayRequested = true;
-        playbackState.initialised = true;
-        stopPlaybackTimer();
-        if (playbackFrame) {
-          playbackFrame.hidden = true;
-          playbackFrame.removeAttribute("src");
+        if (recording.fps) {
+          items.push(`${recording.fps} fps`);
         }
-        if (playbackControls) {
-          playbackControls.hidden = true;
+        if (recording.frame_count) {
+          items.push(`${recording.frame_count} frames`);
         }
-        if (playbackSlider) {
-          playbackSlider.value = "0";
-          playbackSlider.max = "0";
-          playbackSlider.disabled = true;
+        if (recording.chunk_count) {
+          items.push(`${recording.chunk_count} chunk${recording.chunk_count === 1 ? "" : "s"}`);
         }
-        if (playbackRateSelect) {
-          playbackRateSelect.value = "1";
-        }
-        if (loopToggleButton) {
-          loopToggleButton.setAttribute("aria-pressed", "false");
-          loopToggleButton.textContent = "Loop off";
-        }
-        updateTimeDisplay(0);
-        updateTransportState();
-      }
-
-      function normaliseFrames(rawFrames) {
-        if (!Array.isArray(rawFrames)) {
-          return [];
-        }
-        return rawFrames
-          .map((frame) => ({
-            jpeg: frame && typeof frame.jpeg === "string" ? frame.jpeg : null,
-            timestamp:
-              frame && typeof frame.timestamp === "number" && Number.isFinite(frame.timestamp)
-                ? Number(frame.timestamp)
-                : null,
-          }))
-          .filter((frame) => typeof frame.jpeg === "string" && frame.jpeg.length > 0);
-      }
-
-      function appendFrames(rawFrames) {
-        const playable = normaliseFrames(rawFrames);
-        if (!playable.length) {
-          return false;
-        }
-        playable.forEach((frame) => {
-          if (
-            playbackState.firstTimestamp === null &&
-            frame.timestamp !== null &&
-            Number.isFinite(frame.timestamp)
-          ) {
-            playbackState.firstTimestamp = frame.timestamp;
+        if (recording.size_bytes) {
+          const display = formatBytes(recording.size_bytes);
+          if (display) {
+            items.push(`Size ${display}`);
           }
-          const existingCount = playbackState.frames.length;
-          if (existingCount === 0) {
-            playbackState.frames.push(frame);
-            playbackState.frameTimes.push(0);
-            playbackState.intervals.push(playbackState.fallbackInterval);
-            return;
-          }
-          const previousIndex = existingCount - 1;
-          const previousFrame = playbackState.frames[previousIndex];
-          const previousTimestamp = previousFrame.timestamp;
-          const currentTimestamp = frame.timestamp;
-          let interval = playbackState.fallbackInterval;
-          if (
-            previousTimestamp !== null &&
-            Number.isFinite(previousTimestamp) &&
-            currentTimestamp !== null &&
-            Number.isFinite(currentTimestamp) &&
-            currentTimestamp >= previousTimestamp
-          ) {
-            interval = Math.max(40, Math.round((currentTimestamp - previousTimestamp) * 1000));
-          } else if (
-            currentTimestamp !== null &&
-            Number.isFinite(currentTimestamp) &&
-            playbackState.firstTimestamp !== null &&
-            Number.isFinite(playbackState.firstTimestamp)
-          ) {
-            const elapsedCurrent = Math.max(
-              0,
-              Math.round((currentTimestamp - playbackState.firstTimestamp) * 1000),
-            );
-            const priorTime = playbackState.frameTimes[previousIndex] ?? 0;
-            const priorElapsed = Math.max(0, Math.round(priorTime * 1000));
-            if (elapsedCurrent > priorElapsed) {
-              interval = Math.max(40, elapsedCurrent - priorElapsed);
-            }
-          }
-          playbackState.intervals[previousIndex] = interval;
-          let frameTime = 0;
-          if (
-            currentTimestamp !== null &&
-            Number.isFinite(currentTimestamp) &&
-            playbackState.firstTimestamp !== null &&
-            Number.isFinite(playbackState.firstTimestamp)
-          ) {
-            frameTime = Math.max(0, currentTimestamp - playbackState.firstTimestamp);
-          } else {
-            const priorTime = playbackState.frameTimes[previousIndex] ?? 0;
-            frameTime = priorTime + interval / 1000;
-          }
-          playbackState.frames.push(frame);
-          playbackState.frameTimes.push(frameTime);
-          playbackState.intervals.push(playbackState.fallbackInterval);
-        });
-        return true;
+        }
+        if (recording.started_at) {
+          items.push(new Date(recording.started_at).toLocaleString());
+        }
+        metaList.innerHTML = items
+          .map((text) => `<span class="meta-pill">${text}</span>`)
+          .join("");
       }
 
-      function ensurePlaybackVisible() {
-        if (playbackFrame) {
-          playbackFrame.hidden = false;
-        }
-        if (playbackControls) {
-          playbackControls.hidden = false;
-        }
-        setupSliderEvents();
-      }
-
-      function refreshControls() {
-        const frameCount = playbackState.frames.length;
-        const lastIndex = frameCount - 1;
-        const lastTime = playbackState.frameTimes[lastIndex];
-        const fallbackSeconds =
-          frameCount > 1 ? (frameCount - 1) * (playbackState.fallbackInterval / 1000) : 0;
-        let totalDuration = 0;
-        if (typeof lastTime === "number" && Number.isFinite(lastTime) && lastTime > 0) {
-          totalDuration = lastTime;
-        } else if (Number.isFinite(fallbackSeconds) && fallbackSeconds > 0) {
-          totalDuration = fallbackSeconds;
-        }
-        playbackState.totalDuration = totalDuration;
-        if (playbackSlider && !playbackState.isScrubbing) {
-          playbackSlider.max = String(Math.max(lastIndex, 0));
-          playbackSlider.disabled = frameCount <= 1;
-        }
-        const clampedIndex = Math.max(0, Math.min(playbackState.index, lastIndex));
-        updateTimeDisplay(clampedIndex);
-        updateTransportState();
-      }
-
-      function ingestFrames(rawFrames, { fps, silent = false } = {}) {
-        if (typeof fps === "number" && Number.isFinite(fps) && fps > 0) {
-          updateFallbackFromFps(fps);
-        }
-        const appended = appendFrames(rawFrames);
-        if (!appended) {
-          if (!silent && !playbackState.frames.length) {
-            setStatus("Recording does not contain any frames.", "error");
-            if (playbackFrame) {
-              playbackFrame.hidden = true;
-            }
-          }
-          return false;
-        }
-        ensurePlaybackVisible();
-        refreshControls();
-        if (!playbackState.hasInitialFrame) {
-          showFrame(0);
-        }
-        if (playbackState.autoPlayRequested && playbackState.frames.length > 1 && !playbackState.isPlaying) {
-          startPlayback();
-        } else if (playbackState.isPlaying) {
-          scheduleNextFrame();
-        } else {
-          updateTransportState();
-        }
-        return true;
-      }
-
-      function stopPlaybackTimer() {
-        if (playbackState.timer) {
-          window.clearTimeout(playbackState.timer);
-          playbackState.timer = null;
-        }
-      }
-
-      function updateTimeDisplay(index) {
-        if (currentTimeLabel) {
-          const seconds = playbackState.frameTimes[index] ?? 0;
-          currentTimeLabel.textContent = `Current ${formatTime(seconds)}`;
-        }
-        if (totalTimeLabel) {
-          totalTimeLabel.textContent = `Length ${formatTime(playbackState.totalDuration)}`;
-        }
-      }
-
-      function updateTransportState() {
-        const { frames, index, isPlaying, isLooping } = playbackState;
-        const multiFrame = frames.length > 1;
-        const lastIndex = Math.max(0, frames.length - 1);
-
-        if (playPauseButton) {
-          playPauseButton.disabled = !multiFrame;
-          playPauseButton.textContent = isPlaying ? "Pause" : "Play";
-          playPauseButton.setAttribute("aria-pressed", isPlaying ? "true" : "false");
-          playPauseButton.setAttribute(
-            "aria-label",
-            isPlaying ? "Pause recording" : "Play recording",
-          );
-        }
-        if (frameBackButton) {
-          frameBackButton.disabled = !multiFrame || index <= 0;
-        }
-        if (frameForwardButton) {
-          frameForwardButton.disabled = !multiFrame || index >= lastIndex;
-        }
-        if (jumpStartButton) {
-          jumpStartButton.disabled = !multiFrame || index <= 0;
-        }
-        if (jumpEndButton) {
-          jumpEndButton.disabled = !multiFrame || index >= lastIndex;
-        }
-        if (loopToggleButton) {
-          loopToggleButton.disabled = !multiFrame;
-          loopToggleButton.textContent = isLooping ? "Loop on" : "Loop off";
-          loopToggleButton.setAttribute("aria-pressed", isLooping ? "true" : "false");
-        }
-        if (playbackRateSelect) {
-          playbackRateSelect.disabled = !multiFrame;
-        }
-      }
-
-      function getFrameDelay(index) {
-        const baseInterval = playbackState.intervals[index] ?? playbackState.fallbackInterval;
-        const rate = playbackState.playbackRate > 0 ? playbackState.playbackRate : 1;
-        const scaled = baseInterval / rate;
-        const minimum = 16;
-        if (!Number.isFinite(scaled) || scaled <= 0) {
-          return Math.max(minimum, playbackState.fallbackInterval);
-        }
-        return Math.max(minimum, Math.round(scaled));
-      }
-
-      function showFrame(index, { updateSlider = true } = {}) {
-        if (!playbackFrame || !playbackState.frames.length) {
+      function updateChunkUI() {
+        if (!chunks.length) {
+          actions.hidden = true;
           return;
         }
-        const normalizedIndex = Math.max(0, Math.min(index, playbackState.frames.length - 1));
-        const frame = playbackState.frames[normalizedIndex];
-        if (!frame || typeof frame.jpeg !== "string") {
-          return;
-        }
-        playbackState.index = normalizedIndex;
-        playbackState.hasInitialFrame = true;
-        playbackFrame.src = `data:image/jpeg;base64,${frame.jpeg}`;
-        if (
-          playbackSlider &&
-          updateSlider &&
-          !playbackState.isScrubbing &&
-          Number.isFinite(normalizedIndex)
-        ) {
-          playbackSlider.value = String(normalizedIndex);
-        }
-        updateTimeDisplay(normalizedIndex);
-        updateTransportState();
-      }
-
-      function scheduleNextFrame() {
-        stopPlaybackTimer();
-        if (
-          !playbackState.isPlaying ||
-          playbackState.isScrubbing ||
-          playbackState.frames.length <= 1
-        ) {
-          return;
-        }
-        const currentIndex = playbackState.index;
-        const delay = getFrameDelay(currentIndex);
-        playbackState.timer = window.setTimeout(() => {
-          playbackState.timer = null;
-          if (
-            !playbackState.isPlaying ||
-            playbackState.isScrubbing ||
-            !playbackState.frames.length
-          ) {
-            return;
+        const total = chunks.length;
+        const current = currentChunkIndex + 1;
+        chunkIndicator.textContent = `Chunk ${current} of ${total}`;
+        prevChunkButton.disabled = currentChunkIndex === 0;
+        nextChunkButton.disabled = currentChunkIndex >= total - 1;
+        chunkList.innerHTML = "";
+        chunks.forEach((chunk, index) => {
+          const button = document.createElement("button");
+          button.type = "button";
+          button.className = "chunk-pill";
+          if (index === currentChunkIndex) {
+            button.classList.add("active");
           }
-          let nextIndex = playbackState.index + 1;
-          if (nextIndex >= playbackState.frames.length) {
-            if (playbackState.isLooping && playbackState.frames.length) {
-              nextIndex = 0;
-              showFrame(nextIndex);
-              scheduleNextFrame();
-            } else {
-              playbackState.isPlaying = false;
-              updateTransportState();
-            }
-            return;
-          }
-          showFrame(nextIndex);
-          scheduleNextFrame();
-        }, delay);
-      }
-
-      function pausePlayback() {
-        if (!playbackState.frames.length) {
-          return;
-        }
-        playbackState.isPlaying = false;
-        playbackState.autoPlayRequested = false;
-        stopPlaybackTimer();
-        updateTransportState();
-      }
-
-      function startPlayback({ restart = false } = {}) {
-        playbackState.autoPlayRequested = true;
-        if (!playbackState.frames.length) {
-          return;
-        }
-        if (playbackState.frames.length <= 1) {
-          playbackState.isPlaying = false;
-          updateTransportState();
-          return;
-        }
-        if (
-          restart ||
-          (playbackState.index >= playbackState.frames.length - 1 && !playbackState.isLooping)
-        ) {
-          showFrame(0);
-        }
-        playbackState.isPlaying = true;
-        updateTransportState();
-        scheduleNextFrame();
-      }
-
-      function togglePlayback() {
-        if (playbackState.isPlaying) {
-          pausePlayback();
-        } else {
-          startPlayback();
-        }
-      }
-
-      function stepFrame(step) {
-        if (!playbackState.frames.length || !Number.isFinite(step)) {
-          return;
-        }
-        const target = Math.max(
-          0,
-          Math.min(playbackState.index + Math.trunc(step), playbackState.frames.length - 1),
-        );
-        pausePlayback();
-        showFrame(target);
-      }
-
-      function jumpToStart() {
-        if (!playbackState.frames.length) {
-          return;
-        }
-        showFrame(0);
-        if (playbackState.isPlaying) {
-          scheduleNextFrame();
-        }
-      }
-
-      function jumpToEnd() {
-        if (!playbackState.frames.length) {
-          return;
-        }
-        const lastIndex = playbackState.frames.length - 1;
-        showFrame(lastIndex);
-        pausePlayback();
-      }
-
-      function toggleLooping() {
-        if (!playbackState.frames.length) {
-          return;
-        }
-        playbackState.isLooping = !playbackState.isLooping;
-        updateTransportState();
-        if (playbackState.isPlaying) {
-          scheduleNextFrame();
-        }
-      }
-
-      function setPlaybackRate(rate) {
-        if (!Number.isFinite(rate) || rate <= 0) {
-          return;
-        }
-        playbackState.playbackRate = rate;
-        updateTransportState();
-        if (playbackState.isPlaying) {
-          scheduleNextFrame();
-        }
-      }
-
-      function setupSliderEvents() {
-        if (!playbackSlider) {
-          return;
-        }
-        if (playbackSlider.dataset.enhanced === "true") {
-          return;
-        }
-        const beginScrub = () => {
-          playbackState.isScrubbing = true;
-          stopPlaybackTimer();
-        };
-        const endScrub = () => {
-          if (!playbackState.frames.length) {
-            playbackState.isScrubbing = false;
-            updateTransportState();
-            return;
-          }
-          playbackState.isScrubbing = false;
-          if (playbackState.isPlaying) {
-            scheduleNextFrame();
-          } else {
-            updateTransportState();
-          }
-        };
-        playbackSlider.addEventListener("input", (event) => {
-          if (!playbackState.frames.length) {
-            return;
-          }
-          beginScrub();
-          const target = event.target;
-          const value = Number(target && typeof target.value === "string" ? target.value : playbackSlider.value);
-          if (Number.isFinite(value)) {
-            showFrame(Math.round(value), { updateSlider: false });
-          }
-        });
-        playbackSlider.addEventListener("change", endScrub);
-        playbackSlider.addEventListener("pointerdown", beginScrub);
-        playbackSlider.addEventListener("pointerup", endScrub);
-        playbackSlider.addEventListener("mousedown", beginScrub);
-        playbackSlider.addEventListener("mouseup", endScrub);
-        playbackSlider.addEventListener("touchstart", beginScrub, { passive: true });
-        playbackSlider.addEventListener("touchend", endScrub, { passive: true });
-        playbackSlider.addEventListener("blur", () => {
-          if (playbackState.isScrubbing) {
-            endScrub();
-          }
-        });
-        playbackSlider.dataset.enhanced = "true";
-      }
-
-      if (playPauseButton) {
-        playPauseButton.addEventListener("click", () => {
-          togglePlayback();
-        });
-      }
-      if (frameBackButton) {
-        frameBackButton.addEventListener("click", () => {
-          stepFrame(-1);
-        });
-      }
-      if (frameForwardButton) {
-        frameForwardButton.addEventListener("click", () => {
-          stepFrame(1);
-        });
-      }
-      if (jumpStartButton) {
-        jumpStartButton.addEventListener("click", () => {
-          jumpToStart();
-        });
-      }
-      if (jumpEndButton) {
-        jumpEndButton.addEventListener("click", () => {
-          jumpToEnd();
-        });
-      }
-      if (loopToggleButton) {
-        loopToggleButton.addEventListener("click", () => {
-          toggleLooping();
-        });
-      }
-      if (playbackRateSelect) {
-        playbackRateSelect.addEventListener("change", (event) => {
-          const value = Number(event.target && event.target.value);
-          if (Number.isFinite(value) && value > 0) {
-            setPlaybackRate(value);
-          }
-        });
-      }
-
-      updateTransportState();
-
-      function renderMeta(data) {
-        metaList.innerHTML = "";
-        if (chunkSummary) {
-          chunkSummary.textContent = "";
-        }
-        const entries = [];
-        if (data.started_at) {
-          entries.push(`Started: ${new Date(data.started_at).toLocaleString()}`);
-        }
-        if (data.ended_at) {
-          entries.push(`Finished: ${new Date(data.ended_at).toLocaleString()}`);
-        }
-        if (typeof data.duration_seconds === "number") {
-          entries.push(`Duration: ${data.duration_seconds.toFixed(1)}s`);
-        }
-        if (typeof data.frame_count === "number") {
-          entries.push(`Frames: ${data.frame_count}`);
-        }
-        if (typeof data.fps === "number") {
-          entries.push(`Recorded at ${data.fps} fps`);
-        }
-        if (typeof data.size_bytes === "number") {
-          const sizeLabel = formatBytes(data.size_bytes);
-          if (sizeLabel) {
-            entries.push(`Size: ${sizeLabel}`);
-          }
-        }
-        if (!entries.length) {
-          metaList.textContent = "No metadata available.";
-          return;
-        }
-        entries.forEach((text) => {
-          const span = document.createElement("span");
-          span.textContent = text;
-          metaList.appendChild(span);
-        });
-        if (Array.isArray(data.chunks) && data.chunks.length && chunkSummary) {
-          const details = data.chunks
-            .map((chunk, idx) => {
-              if (!chunk || typeof chunk !== "object") {
-                return null;
-              }
-              const label = idx + 1;
-              const sizeLabel = formatBytes(chunk.size_bytes);
-              return sizeLabel ? `Chunk ${label} — ${sizeLabel}` : null;
-            })
-            .filter(Boolean);
-          if (details.length) {
-            chunkSummary.textContent = details.join(" • ");
-          }
-        }
-      }
-
-      async function fetchRecordingPayload(includeFrames) {
-        const params = new URLSearchParams();
-        params.set("include_frames", includeFrames ? "true" : "false");
-        const response = await fetch(
-          `/api/surveillance/recordings/${encodeURIComponent(recordingName)}?${params.toString()}`,
-          { cache: "no-store" },
-        );
-        if (!response.ok) {
-          throw new Error(`Request failed with ${response.status}`);
-        }
-        const payload = await response.json();
-        if (!payload || typeof payload !== "object") {
-          throw new Error("Invalid recording payload");
-        }
-        return payload;
-      }
-
-      async function fetchRecordingChunk(index, total) {
-        if (Number.isFinite(total) && total > 0) {
-          setStatus(`Loading chunk ${index} of ${total}…`);
-        } else {
-          setStatus(`Loading chunk ${index}…`);
-        }
-        const response = await fetch(
-          `/api/surveillance/recordings/${encodeURIComponent(recordingName)}/chunks/${index}`,
-          { cache: "no-store" },
-        );
-        if (!response.ok) {
-          throw new Error(`Chunk request failed with ${response.status}`);
-        }
-        const payload = await response.json();
-        if (!payload || typeof payload !== "object") {
-          throw new Error("Invalid chunk payload");
-        }
-        return payload;
-      }
-
-      async function loadRecording() {
-        if (!recordingName) {
-          setStatus("Missing recording identifier.", "error");
-          return;
-        }
-        title.textContent = recordingName;
-        playbackFrame.hidden = true;
-        if (playbackControls) {
-          playbackControls.hidden = true;
-        }
-        stopPlaybackTimer();
-        setStatus("Loading recording…");
-        try {
-          let payload;
-          let payloadIncludesFrames = false;
-          try {
-            payload = await fetchRecordingPayload(false);
-          } catch (metaError) {
-            console.warn("Falling back to full recording fetch", metaError);
-            payload = await fetchRecordingPayload(true);
-            payloadIncludesFrames = true;
-          }
-
-          renderMeta(payload);
-
-          let fps =
-            typeof payload.fps === "number" && Number.isFinite(payload.fps) && payload.fps > 0
-              ? payload.fps
+          const duration = formatDuration(chunk.duration_seconds ?? 0);
+          const sizeDisplay = formatBytes(chunk.size_bytes);
+          const offset =
+            typeof chunk.start_offset_seconds === "number"
+              ? formatDuration(chunk.start_offset_seconds)
               : null;
-          resetPlaybackState(fps);
-          let framesLoaded = false;
-
-          const ensureFps = (value) => {
-            if (typeof value === "number" && Number.isFinite(value) && value > 0) {
-              fps = value;
-              updateFallbackFromFps(fps);
-            }
-          };
-
-          ensureFps(payload.fps);
-
-          if (payloadIncludesFrames && Array.isArray(payload.frames)) {
-            const appended = ingestFrames(payload.frames, { fps, silent: false });
-            if (appended) {
-              framesLoaded = true;
-              setStatus("Playing recording…");
-            }
-          } else if (Array.isArray(payload.chunks) && payload.chunks.length > 0) {
-            const total = payload.chunks.length;
-            for (let idx = 0; idx < total; idx += 1) {
-              const chunkNumber = idx + 1;
-              setStatus(`Loading chunk ${chunkNumber} of ${total}…`);
-              const chunkPayload = await fetchRecordingChunk(chunkNumber, total);
-              ensureFps(chunkPayload.fps);
-              const appended = ingestFrames(chunkPayload.frames, {
-                fps,
-                silent: framesLoaded,
-              });
-              if (appended) {
-                framesLoaded = true;
-                setStatus(`Playing recording… (chunk ${chunkNumber}/${total})`);
-              }
-            }
-          } else if (Array.isArray(payload.frames)) {
-            const appended = ingestFrames(payload.frames, { fps, silent: false });
-            if (appended) {
-              framesLoaded = true;
-              setStatus("Playing recording…");
-            }
+          const parts = [`#${index + 1}`, duration];
+          if (offset) {
+            parts.push(`@${offset}`);
           }
-
-          if (!framesLoaded) {
-            const fallback = await fetchRecordingPayload(true);
-            ensureFps(fallback.fps);
-            resetPlaybackState(fps);
-            const appended = ingestFrames(fallback.frames, { fps, silent: false });
-            if (!appended) {
-              throw new Error("Recording does not contain any frames.");
-            }
-            framesLoaded = true;
-            if (playbackState.frames.length <= 1) {
-              setStatus("Recording contains a single frame.");
-            } else {
-              setStatus("Playing recording…");
-            }
-          } else if (playbackState.frames.length <= 1) {
-            setStatus("Recording contains a single frame.");
-          } else {
-            setStatus("Playing recording…");
+          if (sizeDisplay) {
+            parts.push(sizeDisplay);
           }
-        } catch (error) {
-          console.error("Failed to load recording", error);
-          const message = error instanceof Error ? error.message : "Unable to load recording";
-          setStatus(message, "error");
+          button.textContent = parts.join(" · ");
+          button.addEventListener("click", () => loadChunk(index, true));
+          chunkList.appendChild(button);
+        });
+        actions.hidden = false;
+      }
+
+      function buildChunkUrl(index) {
+        const chunkNumber = index + 1;
+        const encodedName = encodeURIComponent(recordingName);
+        return `/api/surveillance/recordings/${encodedName}/chunks/${chunkNumber}`;
+      }
+
+      function loadChunk(index, autoplay = false) {
+        if (index < 0 || index >= chunks.length) {
+          return;
+        }
+        currentChunkIndex = index;
+        const chunkUrl = buildChunkUrl(index);
+        video.src = chunkUrl;
+        video.dataset.chunkIndex = String(index + 1);
+        updateChunkUI();
+        if (autoplay) {
+          const playPromise = video.play();
+          if (playPromise && typeof playPromise.catch === "function") {
+            playPromise.catch(() => {
+              /* autoplay prevented */
+            });
+          }
         }
       }
 
-      window.addEventListener("beforeunload", () => {
-        stopPlaybackTimer();
+      async function initialise() {
+        if (!recordingName) {
+          setStatus("Recording name missing", "error");
+          return;
+        }
+        try {
+          const encodedName = encodeURIComponent(recordingName);
+          const response = await fetch(
+            `/api/surveillance/recordings/${encodedName}?include_frames=false`
+          );
+          if (!response.ok) {
+            throw new Error(`Request failed with status ${response.status}`);
+          }
+          const payload = await response.json();
+          const recording = payload.recording ?? payload;
+          if (!recording || typeof recording !== "object") {
+            throw new Error("Invalid recording payload");
+          }
+          recordingMetadata = recording;
+          title.textContent = recording.name || recordingName;
+          updateMetaDisplay(recording);
+          const chunkArray = Array.isArray(recording.chunks) ? recording.chunks : [];
+          chunks = chunkArray.filter((chunk) => chunk && typeof chunk === "object");
+          downloadLink.href = `/api/surveillance/recordings/${encodeURIComponent(
+            recordingName
+          )}/download`;
+          if (recording.thumbnail) {
+            video.poster = `data:image/jpeg;base64,${recording.thumbnail}`;
+          }
+          if (!chunks.length) {
+            setStatus("This recording does not contain any video chunks", "error");
+            video.hidden = true;
+            actions.hidden = true;
+            return;
+          }
+          setStatus(`Loaded ${chunks.length} chunk${chunks.length === 1 ? "" : "s"}.`);
+          video.hidden = false;
+          loadChunk(0, false);
+        } catch (error) {
+          console.error(error);
+          setStatus("Unable to load recording", "error");
+          video.hidden = true;
+          actions.hidden = true;
+        }
+      }
+
+      prevChunkButton.addEventListener("click", () => {
+        if (currentChunkIndex > 0) {
+          loadChunk(currentChunkIndex - 1, true);
+        }
+      });
+      nextChunkButton.addEventListener("click", () => {
+        if (currentChunkIndex < chunks.length - 1) {
+          loadChunk(currentChunkIndex + 1, true);
+        }
+      });
+      video.addEventListener("ended", () => {
+        if (currentChunkIndex < chunks.length - 1) {
+          loadChunk(currentChunkIndex + 1, true);
+        }
       });
 
-      loadRecording();
+      initialise();
     </script>
   </body>
 </html>

--- a/src/rev_cam/static/surveillance_settings.html
+++ b/src/rev_cam/static/surveillance_settings.html
@@ -457,15 +457,6 @@
                 <input id="chunk-duration" type="number" min="0" max="86400" step="1" />
                 <span class="muted">Set to 0 to keep each recording as a single file.</span>
               </div>
-              <label class="option inline-option">
-                <input type="checkbox" id="chunk-mp4-enabled" />
-                <div>
-                  <strong>Create MP4 chunk files</strong>
-                  <span class="helper"
-                    >Generate an .mp4 alongside each JSON chunk for quick playback.</span
-                  >
-                </div>
-              </label>
               <div>
                 <label for="storage-threshold">Stop recording below free space (%)</label>
                 <input id="storage-threshold" type="number" min="1" max="90" step="1" />
@@ -527,7 +518,6 @@
       const overlayCheckbox = document.getElementById("recording-overlays");
       const rememberCheckbox = document.getElementById("remember-recording");
       const chunkDurationInput = document.getElementById("chunk-duration");
-      const chunkMp4Checkbox = document.getElementById("chunk-mp4-enabled");
       const storageThresholdInput = document.getElementById("storage-threshold");
       const autoPurgeInput = document.getElementById("auto-purge-days");
       const motionEnabledInput = document.getElementById("motion-enabled");
@@ -721,10 +711,6 @@
         chunkDurationInput.addEventListener("input", updateSummary);
       }
 
-      if (chunkMp4Checkbox) {
-        chunkMp4Checkbox.addEventListener("change", updateSummary);
-      }
-
       function getSelectedProfile() {
         const selected = profileInputs.find((input) => input.checked);
         return selected ? selected.value : "standard";
@@ -806,9 +792,6 @@
             text += ` • Split every ${durationLabel}`;
           }
         }
-        if (chunkMp4Checkbox && chunkMp4Checkbox.checked) {
-          text += " • MP4 chunk export enabled";
-        }
         if (motionEnabledInput && motionEnabledInput.checked && effective.fps) {
           const decimation = getMotionDecimation();
           const motionFps = effective.fps / Math.max(1, decimation);
@@ -852,9 +835,6 @@
           const seconds = Number(settings.chunk_duration_seconds ?? 0);
           const normalised = Number.isFinite(seconds) && seconds > 0 ? Math.round(seconds) : 0;
           chunkDurationInput.value = normalised;
-        }
-        if (chunkMp4Checkbox) {
-          chunkMp4Checkbox.checked = settings.chunk_mp4_enabled === true;
         }
         if (storageThresholdInput) {
           const threshold = Number(settings.storage_threshold_percent ?? 10);
@@ -990,9 +970,6 @@
           } else {
             payload.chunk_duration_seconds = 0;
           }
-        }
-        if (chunkMp4Checkbox) {
-          payload.chunk_mp4_enabled = chunkMp4Checkbox.checked;
         }
         if (storageThresholdInput) {
           const thresholdValue = parseFloat(storageThresholdInput.value);

--- a/tests/test_app_surveillance.py
+++ b/tests/test_app_surveillance.py
@@ -148,13 +148,20 @@ def test_update_surveillance_settings_expert_validation(client: TestClient) -> N
 def test_delete_surveillance_recording(client: TestClient) -> None:
     recordings_dir: Path = client.recordings_dir
     name = "20230101-010101"
-    chunk_file = recordings_dir / f"{name}.chunk001.json"
-    chunk_file.write_text(json.dumps({"frames": []}), encoding="utf-8")
+    chunk_file = recordings_dir / f"{name}.chunk001.mp4"
+    chunk_file.write_bytes(b"mp4")
     meta = recordings_dir / f"{name}.meta.json"
     meta.write_text(
         json.dumps({
             "name": name,
-            "chunks": [{"file": chunk_file.name, "frame_count": 0, "size_bytes": 2}],
+            "chunks": [
+                {
+                    "file": chunk_file.name,
+                    "frame_count": 0,
+                    "size_bytes": chunk_file.stat().st_size,
+                    "media_type": "video/mp4",
+                }
+            ],
             "ended_at": "2023-01-01T00:00:00+00:00",
         }),
         encoding="utf-8",
@@ -168,9 +175,9 @@ def test_delete_surveillance_recording(client: TestClient) -> None:
 def test_fetch_surveillance_recording_metadata_and_chunk(client: TestClient) -> None:
     recordings_dir: Path = client.recordings_dir
     name = "20230102-020202"
-    frames = [{"jpeg": "ZmFrZQ==", "timestamp": 0.0}]
-    chunk_file = recordings_dir / f"{name}.chunk001.json"
-    chunk_file.write_text(json.dumps({"frames": frames}), encoding="utf-8")
+    chunk_file = recordings_dir / f"{name}.chunk001.mp4"
+    chunk_payload = b"fake-mp4-data"
+    chunk_file.write_bytes(chunk_payload)
     meta = recordings_dir / f"{name}.meta.json"
     meta.write_text(
         json.dumps(
@@ -180,9 +187,11 @@ def test_fetch_surveillance_recording_metadata_and_chunk(client: TestClient) -> 
                 "chunks": [
                     {
                         "file": chunk_file.name,
-                        "frame_count": len(frames),
+                        "frame_count": 10,
                         "size_bytes": chunk_file.stat().st_size,
-                        "compression": None,
+                        "duration_seconds": 2.5,
+                        "media_type": "video/mp4",
+                        "start_offset_seconds": 0.0,
                     }
                 ],
             }
@@ -197,16 +206,15 @@ def test_fetch_surveillance_recording_metadata_and_chunk(client: TestClient) -> 
     payload = response.json()
     assert payload["name"] == name
     assert payload["chunks"][0]["file"] == chunk_file.name
+    assert payload["chunks"][0]["media_type"] == "video/mp4"
+    assert payload["chunks"][0]["duration_seconds"] == 2.5
     assert "frames" not in payload
 
     chunk_response = client.get(f"/api/surveillance/recordings/{name}/chunks/1")
     assert chunk_response.status_code == 200
-    chunk_payload = chunk_response.json()
-    assert chunk_payload["chunk_index"] == 1
-    assert chunk_payload["chunk_count"] == 1
-    assert chunk_payload["frame_count"] == 1
-    assert chunk_payload["fps"] == 5
-    assert chunk_payload["frames"] == frames
+    assert chunk_response.headers["content-type"].startswith("video/mp4")
+    assert "inline" in chunk_response.headers["content-disposition"].lower()
+    assert chunk_response.content == chunk_payload
 
 
 def test_fetch_surveillance_recording_chunk_not_found(client: TestClient) -> None:

--- a/tests/test_recording_cleanup.py
+++ b/tests/test_recording_cleanup.py
@@ -17,11 +17,16 @@ def _write(path: Path, data: bytes | str = b"data") -> None:
 
 def test_remove_recording_files_removes_known_artifacts(tmp_path: Path) -> None:
     name = "example"
-    chunk_name = f"{name}.chunk001.json.gz"
+    chunk_name = f"{name}.chunk001.mp4"
     metadata = {
         "name": name,
         "chunks": [
-            {"file": chunk_name, "frame_count": 1, "compression": "gzip"},
+            {
+                "file": chunk_name,
+                "frame_count": 1,
+                "size_bytes": 2,
+                "media_type": "video/mp4",
+            },
         ],
     }
 


### PR DESCRIPTION
## Summary
- refactor the surveillance recording manager to write MP4 chunk files in place of JSON frame blobs and update metadata accordingly
- stream recorded chunks directly from the API as video/mp4, remove the legacy MP4 toggle from configuration, and modernize the surveillance playback UI to drive an HTML5 video element with chunk navigation
- refresh the surveillance tests to validate MP4 chunk output, streaming responses, and cleanup behaviour

## Testing
- pytest tests/test_app_surveillance.py tests/test_motion_detection.py tests/test_recording_cleanup.py

------
https://chatgpt.com/codex/tasks/task_e_68e1b03af410833298faf9aa3ac32c32