### PR TITLE
Add work centre detail retrieval support

### DIFF
--- a/src/revcam/frontend/work_centres.py
+++ b/src/revcam/frontend/work_centres.py
@@ -18,6 +18,12 @@ class WorkCentreForm:
         payload = response.json()
         return payload.get("results", [])
 
+    def retrieve(self, work_centre_id: int) -> dict[str, Any] | None:
+        response = self.client.get(f"/engineering/work-centres/{work_centre_id}/")
+        if response.status_code == 200:
+            return response.json()
+        return None
+
     def create(self, *, name: str, code: str | None = None, description: str | None = None) -> tuple[bool, str]:
         name = (name or "").strip()
         if not name:

--- a/tests/engineering/conftest.py
+++ b/tests/engineering/conftest.py
@@ -12,6 +12,7 @@ from rev_cam.engineering_api import (
     WorkCentreUpdatePayload,
     create_work_centre,
     get_engineering_dashboard,
+    get_work_centre,
     list_work_centres,
     update_work_centre,
 )
@@ -51,6 +52,15 @@ class _Response:
 
 class SimpleAPIClient:
     def get(self, path: str):
+        if path.startswith("/engineering/work-centres/") and path.rstrip("/").split("/")[-1].isdigit():
+            work_centre_id = int(path.rstrip("/").split("/")[-1])
+            try:
+                data = get_work_centre(work_centre_id)
+            except HTTPException as exc:
+                detail = getattr(exc, "detail", None) or str(exc)
+                status = getattr(exc, "status_code", 404)
+                return _Response(status, {"detail": detail})
+            return _Response(200, data.model_dump())
         if path.startswith("/engineering/work-centres"):
             query = None
             if "?name=" in path:

--- a/tests/engineering/test_frontend.py
+++ b/tests/engineering/test_frontend.py
@@ -32,6 +32,10 @@ def test_work_centre_form_integration(client):
     assert updated is True
     assert "updated" in update_message.lower()
 
+    detail = form.retrieve(centre_id)
+    assert detail is not None
+    assert detail["description"] == "Metal fabrication"
+
 
 def test_sop_form_uses_work_centres(client):
     work_form = WorkCentreForm(client)

--- a/tests/engineering/test_work_centres_api.py
+++ b/tests/engineering/test_work_centres_api.py
@@ -16,12 +16,21 @@ def test_work_centre_crud_flow(client):
     assert payload["results"][0]["name"] == "Assembly"
 
     work_centre_id = created["id"]
+    response = client.get(f"/engineering/work-centres/{work_centre_id}/")
+    assert response.status_code == 200
+    detail = response.json()
+    assert detail["name"] == "Assembly"
+
     response = client.patch(
         f"/engineering/work-centres/{work_centre_id}/",
         json={"description": "Updated description"},
     )
     assert response.status_code == 200, response.content
     assert response.json()["description"] == "Updated description"
+
+    missing = client.get("/engineering/work-centres/999/")
+    assert missing.status_code == 404
+    assert "not found" in missing.json()["detail"].lower()
 
     response = client.post(
         "/engineering/work-centres/",


### PR DESCRIPTION
## Summary
- allow the frontend work centre form to retrieve individual records through the API client
- teach the engineering test client about the work centre detail endpoint and cover 404 responses
- extend integration tests to exercise the new retrieval helper after updates

## Testing
- pytest tests/engineering/test_work_centres_api.py tests/engineering/test_frontend.py tests/engineering/test_sop_work_centres.py

------
https://chatgpt.com/codex/tasks/task_e_6904abf7ccc48332af8b22016dcc1fbf